### PR TITLE
[TASK] Update PHP_CodeSniffer to 3.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_script:
     else
       echo "xdebug.ini does not exist"
     fi
-  - vendor/bin/phpcs --config-set encoding utf-8
   - if [ "$GITHUB_COMPOSER_AUTH" ]; then composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH; fi
 
 script:

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1762,7 +1762,7 @@ class Emogrifier
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function handleXpathQueryWarnings( // @codingStandardsIgnoreLine
+    public function handleXpathQueryWarnings( // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
         $type,
         $message,
         $file,

--- a/Configuration/PhpCodeSniffer/Standards/Emogrifier/ruleset.xml
+++ b/Configuration/PhpCodeSniffer/Standards/Emogrifier/ruleset.xml
@@ -8,6 +8,7 @@
     <rule ref="PSR2"/>
 
     <!-- Arrays -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 
@@ -81,6 +82,7 @@
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
     <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.PHP.DiscourageGoto"/>
     <rule ref="Generic.PHP.ForbiddenFunctions"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
     <rule ref="Squiz.PHP.CommentedOutCode">

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "^5.5.0 || ~7.0.0 || ~7.1.0 || ~7.2.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.1.0",
+        "squizlabs/php_codesniffer": "^3.2.0",
         "phpunit/phpunit": "^4.8.0"
     },
     "autoload": {


### PR DESCRIPTION
Also use the new whitelisting syntax and make use of two newly-available
sniffs.