### PR TITLE
[BUGFIX] CSS property values with newlines dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- CSS rules with property values containing newlines are dropped.
+- Allow CSS property values containing newlines
+  ([#504](https://github.com/MyIntervals/emogrifier/pull/504))
 
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- CSS rules with property values containing newlines are dropped.
 
 
 ## 2.0.0

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1710,7 +1710,7 @@ class Emogrifier
 
         foreach ($declarations as $declaration) {
             $matches = [];
-            if (!preg_match('/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/', trim($declaration), $matches)) {
+            if (!preg_match('/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s', trim($declaration), $matches)) {
                 continue;
             }
 

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -759,18 +759,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
                 '-webkit-text-size-adjust: none;'
             ],
             'one declaration with linefeed in property value' => [
-                'text-shadow:' . static::LF .
-                    '1px 1px 3px #000,' . static::LF .
-                    '1px 1px 1px #000;',
-                'text-shadow: 1px 1px 3px #000,' . static::LF .
-                    '1px 1px 1px #000;',
+                "text-shadow:\n1px 1px 3px #000,\n1px 1px 1px #000;",
+                "text-shadow: 1px 1px 3px #000,\n1px 1px 1px #000;"
             ],
             'one declaration with Windows line ending in property value' => [
-                'text-shadow:' . "\r\n" .
-                    '1px 1px 3px #000,' . "\r\n" .
-                    '1px 1px 1px #000;',
-                'text-shadow: 1px 1px 3px #000,' . "\r\n" .
-                    '1px 1px 1px #000;',
+                "text-shadow:\r\n1px 1px 3px #000,\r\n1px 1px 1px #000;",
+                "text-shadow: 1px 1px 3px #000,\r\n1px 1px 1px #000;"
             ],
         ];
     }

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -758,6 +758,20 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
                 '-webkit-text-size-adjust:none;',
                 '-webkit-text-size-adjust: none;'
             ],
+            'one declaration with linefeed in property value' => [
+                'text-shadow:' . static::LF .
+                    '1px 1px 3px #000,' . static::LF .
+                    '1px 1px 1px #000;',
+                'text-shadow: 1px 1px 3px #000,' . static::LF .
+                    '1px 1px 1px #000;',
+            ],
+            'one declaration with Windows line ending in property value' => [
+                'text-shadow:' . "\r\n" .
+                    '1px 1px 3px #000,' . "\r\n" .
+                    '1px 1px 1px #000;',
+                'text-shadow: 1px 1px 3px #000,' . "\r\n" .
+                    '1px 1px 1px #000;',
+            ],
         ];
     }
 


### PR DESCRIPTION
Added the 's' (PCRE_DOTALL) pattern modifier for `preg_match` in
`parseCssDeclarationsBlock` so that property values containing newlines are also
matched.  Added PHPUnit tests for such property values.