### PR TITLE
[BUGFIX] @media rule after empty @media rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow CSS between empty `@media` rule and another `@media` rule
+  ([#534](https://github.com/MyIntervals/emogrifier/pull/534))
 - Allow additional whitespace in media-query-list of disallowed `@media` rules
   ([#532](https://github.com/MyIntervals/emogrifier/pull/532))
 - Allow multiple minified `@import` rules in the CSS without error (note:

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1275,8 +1275,11 @@ class Emogrifier
             $mediaTypesExpression = '|' . implode('|', array_keys($this->allowedMediaTypes));
         }
 
+        $mediaRuleBodyMatcher = '[^{]*+{(?:[^{}]*+{.*})?\\s*+}\\s*+';
+
         $cssSplitForAllowedMediaTypes = preg_split(
-            '#(@media\\s++(?:only\\s++)?+(?:[\\s{\\(]\\s*' . $mediaTypesExpression . ')\\s*[^{]*+{.*}\\s*}\\s*)#misU',
+            '#(@media\\s++(?:only\\s++)?+(?:(?=[{\\(])' . $mediaTypesExpression . ')' . $mediaRuleBodyMatcher
+                . ')#misU',
             $cssWithoutComments,
             -1,
             PREG_SPLIT_DELIM_CAPTURE
@@ -1285,7 +1288,7 @@ class Emogrifier
         // filter the CSS outside/between allowed @media rules
         $cssCleaningMatchers = [
             'import/charset directives' => '/\\s*+@(?:import|charset)\\s[^;]++;/i',
-            'remaining media enclosures' => '/\\s*+@media\\s[^{]+{(.*)}\\s*}\\s/isU',
+            'remaining media enclosures' => '/\\s*+@media\\s' . $mediaRuleBodyMatcher . '/isU',
         ];
 
         $splitCss = [];

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1726,15 +1726,13 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return string[][]
      */
-    public function mediaTypesDataProvider()
+    public function mediaTypeDataProvider()
     {
         return [
-            'disallowed type after disallowed type' => ['tv', 'speech', false],
-            'allowed type after disallowed type' => ['tv', 'all', true],
-            'disallowed type after allowed type' => ['screen', 'tv', false],
-            'allowed type after allowed type' => ['screen', 'all', true],
+            'disallowed type' => ['tv'],
+            'allowed type' => ['screen'],
         ];
     }
 
@@ -1742,24 +1740,47 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $emptyRuleMediaType
-     * @param string $mediaType
-     * @param bool $isAllowedType
      *
-     * @dataProvider mediaTypesDataProvider
+     * @dataProvider mediaTypeDataProvider
      */
-    public function emogrifyKeepsMediaRuleAfterEmptyMediaRuleIffAllowed($emptyRuleMediaType, $mediaType, $isAllowedType)
+    public function emogrifyKeepsMediaRuleAfterEmptyMediaRule($emptyRuleMediaType)
     {
         $this->subject->setHtml('<html><h1></h1></html>');
-        $mediaCss = '@media ' . $mediaType . ' { h1 { color: red; } }';
-        $this->subject->setCss('@media ' . $emptyRuleMediaType . ' {} ' . $mediaCss);
+        $this->subject->setCss('@media ' . $emptyRuleMediaType . ' {} @media all { h1 { color: red; } }');
 
         $result = $this->subject->emogrify();
 
-        if ($isAllowedType) {
-            static::assertContainsCss($mediaCss, $result);
-        } else {
-            static::assertNotContains('@media', $result);
-        }
+        static::assertContainsCss('@media all { h1 { color: red; } }', $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $emptyRuleMediaType
+     *
+     * @dataProvider mediaTypeDataProvider
+     */
+    public function emogrifyNotKeepsUnneededMediaRuleAfterEmptyMediaRule($emptyRuleMediaType)
+    {
+        $this->subject->setHtml('<html><h1></h1></html>');
+        $this->subject->setCss('@media ' . $emptyRuleMediaType . ' {} @media speech { h1 { color: red; } }');
+
+        $result = $this->subject->emogrify();
+
+        static::assertNotContains('@media', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function mediaTypesDataProvider()
+    {
+        return [
+            'disallowed type after disallowed type' => ['tv', 'speech'],
+            'allowed type after disallowed type' => ['tv', 'all'],
+            'disallowed type after allowed type' => ['screen', 'tv'],
+            'allowed type after allowed type' => ['screen', 'all'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Corrected regular expression for splitting out `@media` rules from the CSS not
to consume a subsequent `@media` rule after an empty one.

Similarly corrected the regular expression cleaning the unneeded `@media` rules,
using a common subexpression for matching a `@media` rule body.

(Found while working on #280, as the regular expression would match `"@media
screen {} @media tv { h1 { color: red; } }"` as a single `@media` rule, causing an
issue parsing its presumed rule body later.)