### PR TITLE
[ENHANCEMENT] Use composer script to run unit tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,7 @@ code coverage of the fixed bugs and the new features.
 To run the existing PHPUnit tests, run this command:
 
 ```shell
-vendor/bin/phpunit tests/
+composer test
 ```
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
 - >
   echo;
   echo "Running the unit tests";
-  vendor/bin/phpunit tests/;
+  composer test;
 
 - >
   echo;

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,9 @@
             "Pelago\\Tests\\": "tests/"
         }
     },
+    "scripts": {
+        "test": "phpunit tests/"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.1.x-dev"


### PR DESCRIPTION
Command is defined in a single place (composer.json) and if it ever needs
to be modified, it has to be modified in one place.
To run PHPUnit tests simply use command `composer test`.

(Next: composer command for phpcs too.)