### PR TITLE
[FEATURE] Use composer script to run phpcs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -89,7 +89,7 @@ We will only merge pull requests that follow the project's coding style.
 Please check your code with the provided PHP_CodeSniffer standard:
 
 ```shell
-vendor/bin/phpcs --standard=config/PhpCodeSniffer.xml src/ tests/
+composer phpcs
 ```
 
 Please make your code clean, well-readable and easy to understand.

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ script:
 - >
   echo;
   echo "Running PHP_CodeSniffer";
-  vendor/bin/phpcs --standard=config/PhpCodeSniffer.xml src/ tests/;
+  composer phpcs;

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit tests/"
+        "test": "phpunit tests/",
+        "phpcs": "phpcs --standard=config/PhpCodeSniffer.xml src/ tests/"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Running PHP_CodeSniffer is now more developer-friendly: `composer phpcs`.