### PR TITLE
[BUGFIX] Make all exception codes 32-bit compatible

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1210,7 +1210,7 @@ class Emogrifier
         if ($bodyElement === null) {
             throw new \BadMethodCallException(
                 'getBodyElement method may only be called after ensureExistenceOfBodyElement has been called.',
-                1508173775427
+                1508173775
             );
         }
 

--- a/Classes/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/Classes/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
@@ -32,10 +32,10 @@ abstract class AbstractHtmlProcessor
     public function __construct($unprocessedHtml)
     {
         if (!is_string($unprocessedHtml)) {
-            throw new \InvalidArgumentException('The provided HTML must be a string.', 1515459744321);
+            throw new \InvalidArgumentException('The provided HTML must be a string.', 1515459744);
         }
         if ($unprocessedHtml === '') {
-            throw new \InvalidArgumentException('The provided HTML must not be empty.', 1515763647038);
+            throw new \InvalidArgumentException('The provided HTML must not be empty.', 1515763647);
         }
 
         $this->xmlDocument = $this->createXmlDocument($unprocessedHtml);


### PR DESCRIPTION
Exception codes bigger or equal than 2^31 will throw an error on x86 systems (or x86 builds):

```
Error: Wrong parameters for InvalidArgumentException([string $message [, long $code [, Throwable $previous = NULL]]])
```