### PR TITLE
[TASK] Remove the $css parameter from the CssInliner constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#513](https://github.com/jjriv/emogrifier/pull/513),
   [#516](https://github.com/jjriv/emogrifier/pull/516))
 - Add a CssInliner class
-  ([#514](https://github.com/jjriv/emogrifier/pull/514))
+  ([#514](https://github.com/jjriv/emogrifier/pull/514),
+  [#522](https://github.com/jjriv/emogrifier/pull/522))
 - Composer scripts for the various CI build steps
 - Validate the composer.json on Travis
   ([#476](https://github.com/jjriv/emogrifier/pull/476))

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -220,13 +220,11 @@ class CssInliner
     /**
      * The constructor.
      *
-     * @param string $html the HTML to emogrify, must be UTF-8-encoded
-     * @param string $css the CSS to merge, must be UTF-8-encoded
+     * @param string $html the HTML to inline, must be UTF-8-encoded
      */
-    public function __construct($html = '', $css = '')
+    public function __construct($html = '')
     {
         $this->setHtml($html);
-        $this->setCss($css);
     }
 
     /**


### PR DESCRIPTION
This interface change the is first step toward having CssInliner
inherit from AbstractHtmlProcessor.