### PR TITLE
[BUGFIX] @media query with extra whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow additional whitespace in media-query-list of disallowed `@media` rules
+  ([#532](https://github.com/MyIntervals/emogrifier/pull/532))
 - Allow multiple minified `@import` rules in the CSS without error (note:
   `@import`s are currently ignored,
   [#527](https://github.com/MyIntervals/emogrifier/pull/527))

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1276,7 +1276,7 @@ class Emogrifier
         }
 
         $cssSplitForAllowedMediaTypes = preg_split(
-            '#(@media\\s+(?:only\\s)?(?:[\\s{\\(]\\s*' . $mediaTypesExpression . ')\\s*[^{]*+{.*}\\s*}\\s*)#misU',
+            '#(@media\\s++(?:only\\s++)?+(?:[\\s{\\(]\\s*' . $mediaTypesExpression . ')\\s*[^{]*+{.*}\\s*}\\s*)#misU',
             $cssWithoutComments,
             -1,
             PREG_SPLIT_DELIM_CAPTURE

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1246,6 +1246,31 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'style in "speech" media type rule' => ['@media speech {p {color: #000;}}', '#000'],
             'style in "tty" media type rule' => ['@media tty {p {color: #000;}}', '#000'],
             'style in "tv" media type rule' => ['@media tv {p {color: #000;}}', '#000'],
+            'style in "tv" media type rule with extra spaces' => [
+                '  @media  tv  {  p  {  color  :  #000  ;  }  }  ',
+                '#000'
+            ],
+            'style in "tv" media type rule with linefeeds' => [
+                "\n@media\ntv\n{\np\n{\ncolor\n:\n#000\n;\n}\n}\n",
+                '#000'
+            ],
+            'style in "tv" media type rule with Windows line endings' => [
+                "\r\n@media\r\ntv\r\n{\r\np\r\n{\r\ncolor\r\n:\r\n#000\r\n;\r\n}\r\n}\r\n",
+                '#000'
+            ],
+            'style in "only tv" media type rule' => ['@media only tv {p {color: #000;}}', '#000'],
+            'style in "only tv" media type rule with extra spaces' => [
+                '  @media  only  tv  {  p  {  color  :  #000  ;  }  }  ',
+                '#000'
+            ],
+            'style in "only tv" media type rule with linefeeds' => [
+                "\n@media\nonly\ntv\n{\np\n{\ncolor\n:\n#000\n;\n}\n}\n",
+                '#000'
+            ],
+            'style in "only tv" media type rule with Windows line endings' => [
+                "\r\n@media\r\nonly\r\ntv\r\n{\r\np\r\n{\r\ncolor\r\n:\r\n#000\r\n;\r\n}\r\n}\r\n",
+                '#000'
+            ],
         ];
     }
 
@@ -1294,8 +1319,24 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         return [
             'style in "only all" media type rule' => ['@media only all {p {color: #000;}}'],
             'style in "only screen" media type rule' => ['@media only screen {p {color: #000;}}'],
+            'style in "only screen" media type rule with extra spaces'
+                => ['  @media  only  screen  {  p  {  color  :  #000;  }  }  '],
+            'style in "only screen" media type rule with linefeeds'
+                => ["\n@media\nonly\nscreen\n{\np\n{\ncolor\n:\n#000;\n}\n}\n"],
+            'style in "only screen" media type rule with Windows line endings'
+                => ["\r\n@media\r\nonly\r\nscreen\r\n{\r\np\r\n{\r\ncolor\r\n:\r\n#000;\r\n}\r\n}\r\n"],
             'style in media type rule' => ['@media {p {color: #000;}}'],
+            'style in media type rule with extra spaces' => ['  @media  {  p  {  color  :  #000;  }  }  '],
+            'style in media type rule with linefeeds' => ["\n@media\n{\np\n{\ncolor\n:\n#000;\n}\n}\n"],
+            'style in media type rule with Windows line endings'
+                => ["\r\n@media\r\n{\r\np\r\n{\r\ncolor\r\n:\r\n#000;\r\n}\r\n}\r\n"],
             'style in "screen" media type rule' => ['@media screen {p {color: #000;}}'],
+            'style in "screen" media type rule with extra spaces'
+                => ['  @media  screen  {  p  {  color  :  #000;  }  }  '],
+            'style in "screen" media type rule with linefeeds'
+                => ["\n@media\nscreen\n{\np\n{\ncolor\n:\n#000;\n}\n}\n"],
+            'style in "screen" media type rule with Windows line endings'
+                => ["\r\n@media\r\nscreen\r\n{\r\np\r\n{\r\ncolor\r\n:\r\n#000;\r\n}\r\n}\r\n"],
             'style in "print" media type rule' => ['@media print {p {color: #000;}}'],
             'style in "all" media type rule' => ['@media all {p {color: #000;}}'],
         ];


### PR DESCRIPTION
Corrected regular expression for splitting out @media rules from the CSS not to
include disallowed media types with extra whitespace before the type.