### PR TITLE
[BUGFIX] Individual/shorthand style property order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Style property ordering when multiple mixed individual and shorthand
+  properties apply ([#511](https://github.com/MyIntervals/emogrifier/pull/511),
+  [#508](https://github.com/MyIntervals/emogrifier/issues/508))
 - Calculation of selector precedence for selectors involving pseudo-classes
   and/or attributes ([#502](https://github.com/MyIntervals/emogrifier/pull/502))
 - Allow `@charset` in the CSS without error (note: its value is currently

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1009,12 +1009,12 @@ class Emogrifier
      */
     private function generateStyleStringFromDeclarationsArrays(array $oldStyles, array $newStyles)
     {
-        $combinedStyles = array_merge($oldStyles, $newStyles);
-        $cacheKey = serialize($combinedStyles);
+        $cacheKey = serialize([$oldStyles, $newStyles]);
         if (isset($this->caches[static::CACHE_KEY_COMBINED_STYLES][$cacheKey])) {
             return $this->caches[static::CACHE_KEY_COMBINED_STYLES][$cacheKey];
         }
 
+        // Unset the overridden styles to preserve order, important if shorthand and individual properties are mixed
         foreach ($oldStyles as $attributeName => $attributeValue) {
             if (!isset($newStyles[$attributeName])) {
                 continue;
@@ -1024,9 +1024,13 @@ class Emogrifier
             if ($this->attributeValueIsImportant($attributeValue)
                 && !$this->attributeValueIsImportant($newAttributeValue)
             ) {
-                $combinedStyles[$attributeName] = $attributeValue;
+                unset($newStyles[$attributeName]);
+            } else {
+                unset($oldStyles[$attributeName]);
             }
         }
+
+        $combinedStyles = array_merge($oldStyles, $newStyles);
 
         $style = '';
         foreach ($combinedStyles as $attributeName => $attributeValue) {

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1739,12 +1739,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        // Property order in style attribute now follows precedence order, though used to follow application order
-        // Either is valid in this case
-        static::assertThat($result, static::logicalOr(
-            static::stringContains('<p style="margin: 0; padding-top: 1px; padding-bottom: 3px; text-align: center;">'),
-            static::stringContains('<p style="margin: 0; padding-bottom: 3px; padding-top: 1px; text-align: center;">')
-        ));
+        static::assertContains(
+            '<p style="margin: 0; padding-bottom: 3px; padding-top: 1px; text-align: center;">',
+            $result
+        );
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -2018,6 +2018,22 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function emogrifyAppliesLaterShorthandStyleAfterIndividualStyle()
+    {
+        $this->setSubjectBoilerplateHtml();
+        $this->subject->setCss('p { margin-top: 1px; } p { margin: 2px; }');
+
+        $result = $this->subject->emogrify();
+
+        static::assertContains(
+            '<p style="margin-top: 1px; margin: 2px;">',
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
     public function emogrifyAppliesLaterOverridingStyleAfterStyleAfterOverriddenStyle()
     {
         $this->setSubjectBoilerplateHtml();


### PR DESCRIPTION
Fix for style property ordering when multiple mixed individual and shorthand
properties apply (#508).

In `generateStyleStringFromDeclarationsArrays`, an overridden style was
retaining its original position in the property list from the result of
`array_merge`, which could be before a shorthand/individual variant it should
apply after.

The properties that are overridden are now `unset` from the arrays before the
`array_merge`, so that the correct order is maintained.