### PR TITLE
[BUGFIX] Descendent attribute selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow attribute selectors in descendants
+  ([#506](https://github.com/MyIntervals/emogrifier/pull/505),
+  [#381](https://github.com/MyIntervals/emogrifier/issues/381))
 - Allow adjacent sibling CSS selector combinator in minified CSS
   ([#505](https://github.com/MyIntervals/emogrifier/pull/505))
 - Allow CSS property values containing newlines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Allow attribute selectors in descendants
-  ([#506](https://github.com/MyIntervals/emogrifier/pull/505),
+  ([#506](https://github.com/MyIntervals/emogrifier/pull/506),
   [#381](https://github.com/MyIntervals/emogrifier/issues/381))
 - Allow adjacent sibling CSS selector combinator in minified CSS
   ([#505](https://github.com/MyIntervals/emogrifier/pull/505))

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -178,8 +178,8 @@ class Emogrifier
         '/\\s*\\+\\s*/' => '/following-sibling::*[1]/self::',
         // child
         '/\\s*>\\s*/' => '/',
-        // descendant
-        '/\\s+(?=.*[^\\]]{1}$)/' => '//',
+        // descendant (don't match spaces within already translated XPath predicates)
+        '/\\s+(?![^\\[\\]]*+\\])/' => '//',
         // type and :first-child
         '/([^\\/]+):first-child/i' => '*[1]/self::\\1',
         // type and :last-child

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -405,6 +405,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             // broken: attribute value with *, double quotes => with exact match
             // broken: attribute value with *, single quotes => with exact match
             // broken: attribute value with *, no quotes => with exact match
+            // broken: type & attribute presence => with type & attribute
             'type & attribute exact value, double quotes => with type & exact attribute value match' => [
                 'span[title="bonjour"] { %1$s }',
                 '<span title="bonjour" style="%1$s">',
@@ -572,6 +573,52 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'child (without space before or after >) => direct child' => ['p>span { %1$s }', '<span style="%1$s">'],
             'descendant => child' => ['p span { %1$s }', '<span style="%1$s">'],
             'descendant => grandchild' => ['body span { %1$s }', '<span style="%1$s">'],
+            // broken: descendent attribute presence => with attribute
+            // broken: descendent attribute exact value => with exact attribute match
+            // broken: descendent type & attribute presence => with type & attribute
+            'descendent type & attribute exact value => with type & exact attribute match' => [
+                'body span[title="bonjour"] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
+            'descendent type & attribute exact two-word value => with type & exact attribute match' => [
+                'body span[title="buenas dias"] { %1$s }',
+                '<span title="buenas dias" style="%1$s">',
+            ],
+            'descendent type & attribute value with ~ => with type & exact attribute match' => [
+                'body span[title~="bonjour"] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
+            'descendent type & attribute value with ~ => with type & word as 1st of 2 in attribute' => [
+                'body span[title~="buenas"] { %1$s }',
+                '<span title="buenas dias" style="%1$s">',
+            ],
+            'descendant of type & class: type & attribute exact value, no quotes => with type & exact match (#381)' => [
+                'p.p-2 span[title=bonjour] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
+            'descendant of attribute presence => parent with attribute' => [
+                '[class] span { %1$s }',
+                '<p class="p-1"><span style="%1$s">',
+            ],
+            'descendant of attribute exact value => parent with type & exact attribute match' => [
+                '[id="p4"] span { %1$s }',
+                '<p class="p-4" id="p4"><span title="avez-vous" style="%1$s">',
+            ],
+            // broken: descendant of type & attribute presence => parent with type & attribute
+            'descendant of type & attribute exact value => parent with type & exact attribute match' => [
+                'p[id="p4"] span { %1$s }',
+                '<p class="p-4" id="p4"><span title="avez-vous" style="%1$s">',
+            ],
+            // broken: descendant of type & attribute exact two-word value => parent with type & exact attribute match
+            //         (exact match doesn't currently match hyphens, which would be needed to match the class attribute)
+            'descendant of type & attribute value with ~ => parent with type & exact attribute match' => [
+                'p[class~="p-1"] span { %1$s }',
+                '<p class="p-1"><span style="%1$s">',
+            ],
+            'descendant of type & attribute value with ~ => parent with type & word as 1st of 2 in attribute' => [
+                'p[class~="p-5"] span { %1$s }',
+                '<p class="p-5 additional-class"><span title="buenas dias bom dia" style="%1$s">',
+            ],
             // broken: first-child => 1st of many
             'type & :first-child => 1st of many' => ['p:first-child { %1$s }', '<p class="p-1" style="%1$s">'],
             // broken: last-child => last of many


### PR DESCRIPTION
Changed CSS-to-XPath translation matcher for descendant combinator to exclude
only spaces within `[...]`, i.e. when not followed by a closing `]` unless there
is an intervening opening `[` (rather than than excluding any space where the
remaining part of the expression ends with a closing `]`).  This matches spaces
in the original CSS selector but not spaces in already-translated XPath
predicates, and allows attribute selectors to be used in descendants.

Added PHPUnit tests for some attribute selectors as descendants, particularly
where the translated XPath predicate will contain a space.  Also added tests for
the converse (attribute selectors with descendants), and comments for relevant
tests that should be added but would currently fail due to other issues.

This should fix Issue
[#381](https://github.com/MyIntervals/emogrifier/issues/381) and at least
partially address Issue
[#443](https://github.com/MyIntervals/emogrifier/issues/443).

For reference, the original space-exclusion regex was added in
[#327](https://github.com/MyIntervals/emogrifier/pull/327) to avoid matching
spaces in selector attributes.  The purpose changed in
[#458](https://github.com/MyIntervals/emogrifier/pull/458), when the
CSS-to-XPath translation rules were reordered, to avoid matching spaces in XPath
predicates, though the requirement not to match spaces within `[...]` was
unchanged.