### PR TITLE
[BUGFIX] Allow @charset without error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow `@charset` in the CSS without error (note: its value is currently
+  ignored, [#507](https://github.com/MyIntervals/emogrifier/pull/507))
 - Allow attribute selectors in descendants
   ([#506](https://github.com/MyIntervals/emogrifier/pull/506),
   [#381](https://github.com/MyIntervals/emogrifier/issues/381))

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1258,7 +1258,7 @@ class Emogrifier
 
         // filter the CSS
         $search = [
-            'import directives' => '/^\\s*@import\\s[^;]+;/misU',
+            'import/charset directives' => '/^\\s*@(?:import|charset)\\s[^;]+;/misU',
             'remaining media enclosures' => '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
         ];
 

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1091,7 +1091,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider unneededCssThingsDataProvider
      */
-    public function emogrifyUnaffectedByUnneededCssThings($css)
+    public function emogrifyMatchesRuleAfterUnneededCssThing($css)
     {
         $this->subject->setHtml('<html><body></body></html>');
         $this->subject->setCss($css . ' body { color: green; }');

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1054,6 +1054,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'CSS comments with one asterisk' => ['p {color: #000;/* black */}', 'black'],
             'CSS comments with two asterisks' => ['p {color: #000;/** black */}', 'black'],
             '@import directive' => ['@import "foo.css";', '@import'],
+            '@charset directive' => ['@charset "UTF-8";', '@charset'],
             'style in "aural" media type rule' => ['@media aural {p {color: #000;}}', '#000'],
             'style in "braille" media type rule' => ['@media braille {p {color: #000;}}', '#000'],
             'style in "embossed" media type rule' => ['@media embossed {p {color: #000;}}', '#000'],
@@ -1081,6 +1082,23 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $result = $this->subject->emogrify();
 
         static::assertNotContains($markerNotExpectedInHtml, $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $css
+     *
+     * @dataProvider unneededCssThingsDataProvider
+     */
+    public function emogrifyUnaffectedByUnneededCssThings($css)
+    {
+        $this->subject->setHtml('<html><body></body></html>');
+        $this->subject->setCss($css . ' body { color: green; }');
+
+        $result = $this->subject->emogrify();
+
+        static::assertContains('<body style="color: green;">', $result);
     }
 
     /**


### PR DESCRIPTION
Filter out `@charset` at-rules from the CSS before processing, to avoid an error
when presented with CSS containing this at-rule.

Obviously this does not mean `@charset` is supported - its value is still
ignored - but does address the immediate error in #296.

Added PHPUnit test like that for `@import`, and also test that such CSS content
does not prevent Emogrifier working correctly on the remainder of the CSS.