### PR TITLE
[TASK] Deprecate enableCssToHtmlMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 - Support for PHP 5.5 will be removed in Emogrifier 3.0.
 - Support for PHP 5.6 will be removed in Emogrifier 4.0.
+- Converting CSS styles to (non-CSS) HTML attributes will be removed
+  in Emogrifier 3.0. ([#474](https://github.com/jjriv/emogrifier/pull/474))
 
 ### Removed
 

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -729,6 +729,8 @@ class Emogrifier
      * Enables the attachment/override of HTML attributes for which a
      * corresponding CSS property has been set.
      *
+     * @deprecated will be removed in Emogrifier 3.0
+     *
      * @return void
      */
     public function enableCssToHtmlMapping()

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ calling the `emogrify` method:
   well, even if inline and prefer HTML attributes. This function allows you to
   put properties such as height, width, background color and font color in your
   CSS while the transformed content will have all the available HTML tags set.
+  This option will be removed in Emogrifier 3.0.
 
 
 ## Installing with Composer


### PR DESCRIPTION
Nowadays, we can expect email clients to understand CSS reasonably well.
So converting CSS non-CSS HTML attributes will not be needed anymore.