### PR TITLE
[TASK] Make the Composer CI sniffs more future-proof

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,7 @@ code coverage of the fixed bugs and the new features.
 To run the existing PHPUnit tests, run this command:
 
 ```shell
-composer ci:tests
+composer ci:tests:unit
 ```
 
 
@@ -89,7 +89,7 @@ We will only merge pull requests that follow the project's coding style.
 Please check your code with the provided PHP_CodeSniffer standard:
 
 ```shell
-composer ci:sniff
+composer ci:php:sniff
 ```
 
 Please make your code clean, well-readable and easy to understand.

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,14 @@ script:
 - >
   echo;
   echo "Linting all PHP files";
-  composer ci:lint;
+  composer ci:php:lint;
 
 - >
   echo;
   echo "Running the unit tests";
-  composer ci:tests;
+  composer ci:tests:unit;
 
 - >
   echo;
   echo "Running PHP_CodeSniffer";
-  composer ci:sniff;
+  composer ci:php:sniff;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Composer scripts for the various CI build steps
 - Validate the composer.json on Travis
   ([#476](https://github.com/jjriv/emogrifier/pull/476))
 

--- a/composer.json
+++ b/composer.json
@@ -50,15 +50,18 @@
         }
     },
     "scripts": {
-        "ci:lint": "find src/ tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-        "ci:sniff": "phpcs --standard=config/PhpCodeSniffer.xml src/ tests/",
-        "ci:tests": "phpunit tests/",
-        "ci:static": [
-            "@ci:lint",
-            "@ci:sniff"
+        "ci:php:lint": "find src/ tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+        "ci:php:sniff": "phpcs --standard=config/PhpCodeSniffer.xml src/ tests/",
+        "ci:tests:unit": "phpunit tests/",
+        "ci:tests": [
+            "@ci:tests:unit"
         ],
         "ci:dynamic": [
             "@ci:tests"
+        ],
+        "ci:static": [
+            "@ci:php:lint",
+            "@ci:php:sniff"
         ],
         "ci": [
             "@ci:static",


### PR DESCRIPTION
The script names should be named so that we can add integration tests
and configuration file linting while keeping consistent script names
without having to rename the existing scripts.