### PR TITLE
[CLEANUP] Convert self:: to static::

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -651,7 +651,7 @@ class Emogrifier
     private function parseCssRules($css)
     {
         $cssKey = md5($css);
-        if (!isset($this->caches[self::CACHE_KEY_CSS][$cssKey])) {
+        if (!isset($this->caches[static::CACHE_KEY_CSS][$cssKey])) {
             // process the CSS file for selectors and definitions
             preg_match_all('/(?:^|[\\s^{}]*)([^{]+){([^}]*)}/mi', $css, $matches, PREG_SET_ORDER);
 
@@ -689,10 +689,10 @@ class Emogrifier
 
             usort($cssRules, [$this, 'sortBySelectorPrecedence']);
 
-            $this->caches[self::CACHE_KEY_CSS][$cssKey] = $cssRules;
+            $this->caches[static::CACHE_KEY_CSS][$cssKey] = $cssRules;
         }
 
-        return $this->caches[self::CACHE_KEY_CSS][$cssKey];
+        return $this->caches[static::CACHE_KEY_CSS][$cssKey];
     }
 
     /**
@@ -747,11 +747,11 @@ class Emogrifier
      */
     private function clearAllCaches()
     {
-        $this->clearCache(self::CACHE_KEY_CSS);
-        $this->clearCache(self::CACHE_KEY_SELECTOR);
-        $this->clearCache(self::CACHE_KEY_XPATH);
-        $this->clearCache(self::CACHE_KEY_CSS_DECLARATIONS_BLOCK);
-        $this->clearCache(self::CACHE_KEY_COMBINED_STYLES);
+        $this->clearCache(static::CACHE_KEY_CSS);
+        $this->clearCache(static::CACHE_KEY_SELECTOR);
+        $this->clearCache(static::CACHE_KEY_XPATH);
+        $this->clearCache(static::CACHE_KEY_CSS_DECLARATIONS_BLOCK);
+        $this->clearCache(static::CACHE_KEY_COMBINED_STYLES);
     }
 
     /**
@@ -767,11 +767,11 @@ class Emogrifier
     private function clearCache($key)
     {
         $allowedCacheKeys = [
-            self::CACHE_KEY_CSS,
-            self::CACHE_KEY_SELECTOR,
-            self::CACHE_KEY_XPATH,
-            self::CACHE_KEY_CSS_DECLARATIONS_BLOCK,
-            self::CACHE_KEY_COMBINED_STYLES,
+            static::CACHE_KEY_CSS,
+            static::CACHE_KEY_SELECTOR,
+            static::CACHE_KEY_XPATH,
+            static::CACHE_KEY_CSS_DECLARATIONS_BLOCK,
+            static::CACHE_KEY_COMBINED_STYLES,
         ];
         if (!in_array($key, $allowedCacheKeys, true)) {
             throw new \InvalidArgumentException('Invalid cache key: ' . $key, 1391822035);
@@ -995,8 +995,8 @@ class Emogrifier
     {
         $combinedStyles = array_merge($oldStyles, $newStyles);
         $cacheKey = serialize($combinedStyles);
-        if (isset($this->caches[self::CACHE_KEY_COMBINED_STYLES][$cacheKey])) {
-            return $this->caches[self::CACHE_KEY_COMBINED_STYLES][$cacheKey];
+        if (isset($this->caches[static::CACHE_KEY_COMBINED_STYLES][$cacheKey])) {
+            return $this->caches[static::CACHE_KEY_COMBINED_STYLES][$cacheKey];
         }
 
         foreach ($oldStyles as $attributeName => $attributeValue) {
@@ -1018,7 +1018,7 @@ class Emogrifier
         }
         $trimmedStyle = rtrim($style);
 
-        $this->caches[self::CACHE_KEY_COMBINED_STYLES][$cacheKey] = $trimmedStyle;
+        $this->caches[static::CACHE_KEY_COMBINED_STYLES][$cacheKey] = $trimmedStyle;
 
         return $trimmedStyle;
     }
@@ -1339,7 +1339,7 @@ class Emogrifier
             return $html;
         }
 
-        return self::DEFAULT_DOCUMENT_TYPE . $html;
+        return static::DEFAULT_DOCUMENT_TYPE . $html;
     }
 
     /**
@@ -1362,15 +1362,15 @@ class Emogrifier
         $hasHtmlTag = stripos($html, '<html') !== false;
 
         if ($hasHeadTag) {
-            $reworkedHtml = preg_replace('/<head(.*?)>/i', '<head$1>' . self::CONTENT_TYPE_META_TAG, $html);
+            $reworkedHtml = preg_replace('/<head(.*?)>/i', '<head$1>' . static::CONTENT_TYPE_META_TAG, $html);
         } elseif ($hasHtmlTag) {
             $reworkedHtml = preg_replace(
                 '/<html(.*?)>/i',
-                '<html$1><head>' . self::CONTENT_TYPE_META_TAG . '</head>',
+                '<html$1><head>' . static::CONTENT_TYPE_META_TAG . '</head>',
                 $html
             );
         } else {
-            $reworkedHtml = self::CONTENT_TYPE_META_TAG . $html;
+            $reworkedHtml = static::CONTENT_TYPE_META_TAG . $html;
         }
 
         return $reworkedHtml;
@@ -1402,7 +1402,7 @@ class Emogrifier
     private function getCssSelectorPrecedence($selector)
     {
         $selectorKey = md5($selector);
-        if (!isset($this->caches[self::CACHE_KEY_SELECTOR][$selectorKey])) {
+        if (!isset($this->caches[static::CACHE_KEY_SELECTOR][$selectorKey])) {
             $precedence = 0;
             $value = 100;
             // ids: worth 100, classes: worth 10, elements: worth 1
@@ -1417,10 +1417,10 @@ class Emogrifier
                 $precedence += ($value * $number);
                 $value /= 10;
             }
-            $this->caches[self::CACHE_KEY_SELECTOR][$selectorKey] = $precedence;
+            $this->caches[static::CACHE_KEY_SELECTOR][$selectorKey] = $precedence;
         }
 
-        return $this->caches[self::CACHE_KEY_SELECTOR][$selectorKey];
+        return $this->caches[static::CACHE_KEY_SELECTOR][$selectorKey];
     }
 
     /**
@@ -1444,8 +1444,8 @@ class Emogrifier
         );
         $trimmedLowercaseSelector = trim($lowercasePaddedSelector);
         $xPathKey = md5($trimmedLowercaseSelector);
-        if (isset($this->caches[self::CACHE_KEY_XPATH][$xPathKey])) {
-            return $this->caches[self::CACHE_KEY_SELECTOR][$xPathKey];
+        if (isset($this->caches[static::CACHE_KEY_XPATH][$xPathKey])) {
+            return $this->caches[static::CACHE_KEY_SELECTOR][$xPathKey];
         }
 
         $hasNotSelector = (bool)preg_match(
@@ -1462,9 +1462,9 @@ class Emogrifier
             $xPath = '//' . $this->translateCssToXpathPass($partBeforeNot) .
                 '[not(' . $this->translateCssToXpathPassInline($notContents) . ')]';
         }
-        $this->caches[self::CACHE_KEY_SELECTOR][$xPathKey] = $xPath;
+        $this->caches[static::CACHE_KEY_SELECTOR][$xPathKey] = $xPath;
 
-        return $this->caches[self::CACHE_KEY_SELECTOR][$xPathKey];
+        return $this->caches[static::CACHE_KEY_SELECTOR][$xPathKey];
     }
 
     /**
@@ -1512,12 +1512,12 @@ class Emogrifier
     ) {
         $roughXpath = preg_replace(array_keys($this->xPathRules), $this->xPathRules, $trimmedLowercaseSelector);
         $xPathWithIdAttributeMatchers = preg_replace_callback(
-            self::ID_ATTRIBUTE_MATCHER,
+            static::ID_ATTRIBUTE_MATCHER,
             [$this, 'matchIdAttributes'],
             $roughXpath
         );
         $xPathWithIdAttributeAndClassMatchers = preg_replace_callback(
-            self::CLASS_ATTRIBUTE_MATCHER,
+            static::CLASS_ATTRIBUTE_MATCHER,
             $matchClassAttributesCallback,
             $xPathWithIdAttributeMatchers
         );
@@ -1580,25 +1580,25 @@ class Emogrifier
     {
         $parseResult = $this->parseNth($match);
 
-        if (isset($parseResult[self::MULTIPLIER])) {
-            if ($parseResult[self::MULTIPLIER] < 0) {
-                $parseResult[self::MULTIPLIER] = abs($parseResult[self::MULTIPLIER]);
+        if (isset($parseResult[static::MULTIPLIER])) {
+            if ($parseResult[static::MULTIPLIER] < 0) {
+                $parseResult[static::MULTIPLIER] = abs($parseResult[static::MULTIPLIER]);
                 $xPathExpression = sprintf(
-                    '*[(last() - position()) mod %1%u = %2$u]/self::%3$s',
-                    $parseResult[self::MULTIPLIER],
-                    $parseResult[self::INDEX],
+                    '*[(last() - position()) mod %1%u = %2$u]/static::%3$s',
+                    $parseResult[static::MULTIPLIER],
+                    $parseResult[static::INDEX],
                     $match[1]
                 );
             } else {
                 $xPathExpression = sprintf(
-                    '*[position() mod %1$u = %2$u]/self::%3$s',
-                    $parseResult[self::MULTIPLIER],
-                    $parseResult[self::INDEX],
+                    '*[position() mod %1$u = %2$u]/static::%3$s',
+                    $parseResult[static::MULTIPLIER],
+                    $parseResult[static::INDEX],
                     $match[1]
                 );
             }
         } else {
-            $xPathExpression = sprintf('*[%1$u]/self::%2$s', $parseResult[self::INDEX], $match[1]);
+            $xPathExpression = sprintf('*[%1$u]/static::%2$s', $parseResult[static::INDEX], $match[1]);
         }
 
         return $xPathExpression;
@@ -1613,25 +1613,25 @@ class Emogrifier
     {
         $parseResult = $this->parseNth($match);
 
-        if (isset($parseResult[self::MULTIPLIER])) {
-            if ($parseResult[self::MULTIPLIER] < 0) {
-                $parseResult[self::MULTIPLIER] = abs($parseResult[self::MULTIPLIER]);
+        if (isset($parseResult[static::MULTIPLIER])) {
+            if ($parseResult[static::MULTIPLIER] < 0) {
+                $parseResult[static::MULTIPLIER] = abs($parseResult[static::MULTIPLIER]);
                 $xPathExpression = sprintf(
                     '%1$s[(last() - position()) mod %2$u = %3$u]',
                     $match[1],
-                    $parseResult[self::MULTIPLIER],
-                    $parseResult[self::INDEX]
+                    $parseResult[static::MULTIPLIER],
+                    $parseResult[static::INDEX]
                 );
             } else {
                 $xPathExpression = sprintf(
                     '%1$s[position() mod %2$u = %3$u]',
                     $match[1],
-                    $parseResult[self::MULTIPLIER],
-                    $parseResult[self::INDEX]
+                    $parseResult[static::MULTIPLIER],
+                    $parseResult[static::INDEX]
                 );
             }
         } else {
-            $xPathExpression = sprintf('%1$s[%2$u]', $match[1], $parseResult[self::INDEX]);
+            $xPathExpression = sprintf('%1$s[%2$u]', $match[1], $parseResult[static::INDEX]);
         }
 
         return $xPathExpression;
@@ -1647,12 +1647,12 @@ class Emogrifier
         if (in_array(strtolower($match[2]), ['even', 'odd'], true)) {
             // we have "even" or "odd"
             $index = strtolower($match[2]) === 'even' ? 0 : 1;
-            return [self::MULTIPLIER => 2, self::INDEX => $index];
+            return [static::MULTIPLIER => 2, static::INDEX => $index];
         }
         if (stripos($match[2], 'n') === false) {
             // if there is a multiplier
             $index = (int)str_replace(' ', '', $match[2]);
-            return [self::INDEX => $index];
+            return [static::INDEX => $index];
         }
 
         if (isset($match[3])) {
@@ -1668,7 +1668,7 @@ class Emogrifier
         if ($multiplier === '') {
             $multiplier = 1;
         } elseif ($multiplier === '0') {
-            return [self::INDEX => $index];
+            return [static::INDEX => $index];
         } else {
             $multiplier = (int)$multiplier;
         }
@@ -1677,7 +1677,7 @@ class Emogrifier
             $index += abs($multiplier);
         }
 
-        return [self::MULTIPLIER => $multiplier, self::INDEX => $index];
+        return [static::MULTIPLIER => $multiplier, static::INDEX => $index];
     }
 
     /**
@@ -1701,8 +1701,8 @@ class Emogrifier
      */
     private function parseCssDeclarationsBlock($cssDeclarationsBlock)
     {
-        if (isset($this->caches[self::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock])) {
-            return $this->caches[self::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock];
+        if (isset($this->caches[static::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock])) {
+            return $this->caches[static::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock];
         }
 
         $properties = [];
@@ -1718,7 +1718,7 @@ class Emogrifier
             $propertyValue = $matches[2];
             $properties[$propertyName] = $propertyValue;
         }
-        $this->caches[self::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock] = $properties;
+        $this->caches[static::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock] = $properties;
 
         return $properties;
     }

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -109,7 +109,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<html>', $result);
+        static::assertContains('<html>', $result);
     }
 
     /**
@@ -135,7 +135,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<head>', $result);
+        static::assertContains('<head>', $result);
     }
 
     /**
@@ -161,7 +161,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body>', $result);
+        static::assertContains('<body>', $result);
     }
 
     /**
@@ -173,7 +173,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body><p>Hello</p></body>', $result);
+        static::assertContains('<body><p>Hello</p></body>', $result);
     }
 
     /**
@@ -200,7 +200,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($codeNotToBeChanged, $result);
+        static::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -215,7 +215,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        self::assertContains($codeNotToBeChanged, $result);
+        static::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -248,7 +248,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($documentType, $result);
+        static::assertContains($documentType, $result);
     }
 
     /**
@@ -260,7 +260,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
+        static::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
     }
 
     /**
@@ -274,7 +274,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $result = $this->subject->emogrify();
 
         $numberOfContentTypeMetaTags = substr_count($result, 'Content-Type');
-        self::assertSame(1, $numberOfContentTypeMetaTags);
+        static::assertSame(1, $numberOfContentTypeMetaTags);
     }
 
     /**
@@ -287,7 +287,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('<wbr', $result);
+        static::assertNotContains('<wbr', $result);
     }
 
     /**
@@ -300,7 +300,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('<p>', $result);
+        static::assertNotContains('<p>', $result);
     }
 
     /**
@@ -313,7 +313,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p>', $result);
+        static::assertContains('<p>', $result);
     }
 
     /**
@@ -327,7 +327,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->removeUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p>', $result);
+        static::assertContains('<p>', $result);
     }
 
     /**
@@ -589,7 +589,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
+        static::assertContains(sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
     }
 
     /**
@@ -689,7 +689,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
+        static::assertContains(sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
     }
 
     /**
@@ -734,7 +734,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             'html style="' . $expectedStyleAttributeContent . '">',
             $result
         );
@@ -755,7 +755,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'two declarations separated by semicolon & space'
             => ['color: #000; width: 3px;', 'color: #000; width: 3px;'],
             'two declarations separated by semicolon & linefeed' => [
-                'color: #000;' . self::LF . 'width: 3px;',
+                'color: #000;' . static::LF . 'width: 3px;',
                 'color: #000; width: 3px;'
             ],
             'two declarations separated by semicolon & Windows line ending' => [
@@ -784,7 +784,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             'html style="' . $expectedStyleAttributeContent . '">',
             $result
         );
@@ -819,7 +819,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<html style="">', $result);
+        static::assertContains('<html style="">', $result);
     }
 
     /**
@@ -832,7 +832,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($styleAttribute, $result);
+        static::assertContains($styleAttribute, $result);
     }
 
     /**
@@ -848,7 +848,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             'style="' . $cssDeclarations . ' ' . $styleAttributeValue . '"',
             $result
         );
@@ -864,7 +864,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<html style="color: red;">', $result);
+        static::assertContains('<html style="color: red;">', $result);
     }
 
     /**
@@ -876,7 +876,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('style="color: #ccc;"', $result);
+        static::assertContains('style="color: #ccc;"', $result);
     }
 
     /**
@@ -889,7 +889,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('style="margin: 0 2pX;"', $result);
+        static::assertContains('style="margin: 0 2pX;"', $result);
     }
 
     /**
@@ -903,7 +903,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="' . $cssDeclaration . '">target</p>',
             $result
         );
@@ -921,7 +921,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="' . $cssDeclaration . '">target</p>',
             $result
         );
@@ -936,7 +936,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('<style', $result);
+        static::assertNotContains('<style', $result);
     }
 
     /**
@@ -969,8 +969,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->subject->emogrify();
 
-        self::assertContains('color: red', $html);
-        self::assertContains('background-color: blue', $html);
+        static::assertContains('color: red', $html);
+        static::assertContains('background-color: blue', $html);
     }
 
     /**
@@ -986,8 +986,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $subject->setHtml($html);
 
         $html = $subject->emogrify();
-        self::assertContains('color: red', $html);
-        self::assertContains('background-color: blue', $html);
+        static::assertContains('color: red', $html);
+        static::assertContains('background-color: blue', $html);
     }
 
     /**
@@ -1027,7 +1027,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains($markerNotExpectedInHtml, $result);
+        static::assertNotContains($markerNotExpectedInHtml, $result);
     }
 
     /**
@@ -1061,7 +1061,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($css, $result);
+        static::assertContains($css, $result);
     }
 
     /**
@@ -1076,7 +1076,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains($css, $result);
+        static::assertNotContains($css, $result);
     }
 
     /**
@@ -1091,7 +1091,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($css, $result);
+        static::assertContains($css, $result);
     }
 
     /**
@@ -1104,7 +1104,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<head>', $result);
+        static::assertContains('<head>', $result);
     }
 
     /**
@@ -1117,7 +1117,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<!-- original content -->', $result);
+        static::assertContains('<!-- original content -->', $result);
     }
 
     /**
@@ -1131,7 +1131,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body><style type="text/css">', $result);
+        static::assertContains('<body><style type="text/css">', $result);
     }
 
     /**
@@ -1187,7 +1187,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
+        static::assertContains('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1209,7 +1209,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
+        static::assertContains('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1225,7 +1225,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
+        static::assertContains('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1242,7 +1242,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('style="color:red"', $result);
+        static::assertNotContains('style="color:red"', $result);
     }
 
     /**
@@ -1277,7 +1277,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains($css, $result);
+        static::assertNotContains($css, $result);
     }
 
     /**
@@ -1294,7 +1294,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style="color: red"', $result);
     }
 
     /**
@@ -1310,7 +1310,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains($css, $result);
+        static::assertNotContains($css, $result);
     }
 
     /**
@@ -1326,7 +1326,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style="color: red"', $result);
     }
 
     /**
@@ -1339,8 +1339,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('style="color: red"', $result);
-        self::assertNotContains('@media screen', $result);
+        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('@media screen', $result);
     }
 
     /**
@@ -1353,8 +1353,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('style="color: red"', $result);
-        self::assertNotContains('@media screen', $result);
+        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('@media screen', $result);
     }
 
     /**
@@ -1367,7 +1367,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<html style="' . $styleAttributeValue . '">',
             $result
         );
@@ -1384,7 +1384,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains(
+        static::assertNotContains(
             '<html style="' . $styleAttributeValue . '">',
             $result
         );
@@ -1404,7 +1404,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="' . $styleAttributeValue . '">',
             $result
         );
@@ -1420,7 +1420,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains('<html style', $result);
+        static::assertNotContains('<html style', $result);
     }
 
     /**
@@ -1437,7 +1437,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="' . $styleAttributeValue . '">',
             $result
         );
@@ -1454,7 +1454,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="color: #ccc;">', $result);
+        static::assertContains('<p style="color: #ccc;">', $result);
     }
 
     /**
@@ -1471,7 +1471,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="padding-bottom: 1px; padding-top: 0; text-align: center;">', $result);
+        static::assertContains('<p style="padding-bottom: 1px; padding-top: 0; text-align: center;">', $result);
     }
 
     /**
@@ -1489,7 +1489,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="margin: 0; padding-top: 1px; padding-bottom: 3px; text-align: center;">',
             $result
         );
@@ -1508,7 +1508,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="margin: 0; padding-bottom: 1px; text-align: center;">', $result);
+        static::assertContains('<p style="margin: 0; padding-bottom: 1px; text-align: center;">', $result);
     }
 
     /**
@@ -1521,7 +1521,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<div class="bar"></div>', $result);
+        static::assertContains('<div class="bar"></div>', $result);
     }
 
     /**
@@ -1536,7 +1536,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<div class="bar"></div>', $result);
+        static::assertContains('<div class="bar"></div>', $result);
     }
 
     /**
@@ -1550,7 +1550,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->disableInvisibleNodeRemoval();
         $result = $this->subject->emogrify();
 
-        self::assertContains('<div class="foo" style="display: none;">', $result);
+        static::assertContains('<div class="foo" style="display: none;">', $result);
     }
 
     /**
@@ -1565,7 +1565,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('@media only screen and (max-width: 480px)', $result);
+        static::assertContains('@media only screen and (max-width: 480px)', $result);
     }
 
     /**
@@ -1581,7 +1581,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body><br></body>', $result);
+        static::assertContains('<body><br></body>', $result);
     }
 
     /**
@@ -1593,7 +1593,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body><br></body>', $result);
+        static::assertContains('<body><br></body>', $result);
     }
 
     /**
@@ -1605,7 +1605,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body><br></body>', $result);
+        static::assertContains('<body><br></body>', $result);
     }
 
     /**
@@ -1617,7 +1617,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<body><p></p></body>', $result);
+        static::assertContains('<body><p></p></body>', $result);
     }
 
     /**
@@ -1629,12 +1629,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertSame(
-            $this->html5DocumentType . self::LF .
-            '<html>' . self::LF .
-            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . self::LF .
-            '<body><p></p></body>' . self::LF .
-            '</html>' . self::LF,
+        static::assertSame(
+            $this->html5DocumentType . static::LF .
+            '<html>' . static::LF .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . static::LF .
+            '<body><p></p></body>' . static::LF .
+            '</html>' . static::LF,
             $result
         );
     }
@@ -1648,7 +1648,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        self::assertSame('<p></p>', $result);
+        static::assertSame('<p></p>', $result);
     }
 
     /**
@@ -1660,7 +1660,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        self::assertSame('<p></p>', $result);
+        static::assertSame('<p></p>', $result);
     }
 
     /**
@@ -1673,7 +1673,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="margin: 1px;">', $result);
+        static::assertContains('<p style="margin: 1px;">', $result);
     }
 
     /**
@@ -1688,7 +1688,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="text-align: center; margin: 1px;">', $result);
+        static::assertContains('<p style="text-align: center; margin: 1px;">', $result);
     }
 
     /**
@@ -1701,7 +1701,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="margin: 1px !ImPorTant;">', $result);
+        static::assertContains('<p style="margin: 1px !ImPorTant;">', $result);
     }
 
     /**
@@ -1714,7 +1714,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="margin: 2px;">',
             $result
         );
@@ -1730,7 +1730,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="margin: 2px;">',
             $result
         );
@@ -1746,7 +1746,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<p style="margin: 1px;">',
             $result
         );
@@ -1763,7 +1763,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains($uselessQuery, $result);
+        static::assertNotContains($uselessQuery, $result);
     }
 
     /**
@@ -1777,7 +1777,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains($usefulQuery, $result);
+        static::assertContains($usefulQuery, $result);
     }
 
     /**
@@ -1794,7 +1794,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="padding: 1px; text-align: center; margin: 2px;">', $result);
+        static::assertContains('<p style="padding: 1px; text-align: center; margin: 2px;">', $result);
     }
 
     /**
@@ -1808,7 +1808,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addExcludedSelector('p.x');
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p class="x"></p>', $result);
+        static::assertContains('<p class="x"></p>', $result);
     }
 
     /**
@@ -1822,7 +1822,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addExcludedSelector(' p.x ');
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p class="x"></p>', $result);
+        static::assertContains('<p class="x"></p>', $result);
     }
 
     /**
@@ -1836,7 +1836,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addExcludedSelector('p.x');
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="margin: 0;"></p>', $result);
+        static::assertContains('<p style="margin: 0;"></p>', $result);
     }
 
     /**
@@ -1852,7 +1852,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p class="x" style="margin: 0;"></p>', $result);
+        static::assertContains('<p class="x" style="margin: 0;"></p>', $result);
     }
 
     /**
@@ -1882,7 +1882,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p class="x"></p>', $result);
+        static::assertContains('<p class="x"></p>', $result);
     }
 
     /**
@@ -1900,9 +1900,9 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p class="x"></p>', $result);
-        self::assertContains('<p class="y" style="color: red;"></p>', $result);
-        self::assertContains('<p class="z"></p>', $result);
+        static::assertContains('<p class="x"></p>', $result);
+        static::assertContains('<p class="y" style="color: red;"></p>', $result);
+        static::assertContains('<p class="z"></p>', $result);
     }
 
     /**
@@ -1916,7 +1916,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertNotContains($emptyQuery, $result);
+        static::assertNotContains($emptyQuery, $result);
     }
 
     /**
@@ -1938,7 +1938,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertSame(
+        static::assertSame(
             1,
             substr_count($result, '<style type="text/css">' . $css . '</style>')
         );
@@ -1963,7 +1963,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertSame(
+        static::assertSame(
             1,
             substr_count($result, '<style type="text/css">' . $css . '</style>')
         );
@@ -1992,7 +1992,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertSame(
+        static::assertSame(
             1,
             substr_count($result, '<style type="text/css">' . $css . '</style>')
         );
@@ -2030,7 +2030,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<html style="' . $styleRule . '">',
             $result
         );
@@ -2122,7 +2122,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->enableCssToHtmlMapping();
         $html = $this->subject->emogrify();
 
-        self::assertRegExp('/<' . preg_quote($tagName, '/') . '[^>]+' . preg_quote($attributes, '/') . '/', $html);
+        static::assertRegExp('/<' . preg_quote($tagName, '/') . '[^>]+' . preg_quote($attributes, '/') . '/', $html);
     }
 
     /**
@@ -2178,7 +2178,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->enableCssToHtmlMapping();
         $html = $this->subject->emogrify();
 
-        self::assertNotContains(
+        static::assertNotContains(
             $attribute . '="',
             $html
         );
@@ -2194,7 +2194,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->subject->emogrify();
 
-        self::assertNotContains(
+        static::assertNotContains(
             '<img align="right',
             $html
         );
@@ -2210,7 +2210,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->subject->emogrify();
 
-        self::assertContains('<div></div>', $html);
+        static::assertContains('<div></div>', $html);
     }
 
     /**
@@ -2224,7 +2224,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="padding: 10px; padding-left: 20px;">', $result);
+        static::assertContains('<p style="padding: 10px; padding-left: 20px;">', $result);
     }
 
     /**
@@ -2238,7 +2238,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains(
+        static::assertContains(
             '<body>' . $style . '</body>',
             $result
         );
@@ -2253,7 +2253,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     private function assertHtmlStringContainsTagWithAttribute($html, $tagName, $attribute)
     {
-        self::assertTrue(
+        static::assertTrue(
             preg_match('/<' . preg_quote($tagName, '/') . '[^>]+' . preg_quote($attribute, '/') . '/', $html) > 0
         );
     }
@@ -2286,7 +2286,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p class="autoWidth" style="width: auto;">', $result);
+        static::assertContains('<p class="autoWidth" style="width: auto;">', $result);
     }
 
     /**
@@ -2354,7 +2354,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<p style="' . $expectedStyleAttributeContent . '">', $result);
+        static::assertContains('<p style="' . $expectedStyleAttributeContent . '">', $result);
     }
 
     /**


### PR DESCRIPTION
This is the recommended way to access static attributes and methods
as this will take subclasses into account.