### PR TITLE
[BUGFIX] @media rule-matching regex edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow multiple minified `@import` rules in the CSS without error (note:
+  `@import`s are currently ignored,
+  [#524](https://github.com/MyIntervals/emogrifier/pull/524))
+- Allow additional whitespace in media-query-list of disallowed `@media` rules
+  ([#524](https://github.com/MyIntervals/emogrifier/pull/524))
+- Allow disallowed `@media` rule after empty `@media` rule
+  ([#524](https://github.com/MyIntervals/emogrifier/pull/524))
 - Style property ordering when multiple mixed individual and shorthand
   properties apply ([#511](https://github.com/MyIntervals/emogrifier/pull/511),
   [#508](https://github.com/MyIntervals/emogrifier/issues/508))

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1277,8 +1277,10 @@ class Emogrifier
             $mediaTypesExpression = '|' . implode('|', array_keys($this->allowedMediaTypes));
         }
 
+        $mediaRuleBodyMatcher = '[^{]*+{(?:[^{}]*+{.*})?\\s*+}\\s*+';
+
         $cssSplitForAllowedMediaTypes = preg_split(
-            '#(@media\\s+(?:only\\s)?(?:[\\s{\\(]\\s*' . $mediaTypesExpression . ')\\s*[^{]*+{.*}\\s*}\\s*)#misU',
+            '#(@media\\s++(?:only\\s++)?+(?:(?=[{\\(])' . $mediaTypesExpression . ')' . $mediaRuleBodyMatcher . ')#isU',
             $cssWithoutComments,
             -1,
             PREG_SPLIT_DELIM_CAPTURE
@@ -1286,8 +1288,8 @@ class Emogrifier
 
         // filter the CSS outside/between allowed @media rules
         $cssCleaningMatchers = [
-            'import/charset directives' => '/^\\s*@(?:import|charset)\\s[^;]+;/misU',
-            'remaining media enclosures' => '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
+            'import/charset directives' => '/\\s*+@(?:import|charset)\\s[^;]++;/i',
+            'remaining media enclosures' => '/\\s*+@media\\s' . $mediaRuleBodyMatcher . '/isU',
         ];
 
         $splitCss = [];

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -1066,8 +1066,10 @@ class CssInliner
             $mediaTypesExpression = '|' . implode('|', array_keys($this->allowedMediaTypes));
         }
 
+        $mediaRuleBodyMatcher = '[^{]*+{(?:[^{}]*+{.*})?\\s*+}\\s*+';
+
         $cssSplitForAllowedMediaTypes = preg_split(
-            '#(@media\\s+(?:only\\s)?(?:[\\s{\\(]\\s*' . $mediaTypesExpression . ')\\s*[^{]*+{.*}\\s*}\\s*)#misU',
+            '#(@media\\s++(?:only\\s++)?+(?:(?=[{\\(])' . $mediaTypesExpression . ')' . $mediaRuleBodyMatcher . ')#isU',
             $cssWithoutComments,
             -1,
             PREG_SPLIT_DELIM_CAPTURE
@@ -1075,8 +1077,8 @@ class CssInliner
 
         // filter the CSS outside/between allowed @media rules
         $cssCleaningMatchers = [
-            'import/charset directives' => '/^\\s*@(?:import|charset)\\s[^;]+;/misU',
-            'remaining media enclosures' => '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
+            'import/charset directives' => '/\\s*+@(?:import|charset)\\s[^;]++;/i',
+            'remaining media enclosures' => '/\\s*+@media\\s' . $mediaRuleBodyMatcher . '/isU',
         ];
 
         $splitCss = [];

--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1229,7 +1229,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      * @return string[][] Datasets with spaces in the first array entry of each replaced with various alternative
      *                    whitespace.  Keys will have " with ..." appended to provide an appropriate description.
      */
-    private function getDatasetsWithVaryingWhitespace($datasetsWithSpaces)
+    private function getDatasetsWithVaryingWhitespace(array $datasetsWithSpaces)
     {
         $spaceReplacements = [
             'extra spaces' => '  ',

--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1224,6 +1224,30 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string[][] $datasetsWithSpaces
+     *
+     * @return string[][] Datasets with spaces in the first array entry of each replaced with various alternative
+     *                    whitespace.  Keys will have " with ..." appended to provide an appropriate description.
+     */
+    private function getDatasetsWithVaryingWhitespace($datasetsWithSpaces)
+    {
+        $spaceReplacements = [
+            'extra spaces' => '  ',
+            'linefeeds' => "\n",
+            'Windows line endings' => "\r\n",
+        ];
+        $datasets = [];
+        foreach ($datasetsWithSpaces as $description => $dataset) {
+            foreach ($spaceReplacements as $spaceReplacementDescription => $spaceReplacement) {
+                $datasets[$description . ' with ' . $spaceReplacementDescription] = [
+                    0 => str_replace(' ', $spaceReplacement, $dataset[0]),
+                ] + $dataset;
+            }
+        }
+        return $datasets;
+    }
+
+    /**
      * Data provider for things that should be left out when applying the CSS.
      *
      * @return string[][]
@@ -1234,6 +1258,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             'CSS comments with one asterisk' => ['p {color: #000;/* black */}', 'black'],
             'CSS comments with two asterisks' => ['p {color: #000;/** black */}', 'black'],
             '@import directive' => ['@import "foo.css";', '@import'],
+            'two @import directives, minified' => ['@import "foo.css";@import "bar.css";', '@import'],
             '@charset directive' => ['@charset "UTF-8";', '@charset'],
             'style in "aural" media type rule' => ['@media aural {p {color: #000;}}', '#000'],
             'style in "braille" media type rule' => ['@media braille {p {color: #000;}}', '#000'],
@@ -1243,7 +1268,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             'style in "speech" media type rule' => ['@media speech {p {color: #000;}}', '#000'],
             'style in "tty" media type rule' => ['@media tty {p {color: #000;}}', '#000'],
             'style in "tv" media type rule' => ['@media tv {p {color: #000;}}', '#000'],
-        ];
+            'style in "only tv" media type rule' => ['@media only tv {p {color: #000;}}', '#000'],
+        ] + $this->getDatasetsWithVaryingWhitespace([
+            'style in "tv" media type rule' => [' @media tv { p { color : #000 ; } } ', '#000'],
+            'style in "only tv" media type rule' => [' @media only tv { p { color : #000 ; } } ', '#000'],
+        ]);
     }
 
     /**
@@ -1284,7 +1313,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
      * element added to the docuemnt, due to the way that certain parts are `trim`med.  Notably, whitespace either side
-     * of "{" and "}" may be removed.
+     * of "{" and "}" or at the beginning of the CSS may be removed.
      *
      * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
      * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
@@ -1297,11 +1326,14 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     private static function getCssNeedleRegExp($needle)
     {
         $needleMatcher = preg_replace_callback(
-            '/\\s*+([{}])\\s*+|(?:(?!\\s*+[{}]).)++/',
+            '/\\s*+([{}])\\s*+|(?<=^|>)(\\s++)|(?:(?!\\s*+[{}]|(?<=^|>)\\s).)++/',
             function (array $matches) {
                 if (isset($matches[1]) && $matches[1] !== '') {
                     // matched possibly some whitespace, followed by "{" or "}", then possibly more whitespace
                     return '\\s*+' . preg_quote($matches[1], '/') . '\\s*+';
+                } elseif (isset($matches[2]) && $matches[2] !== '') {
+                    // matched optional whitespace at the start of the CSS
+                    return '\\s*+';
                 } else {
                     // matched any other sequence which could not overlap with the above
                     return preg_quote($matches[0], '/');
@@ -1377,7 +1409,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             'style in "screen" media type rule' => ['@media screen {p {color: #000;}}'],
             'style in "print" media type rule' => ['@media print {p {color: #000;}}'],
             'style in "all" media type rule' => ['@media all {p {color: #000;}}'],
-        ];
+        ] + $this->getDatasetsWithVaryingWhitespace([
+            'style in media type rule' => [' @media { p { color : #000; } } '],
+            'style in "screen" media type rule' => [' @media screen { p { color : #000; } } '],
+            'style in "only screen" media type rule' => [' @media only screen { p { color : #000; } } '],
+        ]);
     }
 
     /**
@@ -1761,6 +1797,32 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         static::assertNotContains('style=', $result);
         static::assertNotContains('@media screen', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyKeepsMediaRuleAfterEmptyMediaQuery()
+    {
+        $this->subject->setHtml('<html><h1></h1></html>');
+        $this->subject->setCss('@media screen {} @media all { h1 { color: red; } }');
+
+        $result = $this->subject->emogrify();
+
+        static::assertContainsCss('@media all { h1 { color: red; } }', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyNotKeepsUnneededMediaRuleAfterEmptyMediaQuery()
+    {
+        $this->subject->setHtml('<html><h1></h1></html>');
+        $this->subject->setCss('@media screen {} @media tv { h1 { color: red; } }');
+
+        $result = $this->subject->emogrify();
+
+        static::assertNotContains('@media', $result);
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1228,7 +1228,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      * @return string[][] Datasets with spaces in the first array entry of each replaced with various alternative
      *                    whitespace.  Keys will have " with ..." appended to provide an appropriate description.
      */
-    private function getDatasetsWithVaryingWhitespace($datasetsWithSpaces)
+    private function getDatasetsWithVaryingWhitespace(array $datasetsWithSpaces)
     {
         $spaceReplacements = [
             'extra spaces' => '  ',


### PR DESCRIPTION
In `splitCssAndMediaQuery`:
- Corrected regular expression for splitting out `@media` rules from the CSS:
  - not to consume a subsequent `@media` rule after an empty one;
  - not to allow disallowed media types with an extra space before the type;
- Corrected regular expression cleaning the remaining CSS to remove at-rules
  even if they are not at the beginning of a line;
- Use a common regular expression component for matching a `@media` rule body
- (using possessive quantifiers where possible for improved performance).

Added related PHPUnit tests of which those that would fail illustrate the issues
(and would also fail prior to #515).

(Found while working on #280, as the regular expression would match
`"@media screen {} @media tv { h1 { color: red; } }"` as a single `@media` rule,
causing an issue parsing its presumed rule body with `parseCssRules`.)