### PR TITLE
[BUGFIX] Selector precedence pseudos/attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Calculation of selector precedence for selectors involving pseudo-classes
+  and/or attributes.
 
 
 ## 2.0.0

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1404,18 +1404,24 @@ class Emogrifier
         $selectorKey = md5($selector);
         if (!isset($this->caches[static::CACHE_KEY_SELECTOR][$selectorKey])) {
             $precedence = 0;
-            $value = 100;
-            // ids: worth 100, classes: worth 10, elements: worth 1
-            $search = ['\\#', '\\.', ''];
+            $value = 10000;
+            $search = [
+                // ids: worth 10000
+                '\\#',
+                // classes, attributes, pseudo-classes (not pseudo-elements) except `:not`: worth 100
+                '(?:\\.|\\[|(?<!:):(?!not\\())',
+                // elements (not attribute values or `:not`), pseudo-elements: worth 1
+                '(?:(?<![="\':\\w-])|::)'
+            ];
 
             foreach ($search as $s) {
                 if (trim($selector) === '') {
                     break;
                 }
                 $number = 0;
-                $selector = preg_replace('/' . $s . '\\w+/', '', $selector, -1, $number);
+                $selector = preg_replace('/' . $s . '[\\w-]++/', '', $selector, -1, $number);
                 $precedence += ($value * $number);
-                $value /= 10;
+                $value /= 100;
             }
             $this->caches[static::CACHE_KEY_SELECTOR][$selectorKey] = $precedence;
         }


### PR DESCRIPTION
Corrected selector precedence calculation for selectors involving
pseudo-classes and/or attributes (ref:
https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity).

Increased multiplier for selector type to allow up to 100 of each type.

Added PHPUnit tests for selector precedence.  Moved common testing HTML to a
constant.