### PR TITLE
[CLEANUP] Add a CssConcatenator class

### DIFF
--- a/src/Emogrifier/CssConcatenator.php
+++ b/src/Emogrifier/CssConcatenator.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Pelago\Emogrifier;
+
+/**
+ * Facilitates building a CSS string by appending rule blocks one at a time, checking whether the media query,
+ * selectors, or declarations block are the same as those from the preceding block and combining blocks in such cases.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+class CssConcatenator
+{
+    /**
+     * CSS under construction.
+     *
+     * @var string
+     */
+    private $css = '';
+
+    /**
+     * Current media query string, e.g. "@media screen and (max-width:639px)" in the currently open media query block,
+     * or an empty string if not currently within a media query block.
+     *
+     * @var string
+     */
+    private $currentMedia = '';
+
+    /**
+     * Array whose keys are selectors for the rule block currently under construction (values are of no significance),
+     * or an empty array if no rule block under construction.
+     *
+     * @var int[]
+     */
+    private $currentSelectorsAsKeys = [];
+
+    /**
+     * Declarations for the rule block currently under construction,
+     * or an empty string if no rule block under construction.
+     *
+     * @var string
+     */
+    private $currentDeclarationsBlock = '';
+
+    /**
+     * Allow extending classes to call `parent::__construct()`.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Append a declaration block to the CSS.
+     *
+     * @param string[]|string $selectors Array of selectors for the rule, e.g. ["ul", "ol", "p:first-child"],
+     *                                   or a single selector, e.g. "ul".
+     * @param string $declarationsBlock The property declarations, e.g. "margin-top: 0.5em; padding: 0".
+     * @param string $media The media query for the rule, e.g. "@media screen and (max-width:639px)",
+     *                      or an empty string if none.
+     */
+    public function append($selectors, $declarationsBlock, $media = '')
+    {
+        $selectorsAsKeys = array_flip((array)$selectors);
+
+        if ($media !== $this->currentMedia) {
+            $this->closeBlocks();
+            if ($media !== '') {
+                $this->css .= $media . '{';
+                $this->currentMedia = $media;
+            }
+        }
+
+        if ($declarationsBlock === $this->currentDeclarationsBlock) {
+            $this->currentSelectorsAsKeys += $selectorsAsKeys;
+        } elseif ($this->hasEquivalentCurrentSelectors($selectorsAsKeys)) {
+            $this->currentDeclarationsBlock
+                = rtrim(rtrim($this->currentDeclarationsBlock), ';') . ';' . $declarationsBlock;
+        } else {
+            $this->closeRuleBlock();
+            $this->currentSelectorsAsKeys = $selectorsAsKeys;
+            $this->currentDeclarationsBlock = $declarationsBlock;
+        }
+    }
+
+    /**
+     * Close any open rule or media blocks and return the CSS.
+     *
+     * @return string
+     */
+    public function getCss()
+    {
+        $this->closeBlocks();
+        return $this->css;
+    }
+
+    /**
+     * Close any open rule or media blocks.
+     *
+     * @return void
+     */
+    private function closeBlocks()
+    {
+        $this->closeRuleBlock();
+        if ($this->currentMedia !== '') {
+            $this->css .= '}';
+            $this->currentMedia = '';
+        }
+    }
+
+    /**
+     * Close any rule block under construction, appending its contents to the CSS.
+     *
+     * @return void
+     */
+    private function closeRuleBlock()
+    {
+        if ($this->currentSelectorsAsKeys !== [] && $this->currentDeclarationsBlock !== '') {
+            $this->css .= implode(',', array_keys($this->currentSelectorsAsKeys))
+                . '{' . $this->currentDeclarationsBlock . '}';
+        }
+        $this->currentSelectorsAsKeys = [];
+        $this->currentDeclarationsBlock = '';
+    }
+
+    /**
+     * Test if a set of selectors is equivalent to that for the rule block currently under construction
+     * (i.e. the same selectors, possibly in a different order).
+     *
+     * @param int[] $selectorsAsKeys Array in which the selectors are the keys, and the values are of no significance
+     *
+     * @return bool
+     */
+    private function hasEquivalentCurrentSelectors(array $selectorsAsKeys)
+    {
+        return count($selectorsAsKeys) === count($this->currentSelectorsAsKeys)
+            && count($selectorsAsKeys) === count($this->currentSelectorsAsKeys + $selectorsAsKeys);
+    }
+}

--- a/src/Emogrifier/CssConcatenator.php
+++ b/src/Emogrifier/CssConcatenator.php
@@ -6,6 +6,33 @@ namespace Pelago\Emogrifier;
  * Facilitates building a CSS string by appending rule blocks one at a time, checking whether the media query,
  * selectors, or declarations block are the same as those from the preceding block and combining blocks in such cases.
  *
+ * Example:
+ *  $concatenator = new CssConcatenator();
+ *  $concatenator->append(['body'], 'color: blue;');
+ *  $concatenator->append(['body'], 'font-size: 16px;');
+ *  $concatenator->append(['p'], 'margin: 1em 0;');
+ *  $concatenator->append(['ul', 'ol'], 'margin: 1em 0;');
+ *  $concatenator->append(['body'], 'font-size: 14px;', '@media screen and (max-width: 400px)');
+ *  $concatenator->append(['ul', 'ol'], 'margin: 0.75em 0;', '@media screen and (max-width: 400px)');
+ *  $css = $concatenator->closeBlocksAndGetCss();
+ *
+ * `$css` (if unminified) would contain the following CSS:
+ * ` body {
+ * `   color: blue;
+ * `   font-size: 16px;
+ * ` }
+ * ` p, ul, ol {
+ * `   margin: 1em 0;
+ * ` }
+ * ` @media screen and (max-width: 400px) {
+ * `   body {
+ * `     font-size: 14px;
+ * `   }
+ * `   ul, ol {
+ * `     margin: 0.75em 0;
+ * `   }
+ * ` }
+ *
  * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 class CssConcatenator
@@ -42,24 +69,16 @@ class CssConcatenator
     private $currentDeclarationsBlock = '';
 
     /**
-     * Allow extending classes to call `parent::__construct()`.
-     */
-    public function __construct()
-    {
-    }
-
-    /**
-     * Append a declaration block to the CSS.
+     * Appends a declaration block to the CSS.
      *
-     * @param string[]|string $selectors Array of selectors for the rule, e.g. ["ul", "ol", "p:first-child"],
-     *                                   or a single selector, e.g. "ul".
+     * @param string[] $selectors Array of selectors for the rule, e.g. ["ul", "ol", "p:first-child"].
      * @param string $declarationsBlock The property declarations, e.g. "margin-top: 0.5em; padding: 0".
      * @param string $media The media query for the rule, e.g. "@media screen and (max-width:639px)",
      *                      or an empty string if none.
      */
-    public function append($selectors, $declarationsBlock, $media = '')
+    public function append(array $selectors, $declarationsBlock, $media = '')
     {
-        $selectorsAsKeys = array_flip((array)$selectors);
+        $selectorsAsKeys = array_flip($selectors);
 
         if ($media !== $this->currentMedia) {
             $this->closeBlocks();
@@ -82,18 +101,18 @@ class CssConcatenator
     }
 
     /**
-     * Close any open rule or media blocks and return the CSS.
+     * Closes any open rule or media blocks and returns the CSS.
      *
      * @return string
      */
-    public function getCss()
+    public function closeBlocksAndGetCss()
     {
         $this->closeBlocks();
         return $this->css;
     }
 
     /**
-     * Close any open rule or media blocks.
+     * Closes any open rule or media blocks.
      *
      * @return void
      */
@@ -107,7 +126,7 @@ class CssConcatenator
     }
 
     /**
-     * Close any rule block under construction, appending its contents to the CSS.
+     * Closes any rule block under construction, appending its contents to the CSS.
      *
      * @return void
      */
@@ -122,7 +141,7 @@ class CssConcatenator
     }
 
     /**
-     * Test if a set of selectors is equivalent to that for the rule block currently under construction
+     * Tests if a set of selectors is equivalent to that for the rule block currently under construction
      * (i.e. the same selectors, possibly in a different order).
      *
      * @param int[] $selectorsAsKeys Array in which the selectors are the keys, and the values are of no significance

--- a/tests/Unit/Emogrifier/CssConcatenatorTest.php
+++ b/tests/Unit/Emogrifier/CssConcatenatorTest.php
@@ -27,9 +27,9 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function closeBlocksAndGetCssInitiallyReturnsEmptyString()
+    public function getCssInitiallyReturnsEmptyString()
     {
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         static::assertSame('', $result);
     }
@@ -41,7 +41,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->subject->append(['p'], 'color: green;');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         static::assertSame('p{color: green;}', $result);
     }
@@ -53,7 +53,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->subject->append(['p'], 'color: green;', '@media screen');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         static::assertSame('@media screen{p{color: green;}}', $result);
     }
@@ -89,7 +89,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append($selectors1, 'color: green;');
         $this->subject->append($selectors2, 'font-size: 16px;');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         $expectedResult = implode(',', $selectors1) . '{color: green;font-size: 16px;}';
 
@@ -104,7 +104,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append(['p'], 'color: green');
         $this->subject->append(['p'], 'font-size: 16px');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         static::assertSame('p{color: green;font-size: 16px}', $result);
     }
@@ -170,7 +170,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append($selectors1, 'color: green;');
         $this->subject->append($selectors2, 'color: green;');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         $expectedResult = implode(',', $combinedSelectors) . '{color: green;}';
 
@@ -190,7 +190,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append($selectors1, 'color: green;');
         $this->subject->append($selectors2, 'font-size: 16px;');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         $expectedResult = implode(',', $selectors1) . '{color: green;}'
             . implode(',', $selectors2) . '{font-size: 16px;}';
@@ -206,7 +206,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append(['p'], 'color: green;', '@media screen');
         $this->subject->append(['ul'], 'font-size: 16px;', '@media screen');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         static::assertSame('@media screen{p{color: green;}ul{font-size: 16px;}}', $result);
     }
@@ -224,7 +224,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append($selectors1, 'color: green;', '@media screen');
         $this->subject->append($selectors2, 'font-size: 16px;', '@media screen');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         $expectedResult = '@media screen{' . implode(',', $selectors1) . '{color: green;font-size: 16px;}}';
 
@@ -248,7 +248,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append($selectors1, 'color: green;', '@media screen');
         $this->subject->append($selectors2, 'color: green;', '@media screen');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         $expectedResult = '@media screen{' . implode(',', $combinedSelectors) . '{color: green;}}';
 
@@ -263,7 +263,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $this->subject->append(['p'], 'color: green;', '@media screen');
         $this->subject->append(['p'], 'color: green;', '@media print');
 
-        $result = $this->subject->closeBlocksAndGetCss();
+        $result = $this->subject->getCss();
 
         static::assertSame('@media screen{p{color: green;}}@media print{p{color: green;}}', $result);
     }

--- a/tests/Unit/Emogrifier/CssConcatenatorTest.php
+++ b/tests/Unit/Emogrifier/CssConcatenatorTest.php
@@ -59,7 +59,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return string[][]
      */
     public function equivalentSelectorsDataProvider()
     {
@@ -110,7 +110,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return string[][]
      */
     public function differentSelectorsDataProvider()
     {
@@ -243,7 +243,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     public function appendCombinesSameRulesWithDifferentSelectorsWithinMediaRule(
         array $selectors1,
         array $selectors2,
-        $combinedSelectors
+        array $combinedSelectors
     ) {
         $this->subject->append($selectors1, 'color: green;', '@media screen');
         $this->subject->append($selectors2, 'color: green;', '@media screen');

--- a/tests/Unit/Emogrifier/CssConcatenatorTest.php
+++ b/tests/Unit/Emogrifier/CssConcatenatorTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Pelago\Tests\Unit\Emogrifier;
+
+use Pelago\Emogrifier\CssConcatenator;
+
+/**
+ * Test case.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CssConcatenator
+     */
+    private $subject = null;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->subject = new CssConcatenator();
+    }
+
+    /**
+     * @test
+     */
+    public function getCssInitiallyReturnsEmptyString()
+    {
+        $result = $this->subject->getCss();
+
+        static::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getCssReturnsSingleAppendedRule()
+    {
+        $this->subject->append('p', 'color: green;');
+
+        $result = $this->subject->getCss();
+
+        static::assertSame('p{color: green;}', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getCssReturnsSingleAppendedMediaRule()
+    {
+        $this->subject->append('p', 'color: green;', '@media screen');
+
+        $result = $this->subject->getCss();
+
+        static::assertSame('@media screen{p{color: green;}}', $result);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function equivalentSelectorsDataProvider()
+    {
+        return [
+            'one selector' => ['p', 'p'],
+            'two selectors' => [
+                ['p', 'ul'],
+                ['p', 'ul'],
+            ],
+            'two selectors in different order' => [
+                ['p', 'ul'],
+                ['ul', 'p'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string[]|string $selectors1
+     * @param string[]|string $selectors2
+     *
+     * @dataProvider equivalentSelectorsDataProvider
+     */
+    public function appendCombinesRulesWithEquivalentSelectors($selectors1, $selectors2)
+    {
+        $this->subject->append($selectors1, 'color: green;');
+        $this->subject->append($selectors2, 'font-size: 16px;');
+
+        $result = $this->subject->getCss();
+
+        $expectedResult = implode(',', (array)$selectors1) . '{color: green;font-size: 16px;}';
+
+        static::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function appendInsertsSemicolonCombiningRulesWithoutTrailingSemicolon()
+    {
+        $this->subject->append('p', 'color: green');
+        $this->subject->append('p', 'font-size: 16px');
+
+        $result = $this->subject->getCss();
+
+        static::assertSame('p{color: green;font-size: 16px}', $result);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function differentSelectorsDataProvider()
+    {
+        return [
+            'single selectors' => [
+                'p',
+                'ul',
+                ['p', 'ul'],
+            ],
+            'single selector and an entirely different pair' => [
+                'p',
+                ['ul', 'ol'],
+                ['p', 'ul', 'ol'],
+            ],
+            'single selector and a superset pair' => [
+                'p',
+                ['p', 'ul'],
+                ['p', 'ul'],
+            ],
+            'pair of selectors and an entirely different single' => [
+                ['p', 'ul'],
+                'ol',
+                ['p', 'ul', 'ol'],
+            ],
+            'pair of selectors and a subset single' => [
+                ['p', 'ul'],
+                'ul',
+                ['p', 'ul'],
+            ],
+            'entirely different pairs of selectors' => [
+                ['p', 'ul'],
+                ['ol', 'h1'],
+                ['p', 'ul', 'ol', 'h1'],
+            ],
+            'pairs of selectors with one common' => [
+                ['p', 'ul'],
+                ['ul', 'ol'],
+                ['p', 'ul', 'ol'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string[]|string $selectors1
+     * @param string[]|string $selectors2
+     * @param string[] $combinedSelectors
+     *
+     * @dataProvider differentSelectorsDataProvider
+     */
+    public function appendCombinesSameRulesWithDifferentSelectors($selectors1, $selectors2, array $combinedSelectors)
+    {
+        $this->subject->append($selectors1, 'color: green;');
+        $this->subject->append($selectors2, 'color: green;');
+
+        $result = $this->subject->getCss();
+
+        $expectedResult = implode(',', $combinedSelectors) . '{color: green;}';
+
+        static::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string[]|string $selectors1
+     * @param string[]|string $selectors2
+     *
+     * @dataProvider differentSelectorsDataProvider
+     */
+    public function appendNotCombinesDifferentRulesWithDifferentSelectors($selectors1, $selectors2)
+    {
+        $this->subject->append($selectors1, 'color: green;');
+        $this->subject->append($selectors2, 'font-size: 16px;');
+
+        $result = $this->subject->getCss();
+
+        $expectedResult = implode(',', (array)$selectors1) . '{color: green;}'
+            . implode(',', (array)$selectors2) . '{font-size: 16px;}';
+
+        static::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function appendCombinesRulesForSameMediaQueryInMediaRule()
+    {
+        $this->subject->append('p', 'color: green;', '@media screen');
+        $this->subject->append('ul', 'font-size: 16px;', '@media screen');
+
+        $result = $this->subject->getCss();
+
+        static::assertSame('@media screen{p{color: green;}ul{font-size: 16px;}}', $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string[]|string $selectors1
+     * @param string[]|string $selectors2
+     *
+     * @dataProvider equivalentSelectorsDataProvider
+     */
+    public function appendCombinesRulesWithEquivalentSelectorsWithinMediaRule($selectors1, $selectors2)
+    {
+        $this->subject->append($selectors1, 'color: green;', '@media screen');
+        $this->subject->append($selectors2, 'font-size: 16px;', '@media screen');
+
+        $result = $this->subject->getCss();
+
+        $expectedResult = '@media screen{' . implode(',', (array)$selectors1) . '{color: green;font-size: 16px;}}';
+
+        static::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string[]|string $selectors1
+     * @param string[]|string $selectors2
+     * @param string[] $combinedSelectors
+     *
+     * @dataProvider differentSelectorsDataProvider
+     */
+    public function appendCombinesSameRulesWithDifferentSelectorsWithinMediaRule(
+        $selectors1,
+        $selectors2,
+        $combinedSelectors
+    ) {
+        $this->subject->append($selectors1, 'color: green;', '@media screen');
+        $this->subject->append($selectors2, 'color: green;', '@media screen');
+
+        $result = $this->subject->getCss();
+
+        $expectedResult = '@media screen{' . implode(',', $combinedSelectors) . '{color: green;}}';
+
+        static::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function appendNotCombinesRulesForDifferentMediaQueryInMediaRule()
+    {
+        $this->subject->append('p', 'color: green;', '@media screen');
+        $this->subject->append('p', 'color: green;', '@media print');
+
+        $result = $this->subject->getCss();
+
+        static::assertSame('@media screen{p{color: green;}}@media print{p{color: green;}}', $result);
+    }
+}


### PR DESCRIPTION
This abstracts the (re-)combining of CSS rules for various media queries and
with various selectors and declaration blocks, merging adjacent rule blocks
where possible (i.e. for the same media query, with the same selectors, or with
the same declarations block).

Although not yet utilized, it will be required for #280 to simplify the code.