### PR TITLE
[FEATURE] Add an AbstractHtmlProcessor class

### DIFF
--- a/Classes/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/Classes/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Pelago\Emogrifier\HtmlProcessor;
+
+/**
+ * Base class for HTML processor that e.g., can remove, add or modify nodes or attributes.
+ *
+ * @author Oliver Klee <github@oliverklee.de>
+ */
+abstract class AbstractHtmlProcessor
+{
+    /**
+     * @var string
+     */
+    const DEFAULT_DOCUMENT_TYPE = '<!DOCTYPE html>';
+
+    /**
+     * @var string
+     */
+    const CONTENT_TYPE_META_TAG = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
+
+    /**
+     * @var \DOMDocument
+     */
+    protected $xmlDocument = null;
+
+    /**
+     * @param string $unprocessedHtml raw HTML, will get heavily normalized
+     *
+     * @throws \InvalidArgumentException if $unprocessedHtml is anything other than a non-empty string
+     */
+    public function __construct($unprocessedHtml)
+    {
+        if (!is_string($unprocessedHtml)) {
+            throw new \InvalidArgumentException('The provided HTML must be a string.', 1515459744321);
+        }
+        if ($unprocessedHtml === '') {
+            throw new \InvalidArgumentException('The provided HTML must not be empty.', 1515763647038);
+        }
+
+        $this->xmlDocument = $this->createXmlDocument($unprocessedHtml);
+    }
+
+    /**
+     * Renders the normalized and processed HTML.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        return $this->xmlDocument->saveHTML();
+    }
+
+    /**
+     * Creates a DOMDocument from $html.
+     *
+     * @param string $html
+     *
+     * @return \DOMDocument
+     */
+    private function createXmlDocument($html)
+    {
+        $xmlDocument = new \DOMDocument;
+        $xmlDocument->strictErrorChecking = false;
+        $xmlDocument->formatOutput = true;
+        $libXmlState = libxml_use_internal_errors(true);
+        $xmlDocument->loadHTML($this->unifyHtml($html));
+        libxml_clear_errors();
+        libxml_use_internal_errors($libXmlState);
+
+        $this->ensureExistenceOfBodyElement($xmlDocument);
+
+        return $xmlDocument;
+    }
+
+    /**
+     * Returns the HTML with added document type and Content-Type meta tag (if any of this is missing).
+     *
+     * @param string $html
+     *
+     * @return string the unified HTML
+     */
+    private function unifyHtml($html)
+    {
+        $htmlWithDocumentType = $this->ensureDocumentType($html);
+
+        return $this->addContentTypeMetaTag($htmlWithDocumentType);
+    }
+
+    /**
+     * Makes sure that the passed HTML has a document type.
+     *
+     * @param string $html
+     *
+     * @return string HTML with document type
+     */
+    private function ensureDocumentType($html)
+    {
+        $hasDocumentType = stripos($html, '<!DOCTYPE') !== false;
+        if ($hasDocumentType) {
+            return $html;
+        }
+
+        return static::DEFAULT_DOCUMENT_TYPE . $html;
+    }
+
+    /**
+     * Adds a Content-Type meta tag for the charset.
+     *
+     * @param string $html
+     *
+     * @return string the HTML with the meta tag added
+     */
+    private function addContentTypeMetaTag($html)
+    {
+        $hasContentTypeMetaTag = stripos($html, 'Content-Type') !== false;
+        if ($hasContentTypeMetaTag) {
+            return $html;
+        }
+
+        // We are trying to insert the meta tag to the right spot in the DOM.
+        // If we just prepended it to the HTML, we would lose attributes set to the HTML tag.
+        $hasHeadTag = stripos($html, '<head') !== false;
+        $hasHtmlTag = stripos($html, '<html') !== false;
+
+        if ($hasHeadTag) {
+            $reworkedHtml = preg_replace('/<head(.*?)>/i', '<head$1>' . static::CONTENT_TYPE_META_TAG, $html);
+        } elseif ($hasHtmlTag) {
+            $reworkedHtml = preg_replace(
+                '/<html(.*?)>/i',
+                '<html$1><head>' . static::CONTENT_TYPE_META_TAG . '</head>',
+                $html
+            );
+        } else {
+            $reworkedHtml = static::CONTENT_TYPE_META_TAG . $html;
+        }
+
+        return $reworkedHtml;
+    }
+
+    /**
+     * Checks that $document has a BODY element and adds it if it is missing.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return void
+     */
+    private function ensureExistenceOfBodyElement(\DOMDocument $document)
+    {
+        if ($document->getElementsByTagName('body')->item(0) !== null) {
+            return;
+        }
+
+        $htmlElement = $document->getElementsByTagName('html')->item(0);
+        $htmlElement->appendChild($document->createElement('body'));
+    }
+}

--- a/Tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/Tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace Pelago\Tests\Unit\Emogrifier\HtmlProcessor;
+
+use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
+use Pelago\Tests\Unit\Emogrifier\HtmlProcessor\Fixtures\TestingHtmlProcessor;
+
+/**
+ * Test case.
+ *
+ * @author Oliver Klee <github@oliverklee.de>
+ */
+class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function fixtureIsAbstractHtmlProcessor()
+    {
+        static::assertInstanceOf(AbstractHtmlProcessor::class, new TestingHtmlProcessor('<html></html>'));
+    }
+
+    /**
+     * @test
+     */
+    public function reformatsHtml()
+    {
+        $rawHtml = '<!DOCTYPE HTML>' .
+            '<html>' .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' .
+            '<body></body>' .
+            '</html>';
+        $formattedHtml = '<!DOCTYPE HTML>' . PHP_EOL .
+            '<html>' . PHP_EOL .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . PHP_EOL .
+            '<body></body>' . PHP_EOL .
+            '</html>' . PHP_EOL;
+
+        $subject = new TestingHtmlProcessor($rawHtml);
+
+        static::assertSame($formattedHtml, $subject->render());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function nonHtmlDataProvider()
+    {
+        return [
+            'empty string' => [''],
+            'null' => [null],
+            'integer' => [2],
+            'float' => [3.14159],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     *
+     * @param mixed $html
+     * @dataProvider nonHtmlDataProvider
+     */
+    public function constructorWithNoHtmlDataThrowsException($html)
+    {
+        new TestingHtmlProcessor($html);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function invalidHtmlDataProvider()
+    {
+        return [
+            'broken nesting gets nested' => ['<b><i></b></i>', '<b><i></i></b>'],
+            'partial opening tag gets closed' => ['<b', '<b></b>'],
+            'only opening tag gets closed' => ['<b>', '<b></b>'],
+            'only closing tag gets removed' => ['foo</b> bar', 'foo bar'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $input
+     * @param string $expectedHtml
+     * @dataProvider invalidHtmlDataProvider
+     */
+    public function renderRepairsBrokenHtml($input, $expectedHtml)
+    {
+        $subject = new TestingHtmlProcessor($input);
+        $result = $subject->render();
+
+        static::assertContains($expectedHtml, $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function contentWithoutHtmlTagDataProvider()
+    {
+        return [
+            'doctype only' => ['<!DOCTYPE html>'],
+            'body content only' => ['<p>Hello</p>'],
+            'HEAD element' => ['<head></head>'],
+            'BODY element' => ['<body></body>'],
+            'HEAD AND BODY element' => ['<head></head><body></body>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $html
+     * @dataProvider contentWithoutHtmlTagDataProvider
+     */
+    public function addsMissingHtmlTag($html)
+    {
+        $subject = new TestingHtmlProcessor($html);
+
+        $result = $subject->render();
+
+        static::assertContains('<html>', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function contentWithoutHeadTagDataProvider()
+    {
+        return [
+            'doctype only' => ['<!DOCTYPE html>'],
+            'body content only' => ['<p>Hello</p>'],
+            'BODY element' => ['<body></body>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $html
+     * @dataProvider contentWithoutHeadTagDataProvider
+     */
+    public function addsMissingHeadTag($html)
+    {
+        $subject = new TestingHtmlProcessor($html);
+
+        $result = $subject->render();
+
+        static::assertContains('<head>', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function contentWithoutBodyTagDataProvider()
+    {
+        return [
+            'doctype only' => ['<!DOCTYPE html>'],
+            'HEAD element' => ['<head></head>'],
+            'body content only' => ['<p>Hello</p>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $html
+     * @dataProvider contentWithoutBodyTagDataProvider
+     */
+    public function addsMissingBodyTag($html)
+    {
+        $subject = new TestingHtmlProcessor($html);
+
+        $result = $subject->render();
+
+        static::assertContains('<body>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function putsMissingBodyElementAroundBodyContent()
+    {
+        $subject = new TestingHtmlProcessor('<p>Hello</p>');
+
+        $result = $subject->render();
+
+        static::assertContains('<body><p>Hello</p></body>', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function specialCharactersDataProvider()
+    {
+        return [
+            'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
+            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
+            'HTML entities' => ['a &amp; b &gt; c'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $codeNotToBeChanged
+     * @dataProvider specialCharactersDataProvider
+     */
+    public function keepsSpecialCharacters($codeNotToBeChanged)
+    {
+        $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
+        $subject = new TestingHtmlProcessor($html);
+
+        $result = $subject->render();
+
+        static::assertContains($codeNotToBeChanged, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function addMissingHtml5DocumentType()
+    {
+        $subject = new TestingHtmlProcessor('<html></html>');
+
+        $result = $subject->render();
+
+        static::assertContains('<!DOCTYPE html>', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function documentTypeDataProvider()
+    {
+        return [
+            'HTML5' => ['<!DOCTYPE html>'],
+            'XHTML 1.0 strict' => [
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" ' .
+                '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'
+            ],
+            'XHTML 1.0 transitional' => [
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" ' .
+                '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+            ],
+            'HTML 4 transitional' => [
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" ' .
+                '"http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $documentType
+     * @dataProvider documentTypeDataProvider
+     */
+    public function keepsExistingDocumentType($documentType)
+    {
+        $html = $documentType . '<html></html>';
+        $subject = new TestingHtmlProcessor($html);
+
+        $result = $subject->render();
+
+        static::assertContains($documentType, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function addsMissingContentTypeMetaTag()
+    {
+        $subject = new TestingHtmlProcessor('<p>Hello</p>');
+
+        $result = $subject->render();
+
+        static::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function notAddsSecondContentTypeMetaTag()
+    {
+        $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>';
+        $subject = new TestingHtmlProcessor($html);
+
+        $result = $subject->render();
+
+        $numberOfContentTypeMetaTags = substr_count($result, 'Content-Type');
+        static::assertSame(1, $numberOfContentTypeMetaTags);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $documentType
+     * @dataProvider documentTypeDataProvider
+     */
+    public function convertsXmlSelfClosingTagsToNonXmlSelfClosingTag($documentType)
+    {
+        $subject = new TestingHtmlProcessor($documentType . '<html><body><br/></body></html>');
+
+        $result = $subject->render();
+
+        static::assertContains('<body><br></body>', $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $documentType
+     * @dataProvider documentTypeDataProvider
+     */
+    public function keepsNonMmlSelfClosingTags($documentType)
+    {
+        $subject = new TestingHtmlProcessor($documentType . '<html><body><br></body></html>');
+
+        $result = $subject->render();
+
+        static::assertContains('<body><br></body>', $result);
+    }
+}

--- a/Tests/Unit/Emogrifier/HtmlProcessor/Fixtures/TestingHtmlProcessor.php
+++ b/Tests/Unit/Emogrifier/HtmlProcessor/Fixtures/TestingHtmlProcessor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Pelago\Tests\Unit\Emogrifier\HtmlProcessor\Fixtures;
+
+use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
+
+/**
+ * Fixture class for AbstractHtmlProcessor.
+ *
+ * @author Oliver Klee <github@oliverklee.de>
+ */
+class TestingHtmlProcessor extends AbstractHtmlProcessor
+{
+}


### PR DESCRIPTION
This class will be the base class for other classes that can remove
invisible nodes, convert CSS to non-CSS attributes etc.

The folder structure will be cleaned up once the Emogrifier class has
been renamed to CssInliner and moved from the Pelago\ namespace to the
Pelage\Emogrifier namespace (which will happen in Emogrifier 4.0.0).