### PR TITLE
[CLEANUP] Allow whitespace removal in @media tests

### DIFF
--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1290,16 +1290,16 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
      * readable and can use inputs containing extra whitespace.
      *
-     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`
+     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
      *
-     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead
+     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
      */
-    private static function getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle)
+    private static function getCssNeedleRegExp($needle)
     {
         $needleMatcher = preg_replace_callback(
             '/\\s*+([{}])\\s*+|(?:(?!\\s*+[{}]).)++/',
-            function ($matches) {
-                if (!empty($matches[1])) {
+            function (array $matches) {
+                if (isset($matches[1]) && $matches[1] !== '') {
                     // matched possibly some whitespace, followed by "{" or "}", then possibly more whitespace
                     return '\\s*+' . preg_quote($matches[1], '/') . '\\s*+';
                 } else {
@@ -1313,30 +1313,31 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Like `assertContains` but allows for removal of some unnecessary whitespace from the CSS
+     * Like `assertContains` but allows for removal of some unnecessary whitespace from the CSS.
      *
      * @param string $needle
      * @param string $haystack
      */
-    private static function assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($needle, $haystack)
+    private static function assertContainsCss($needle, $haystack)
     {
         static::assertRegExp(
-            static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle),
+            static::getCssNeedleRegExp($needle),
             $haystack,
             'Plain text needle: "' . $needle . '"'
         );
     }
 
     /**
-     * Like `assertNotContains` and also enforces the assertion with removal of some unnecessary whitespace from the CSS
+     * Like `assertNotContains` and also enforces the assertion with removal of some unnecessary whitespace from the
+     * CSS.
      *
      * @param string $needle
      * @param string $haystack
      */
-    private static function assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($needle, $haystack)
+    private static function assertNotContainsCss($needle, $haystack)
     {
         static::assertNotRegExp(
-            static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle),
+            static::getCssNeedleRegExp($needle),
             $haystack,
             'Plain text needle: "' . $needle . '"'
         );
@@ -1344,20 +1345,20 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Asserts that a string of CSS occurs exactly a certain number of times in the result, allowing for removal of some
-     * unnecessary whitespace
+     * unnecessary whitespace.
      *
-     * @param string $needle
      * @param int $expectedCount
+     * @param string $needle
      * @param string $haystack
      */
-    private static function assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace(
-        $needle,
+    private static function assertContainsCssCount(
         $expectedCount,
+        $needle,
         $haystack
     ) {
         static::assertSame(
             $expectedCount,
-            preg_match_all(static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle), $haystack),
+            preg_match_all(static::getCssNeedleRegExp($needle), $haystack),
             'Plain text needle: "' . $needle . "\"\nHaystack: \"" . $haystack . '"'
         );
     }
@@ -1393,7 +1394,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertContainsCss($css, $result);
     }
 
     /**
@@ -1460,7 +1461,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($mediaRule1 . $mediaRule2, $result);
+        static::assertContainsCss($mediaRule1 . $mediaRule2, $result);
     }
 
     /**
@@ -1490,7 +1491,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertContainsCss($css, $result);
     }
 
     /**
@@ -1586,7 +1587,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+        static::assertContainsCss(
             '<style type="text/css">' . $css . '</style>',
             $result
         );
@@ -1627,7 +1628,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+        static::assertContainsCss(
             '<style type="text/css">' . $css . '</style>',
             $result
         );
@@ -1682,7 +1683,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertNotContainsCss($css, $result);
     }
 
     /**
@@ -1715,7 +1716,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertNotContainsCss($css, $result);
     }
 
     /**
@@ -2256,7 +2257,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($usefulQuery, $result);
+        static::assertContainsCss($usefulQuery, $result);
     }
 
     /**
@@ -2413,7 +2414,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
+        static::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2435,7 +2436,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
+        static::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2461,7 +2462,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
+        static::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2540,7 +2541,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+        static::assertContainsCss(
             '<body>' . $style . '</body>',
             $result
         );
@@ -2656,6 +2657,6 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        $this->assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        $this->assertContainsCss($css, $result);
     }
 }

--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1282,6 +1282,87 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
+     * element added to the docuemnt, due to the way that certain parts are `trim`med.  Notably, whitespace either side
+     * of "{" and "}" may be removed.
+     *
+     * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
+     * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
+     * readable and can use inputs containing extra whitespace.
+     *
+     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`
+     *
+     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead
+     */
+    private static function getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle)
+    {
+        $needleMatcher = preg_replace_callback(
+            '/\\s*+([{}])\\s*+|(?:(?!\\s*+[{}]).)++/',
+            function ($matches) {
+                if (!empty($matches[1])) {
+                    // matched possibly some whitespace, followed by "{" or "}", then possibly more whitespace
+                    return '\\s*+' . preg_quote($matches[1], '/') . '\\s*+';
+                } else {
+                    // matched any other sequence which could not overlap with the above
+                    return preg_quote($matches[0], '/');
+                }
+            },
+            $needle
+        );
+        return '/' . $needleMatcher . '/';
+    }
+
+    /**
+     * Like `assertContains` but allows for removal of some unnecessary whitespace from the CSS
+     *
+     * @param string $needle
+     * @param string $haystack
+     */
+    private static function assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($needle, $haystack)
+    {
+        static::assertRegExp(
+            static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle),
+            $haystack,
+            'Plain text needle: "' . $needle . '"'
+        );
+    }
+
+    /**
+     * Like `assertNotContains` and also enforces the assertion with removal of some unnecessary whitespace from the CSS
+     *
+     * @param string $needle
+     * @param string $haystack
+     */
+    private static function assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($needle, $haystack)
+    {
+        static::assertNotRegExp(
+            static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle),
+            $haystack,
+            'Plain text needle: "' . $needle . '"'
+        );
+    }
+
+    /**
+     * Asserts that a string of CSS occurs exactly a certain number of times in the result, allowing for removal of some
+     * unnecessary whitespace
+     *
+     * @param string $needle
+     * @param int $expectedCount
+     * @param string $haystack
+     */
+    private static function assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace(
+        $needle,
+        $expectedCount,
+        $haystack
+    ) {
+        static::assertSame(
+            $expectedCount,
+            preg_match_all(static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle), $haystack),
+            'Plain text needle: "' . $needle . "\"\nHaystack: \"" . $haystack . '"'
+        );
+    }
+
+    /**
      * Data provider for media rules.
      *
      * @return string[][]
@@ -1312,7 +1393,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($css, $result);
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
     }
 
     /**
@@ -1379,7 +1460,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($mediaRule1 . $mediaRule2, $result);
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($mediaRule1 . $mediaRule2, $result);
     }
 
     /**
@@ -1409,7 +1490,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($css, $result);
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
     }
 
     /**
@@ -1505,7 +1586,10 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<style type="text/css">' . $css . '</style>', $result);
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+            '<style type="text/css">' . $css . '</style>',
+            $result
+        );
     }
 
     /**
@@ -1543,7 +1627,10 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<style type="text/css">' . $css . '</style>', $result);
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+            '<style type="text/css">' . $css . '</style>',
+            $result
+        );
     }
 
     /**
@@ -1595,7 +1682,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($css, $result);
+        static::assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
     }
 
     /**
@@ -1628,7 +1715,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($css, $result);
+        static::assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
     }
 
     /**
@@ -2169,7 +2256,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($usefulQuery, $result);
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($usefulQuery, $result);
     }
 
     /**
@@ -2326,10 +2413,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertSame(
-            1,
-            substr_count($result, '<style type="text/css">' . $css . '</style>')
-        );
+        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
     }
 
     /**
@@ -2351,10 +2435,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertSame(
-            1,
-            substr_count($result, '<style type="text/css">' . $css . '</style>')
-        );
+        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
     }
 
     /**
@@ -2380,10 +2461,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertSame(
-            1,
-            substr_count($result, '<style type="text/css">' . $css . '</style>')
-        );
+        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
     }
 
     /**
@@ -2462,7 +2540,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
+        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
             '<body>' . $style . '</body>',
             $result
         );
@@ -2578,6 +2656,6 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        $this->assertContains($css, $result);
+        $this->assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
     }
 }

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1289,16 +1289,16 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
      * readable and can use inputs containing extra whitespace.
      *
-     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`
+     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
      *
-     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead
+     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
      */
-    private static function getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle)
+    private static function getCssNeedleRegExp($needle)
     {
         $needleMatcher = preg_replace_callback(
             '/\\s*+([{}])\\s*+|(?:(?!\\s*+[{}]).)++/',
-            function ($matches) {
-                if (!empty($matches[1])) {
+            function (array $matches) {
+                if (isset($matches[1]) && $matches[1] !== '') {
                     // matched possibly some whitespace, followed by "{" or "}", then possibly more whitespace
                     return '\\s*+' . preg_quote($matches[1], '/') . '\\s*+';
                 } else {
@@ -1312,30 +1312,31 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Like `assertContains` but allows for removal of some unnecessary whitespace from the CSS
+     * Like `assertContains` but allows for removal of some unnecessary whitespace from the CSS.
      *
      * @param string $needle
      * @param string $haystack
      */
-    private static function assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($needle, $haystack)
+    private static function assertContainsCss($needle, $haystack)
     {
         static::assertRegExp(
-            static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle),
+            static::getCssNeedleRegExp($needle),
             $haystack,
             'Plain text needle: "' . $needle . '"'
         );
     }
 
     /**
-     * Like `assertNotContains` and also enforces the assertion with removal of some unnecessary whitespace from the CSS
+     * Like `assertNotContains` and also enforces the assertion with removal of some unnecessary whitespace from the
+     * CSS.
      *
      * @param string $needle
      * @param string $haystack
      */
-    private static function assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($needle, $haystack)
+    private static function assertNotContainsCss($needle, $haystack)
     {
         static::assertNotRegExp(
-            static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle),
+            static::getCssNeedleRegExp($needle),
             $haystack,
             'Plain text needle: "' . $needle . '"'
         );
@@ -1343,20 +1344,20 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Asserts that a string of CSS occurs exactly a certain number of times in the result, allowing for removal of some
-     * unnecessary whitespace
+     * unnecessary whitespace.
      *
-     * @param string $needle
      * @param int $expectedCount
+     * @param string $needle
      * @param string $haystack
      */
-    private static function assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace(
-        $needle,
+    private static function assertContainsCssCount(
         $expectedCount,
+        $needle,
         $haystack
     ) {
         static::assertSame(
             $expectedCount,
-            preg_match_all(static::getNeedleRegExpAllowingRemovalOfUnnecessaryCssWhitespace($needle), $haystack),
+            preg_match_all(static::getCssNeedleRegExp($needle), $haystack),
             'Plain text needle: "' . $needle . "\"\nHaystack: \"" . $haystack . '"'
         );
     }
@@ -1392,7 +1393,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertContainsCss($css, $result);
     }
 
     /**
@@ -1459,7 +1460,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($mediaRule1 . $mediaRule2, $result);
+        static::assertContainsCss($mediaRule1 . $mediaRule2, $result);
     }
 
     /**
@@ -1489,7 +1490,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertContainsCss($css, $result);
     }
 
     /**
@@ -1585,7 +1586,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+        static::assertContainsCss(
             '<style type="text/css">' . $css . '</style>',
             $result
         );
@@ -1626,7 +1627,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+        static::assertContainsCss(
             '<style type="text/css">' . $css . '</style>',
             $result
         );
@@ -1681,7 +1682,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertNotContainsCss($css, $result);
     }
 
     /**
@@ -1714,7 +1715,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        static::assertNotContainsCss($css, $result);
     }
 
     /**
@@ -2255,7 +2256,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($usefulQuery, $result);
+        static::assertContainsCss($usefulQuery, $result);
     }
 
     /**
@@ -2412,7 +2413,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
+        static::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2434,7 +2435,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
+        static::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2460,7 +2461,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCountAllowingRemovalOfUnnecessaryCssWhitespace($css, 1, $result);
+        static::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2703,7 +2704,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsAllowingRemovalOfUnnecessaryCssWhitespace(
+        static::assertContainsCss(
             '<body>' . $style . '</body>',
             $result
         );
@@ -2850,6 +2851,6 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        $this->assertContainsAllowingRemovalOfUnnecessaryCssWhitespace($css, $result);
+        $this->assertContainsCss($css, $result);
     }
 }


### PR DESCRIPTION
Added test assertion methods similar to `assertContains` and `assertNotContains`
but which also allow for removal of some unnecessary whitespace from the CSS,
without having to make the test data less humanly readable or change the test
inputs.

Changes for #280 will inevitably mean that during processing, due to the way
that some components of the CSS are `trim`med, some unnecessary whitespace is
removed from the CSS for media queries added to the style element.  Relevant
tests have been changed to used the new assertion methods.