### PR TITLE
[BUGFIX] At-rules not at start of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow multiple minified `@import` rules in the CSS without error (note:
+  `@import`s are currently ignored,
+  [#527](https://github.com/MyIntervals/emogrifier/pull/527))
 - Style property ordering when multiple mixed individual and shorthand
   properties apply ([#511](https://github.com/MyIntervals/emogrifier/pull/511),
   [#508](https://github.com/MyIntervals/emogrifier/issues/508))

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1286,8 +1286,8 @@ class Emogrifier
 
         // filter the CSS outside/between allowed @media rules
         $cssCleaningMatchers = [
-            'import/charset directives' => '/^\\s*@(?:import|charset)\\s[^;]+;/misU',
-            'remaining media enclosures' => '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
+            'import/charset directives' => '/\\s*+@(?:import|charset)\\s[^;]++;/i',
+            'remaining media enclosures' => '/\\s*+@media\\s[^{]+{(.*)}\\s*}\\s/isU',
         ];
 
         $splitCss = [];

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -1073,8 +1073,8 @@ class CssInliner
 
         // filter the CSS outside/between allowed @media rules
         $cssCleaningMatchers = [
-            'import/charset directives' => '/^\\s*@(?:import|charset)\\s[^;]+;/misU',
-            'remaining media enclosures' => '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
+            'import/charset directives' => '/\\s*+@(?:import|charset)\\s[^;]++;/i',
+            'remaining media enclosures' => '/\\s*+@media\\s[^{]+{(.*)}\\s*}\\s/isU',
         ];
 
         $splitCss = [];

--- a/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssInlinerTest.php
@@ -1234,6 +1234,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             'CSS comments with one asterisk' => ['p {color: #000;/* black */}', 'black'],
             'CSS comments with two asterisks' => ['p {color: #000;/** black */}', 'black'],
             '@import directive' => ['@import "foo.css";', '@import'],
+            'two @import directives, minified' => ['@import "foo.css";@import "bar.css";', '@import'],
             '@charset directive' => ['@charset "UTF-8";', '@charset'],
             'style in "aural" media type rule' => ['@media aural {p {color: #000;}}', '#000'],
             'style in "braille" media type rule' => ['@media braille {p {color: #000;}}', '#000'],

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1233,6 +1233,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'CSS comments with one asterisk' => ['p {color: #000;/* black */}', 'black'],
             'CSS comments with two asterisks' => ['p {color: #000;/** black */}', 'black'],
             '@import directive' => ['@import "foo.css";', '@import'],
+            'two @import directives, minified' => ['@import "foo.css";@import "bar.css";', '@import'],
             '@charset directive' => ['@charset "UTF-8";', '@charset'],
             'style in "aural" media type rule' => ['@media aural {p {color: #000;}}', '#000'],
             'style in "braille" media type rule' => ['@media braille {p {color: #000;}}', '#000'],


### PR DESCRIPTION
In `splitCssAndMediaQuery` corrected the cleaning regex to also remove at-rules
even if they are not at the start of a line (removing no-longer/not needed PCRE
modifiers, and for performance using possessive quantifiers where possible).