### PR TITLE
[BUGFIX] Remove the Generic.Arrays.ArrayIndent sniff

### DIFF
--- a/Configuration/PhpCodeSniffer/Standards/Emogrifier/ruleset.xml
+++ b/Configuration/PhpCodeSniffer/Standards/Emogrifier/ruleset.xml
@@ -8,7 +8,6 @@
     <rule ref="PSR2"/>
 
     <!-- Arrays -->
-    <rule ref="Generic.Arrays.ArrayIndent"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 


### PR DESCRIPTION
While Emogrifiert currently does not have any code that is affected by this
sniff, this sniff will complain about perfectly well-formatted code
(as seen in another project).