### PR TITLE
[FEATURE] Expose the DOMDocument in AbstractHtmlProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Expose the DOMDocument in AbstractHtmlProcessor
+  ([#520](https://github.com/jjriv/emogrifier/pull/520))
 - Add an HtmlNormalizer class
   ([#513](https://github.com/jjriv/emogrifier/pull/513),
   [#516](https://github.com/jjriv/emogrifier/pull/516))

--- a/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
@@ -44,6 +44,16 @@ abstract class AbstractHtmlProcessor
     }
 
     /**
+     * Provides access to the internal DOMDocument representation of the HTML in its current state.
+     *
+     * @return \DOMDocument
+     */
+    public function getDomDocument()
+    {
+        return $this->xmlDocument;
+    }
+
+    /**
      * Renders the normalized and processed HTML.
      *
      * @return string

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -318,4 +318,29 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         static::assertContains('<body><br></body>', $result);
     }
+
+    /**
+     * @test
+     */
+    public function getDomDocumentReturnsDomDocument()
+    {
+        $subject = new TestingHtmlProcessor('<html></html>');
+
+        static::assertInstanceOf(\DOMDocument::class, $subject->getDomDocument());
+    }
+
+    /**
+     * @test
+     */
+    public function getDomDocumentWithNormalizedHtmlRepresentsTheGivenHtml()
+    {
+        $html = "<!DOCTYPE html>\n<html>\n<head>" .
+            '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' .
+            "</head>\n<body>\n<br>\n</body>\n</html>\n";
+
+        $subject = new TestingHtmlProcessor($html);
+
+        $domDocument = $subject->getDomDocument();
+        self::assertSame($html, $domDocument->saveHTML());
+    }
 }


### PR DESCRIPTION
This allows chaining multiple HtmlProcessory without the performance
penalty of serializing to HTML and then parsing the HTML into a
DOMDocument for each processor.