### PR TITLE
[CLEANUP] Nonempty rule blocks for @media tests

### DIFF
--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1320,7 +1320,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function removeAllowedMediaTypeRemovesStylesForTheGivenMediaType()
     {
-        $css = '@media screen { html {} }';
+        $css = '@media screen { html { some-property: value; } }';
         $this->subject->setHtml('<html></html>');
         $this->subject->setCss($css);
         $this->subject->removeAllowedMediaType('screen');
@@ -1351,7 +1351,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     public function emogrifyAddsMissingHeadElement()
     {
         $this->subject->setHtml('<html></html>');
-        $this->subject->setCss('@media all { html {} }');
+        $this->subject->setCss('@media all { html { some-property: value; } }');
 
         $result = $this->subject->emogrify();
 
@@ -1364,7 +1364,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepExistingHeadElementContent()
     {
         $this->subject->setHtml('<html><head><!-- original content --></head></html>');
-        $this->subject->setCss('@media all { html {} }');
+        $this->subject->setCss('@media all { html { some-property: value; } }');
 
         $result = $this->subject->emogrify();
 
@@ -1378,7 +1378,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     {
         $html = $this->html5DocumentType . '<html><head><!-- original content --></head></html>';
         $this->subject->setHtml($html);
-        $this->subject->setCss('@media all { html {} }');
+        $this->subject->setCss('@media all { html { some-property: value; } }');
 
         $result = $this->subject->emogrify();
 

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1319,7 +1319,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function removeAllowedMediaTypeRemovesStylesForTheGivenMediaType()
     {
-        $css = '@media screen { html {} }';
+        $css = '@media screen { html { some-property: value; } }';
         $this->subject->setHtml('<html></html>');
         $this->subject->setCss($css);
         $this->subject->removeAllowedMediaType('screen');
@@ -1350,7 +1350,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyAddsMissingHeadElement()
     {
         $this->subject->setHtml('<html></html>');
-        $this->subject->setCss('@media all { html {} }');
+        $this->subject->setCss('@media all { html { some-property: value; } }');
 
         $result = $this->subject->emogrify();
 
@@ -1363,7 +1363,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepExistingHeadElementContent()
     {
         $this->subject->setHtml('<html><head><!-- original content --></head></html>');
-        $this->subject->setCss('@media all { html {} }');
+        $this->subject->setCss('@media all { html { some-property: value; } }');
 
         $result = $this->subject->emogrify();
 
@@ -1377,7 +1377,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $html = $this->html5DocumentType . '<html><head><!-- original content --></head></html>';
         $this->subject->setHtml($html);
-        $this->subject->setCss('@media all { html {} }');
+        $this->subject->setCss('@media all { html { some-property: value; } }');
 
         $result = $this->subject->emogrify();
 


### PR DESCRIPTION
Ensured there's at least one property declaration in CSS rule blocks used with
@media rule tests, as changes for #280 will result in elimination of empty CSS
rule blocks during processing.