### PR TITLE
[CLEANUP] Tighten tests using `assertNotContains`

### DIFF
--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1327,7 +1327,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<style', $result);
+        static::assertNotContains('@media', $result);
     }
 
     /**

--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1327,7 +1327,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($css, $result);
+        static::assertNotContains('<style', $result);
     }
 
     /**
@@ -1493,7 +1493,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color:red"', $result);
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -1545,7 +1545,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -1577,7 +1577,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -1590,7 +1590,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
         static::assertNotContains('@media screen', $result);
     }
 
@@ -1604,7 +1604,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
         static::assertNotContains('@media screen', $result);
     }
 
@@ -1635,10 +1635,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains(
-            '<html style="' . $styleAttributeValue . '">',
-            $result
-        );
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -2091,7 +2088,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($uselessQuery, $result);
+        static::assertNotContains('@media', $result);
     }
 
     /**
@@ -2240,7 +2237,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($emptyQuery, $result);
+        static::assertNotContains('@media', $result);
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1326,7 +1326,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<style', $result);
+        static::assertNotContains('@media', $result);
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1326,7 +1326,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($css, $result);
+        static::assertNotContains('<style', $result);
     }
 
     /**
@@ -1492,7 +1492,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color:red"', $result);
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -1544,7 +1544,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -1576,7 +1576,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -1589,7 +1589,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
         static::assertNotContains('@media screen', $result);
     }
 
@@ -1603,7 +1603,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style="color: red"', $result);
+        static::assertNotContains('style=', $result);
         static::assertNotContains('@media screen', $result);
     }
 
@@ -1634,10 +1634,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains(
-            '<html style="' . $styleAttributeValue . '">',
-            $result
-        );
+        static::assertNotContains('style=', $result);
     }
 
     /**
@@ -2090,7 +2087,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($uselessQuery, $result);
+        static::assertNotContains('@media', $result);
     }
 
     /**
@@ -2239,7 +2236,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($emptyQuery, $result);
+        static::assertNotContains('@media', $result);
     }
 
     /**
@@ -2502,7 +2499,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $html = $this->subject->emogrify();
 
         static::assertNotContains(
-            $attribute . '="',
+            $attribute . '=',
             $html
         );
     }
@@ -2518,7 +2515,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $html = $this->subject->emogrify();
 
         static::assertNotContains(
-            '<img align="right',
+            'align=',
             $html
         );
     }


### PR DESCRIPTION
In tests using `assertNotContains`, assert only that a minimal string sufficient
to indicate a test failure is not present.

Changes for #280 will inevitably mean that during processing, due to the way
that some components of the CSS are `trim`med, some unnecessary whitespace is
removed from the CSS for media queries added to the style element.  Thus
asserting that a complete media query rule is not present in the result may
allow a test to pass that should fail.  Asserting that just, e.g., "@media" or
"@media tv" is not present in the result gives a more stringent test.

For completeness, needles used with `assertNotContains` in other tests have also
been similarly shortened.  Some of these tests would have allowed invalid
passes, e.g. with a semicolon at the end of a style attribute that was asserted
not to be present.