### PR TITLE
[BUGFIX] Fix media regex parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Silence purposefully ignored PHP Warnings
   ([#400](https://github.com/MyIntervals/emogrifier/pull/400))
+- Fix media regex parsing
+  ([#320](https://github.com/MyIntervals/emogrifier/pull/320))
 
 
 ### Security

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1100,7 +1100,7 @@ class Emogrifier
 
         $media = '';
         $cssForAllowedMediaTypes = preg_replace_callback(
-            '#@media\\s+(?:only\\s)?(?:[\\s{\\(]' . $mediaTypesExpression . ')\\s?[^{]+{.*}\\s*}\\s*#misU',
+            '#@media\\s+(?:only\\s)?(?:[\\s{\\(]\\s*' . $mediaTypesExpression . ')\\s*[^{]*{.*}\\s*}\\s*#misU',
             function ($matches) use (&$media) {
                 $media .= $matches[0];
             },
@@ -1110,7 +1110,7 @@ class Emogrifier
         // filter the CSS
         $search = [
             'import directives' => '/^\\s*@import\\s[^;]+;/misU',
-            'remaining media enclosures' => '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
+            'remaining media enclosures' => '/\\s*@media\\s+[^{]+{(.*)}\\s*}\\s*/misU',
         ];
 
         $cleanedCss = preg_replace($search, '', $cssForAllowedMediaTypes);

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1147,7 +1147,15 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'style in "only screen" media type rule' => ['@media only screen { h1 { color:red; } }'],
             'style in "only all" media type rule' => ['@media only all { h1 { color:red; } }'],
             'style in "screen" media type rule' => ['@media screen { h1 { color:red; } }'],
+            'style in "print" media type rule' => ['@media print { * { color:#000 !important; } }'],
             'style in media type rule without specification' => ['@media { h1 { color:red; } }'],
+            'style with multiple media type rules' => [
+                '@media all { p { color: #000; } }' .
+                '@media only screen { h1 { color:red; } }' .
+                '@media only all { h1 { color:red; } }' .
+                '@media print { * { color:#000 !important; } }' .
+                '@media { h1 { color:red; } }'
+            ],
         ];
     }
 
@@ -1165,7 +1173,29 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($css, $result);
+        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $css
+     *
+     * @dataProvider validMediaPreserveDataProvider
+     */
+    public function emogrifyWithValidMinifiedMediaQueryContainsInnerCss($css)
+    {
+        // Minify CSS by removing unnecessary whitespace.
+        $css = preg_replace('/\s*{\s*/', '{', $css);
+        $css = preg_replace('/;?\s*}\s*/', '}', $css);
+        $css = preg_replace('/@media{/', '@media {', $css);
+
+        $this->subject->setHtml('<html><h1></h1><p></p></html>');
+        $this->subject->setCss($css);
+
+        $result = $this->subject->emogrify();
+
+        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1181,7 +1211,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($css, $result);
+        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**


### PR DESCRIPTION
The current regex doesn't take into account possible minification.

Also, the `print` media query was never added to the `$media` variable and stripped from `$cssForAllowedMediaTypes`, thus causing print attributes to be applied to the DOM elements.
