### PR TITLE
 [BUGFIX] Minified adjacent sibling combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Allow CSS property values containing newlines
-  ([#504](https://github.com/MyIntervals/emogrifier/pull/504))
 - Allow adjacent sibling CSS selector combinator in minified CSS
   ([#505](https://github.com/MyIntervals/emogrifier/pull/505))
+- Allow CSS property values containing newlines
+  ([#504](https://github.com/MyIntervals/emogrifier/pull/504))
 
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow adjacent sibling CSS selector combinator in minified CSS
 
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Allow CSS property values containing newlines
   ([#504](https://github.com/MyIntervals/emogrifier/pull/504))
 - Allow adjacent sibling CSS selector combinator in minified CSS
+  ([#505](https://github.com/MyIntervals/emogrifier/pull/505))
 
 
 ## 2.0.0

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -175,7 +175,7 @@ class Emogrifier
         // type and attribute value with * (substring match)
         '/([\\w\\*]+)\\[(\\w+)[\\s]*\\*\\=[\\s]*[\'"]?([\\w-_\\s\\/:;]+)[\'"]?\\]/' => '\\1[contains(@\\2, "\\3")]',
         // adjacent sibling
-        '/\\s+\\+\\s+/' => '/following-sibling::*[1]/self::',
+        '/\\s*\\+\\s*/' => '/following-sibling::*[1]/self::',
         // child
         '/\\s*>\\s*/' => '/',
         // descendant

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -560,6 +560,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             ],
             'adjacent => 2nd of many' => ['p + p { %1$s }', '<p class="p-2" style="%1$s">'],
             'adjacent => last of many' => ['p + p { %1$s }', '<p class="p-6" style="%1$s">'],
+            'adjacent (without space after +) => last of many' => ['p +p { %1$s }', '<p class="p-6" style="%1$s">'],
+            'adjacent (without space before +) => last of many' => ['p+ p { %1$s }', '<p class="p-6" style="%1$s">'],
+            'adjacent (without space before or after +) => last of many' => [
+                'p+p { %1$s }',
+                '<p class="p-6" style="%1$s">'
+            ],
             'child (with spaces around >) => direct child' => ['p > span { %1$s }', '<span style="%1$s">'],
             'child (without space after >) => direct child' => ['p >span { %1$s }', '<span style="%1$s">'],
             'child (without space before >) => direct child' => ['p> span { %1$s }', '<span style="%1$s">'],


### PR DESCRIPTION
Changed `$xPathRules` regular expression for adjacent sibling combinator to
match zero or more spaces either side, rather than one or more, allowing
selectors with this combinator in minified CSS to be matched.  Added PHPUnit
tests for such CSS.