### PR TITLE
[TASK] Test with latest and oldest dependencies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,34 @@ sudo: false
 
 language: php
 
+php:
+- 5.5
+- 5.6
+- 7.0
+- 7.1
+- 7.2
+
 cache:
   directories:
   - vendor
   - $HOME/.composer/cache
 
-matrix:
-  include:
-  - php: 5.5
-  - php: 5.6
-  - php: 7.0
-  - php: 7.1
-  - php: 7.2
+env:
+  matrix:
+  - DEPENDENCIES=latest
+  - DEPENDENCIES=oldest
 
 install:
-  - composer install
+- >
+  echo;
+  if [ "$DEPENDENCIES" = "latest" ]; then
+    echo "Installing the latest dependencies";
+    composer update --with-dependencies --prefer-stable --prefer-dist
+  else
+    echo "Installing the lowest dependencies";
+    composer update --with-dependencies --prefer-stable --prefer-dist --prefer-lowest
+  fi;
+  composer show;
 
 before_script:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Changed
+- Test with latest and oldest dependencies on Travis
+  ([#463](https://github.com/MyIntervals/emogrifier/pull/463))
 - Always enable the debug mode in the tests
   ([#448](https://github.com/MyIntervals/emogrifier/pull/448))
 - Optimize the string operations

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "php": "^5.5.0 || ~7.0.0 || ~7.1.0 || ~7.2.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "3.1.1",
-        "phpunit/phpunit": "4.8.27"
+        "squizlabs/php_codesniffer": "^3.1.0",
+        "phpunit/phpunit": "^4.8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This ensures that our dependency versions given in the composer.json always
provide a working set of packages.

Also make the development dependencies more lenient.

Fixes #394