### PR TITLE
[CLEANUP] Extract method: copyInlineableCssToStyleNode

### DIFF
--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -347,7 +347,7 @@ class CssInliner
             // executions, which can still flood logs/output unnecessarily. Instead, Emogrifier's error handler should
             // always throw an exception and it must be caught here and only rethrown if in debug mode.
             try {
-                // \DOMXPath::query will always return a DOMNodeList or an exception when errors are caught.
+                // \DOMXPath::query will always return a DOMNodeList or throw an exception when errors are caught.
                 $nodesMatchingCssSelectors = $xPath->query($this->translateCssToXpath($cssRule['selector']));
             } catch (\InvalidArgumentException $e) {
                 if ($this->debug) {
@@ -361,25 +361,13 @@ class CssInliner
                 if (in_array($node, $excludedNodes, true)) {
                     continue;
                 }
-                // if it has a style attribute, get it, process it, and append (overwrite) new stuff
-                if ($node->hasAttribute('style')) {
-                    // break it up into an associative array
-                    $oldStyleDeclarations = $this->parseCssDeclarationsBlock($node->getAttribute('style'));
-                } else {
-                    $oldStyleDeclarations = [];
-                }
-                $newStyleDeclarations = $this->parseCssDeclarationsBlock($cssRule['declarationsBlock']);
-                $node->setAttribute(
-                    'style',
-                    $this->generateStyleStringFromDeclarationsArrays($oldStyleDeclarations, $newStyleDeclarations)
-                );
+                $this->copyInlineableCssToStyleAttribute($node, $cssRule);
             }
         }
 
         if ($this->isInlineStyleAttributesParsingEnabled) {
             $this->fillStyleAttributesWithMergedStyles();
         }
-
         if ($this->shouldRemoveInvisibleNodes) {
             $this->removeInvisibleNodes($xPath);
         }
@@ -924,6 +912,32 @@ class CssInliner
         }
 
         $this->addStyleElementToDocument($xmlDocument, $cssConcatenator->getCss());
+    }
+
+    /**
+     * Copies $cssRule into the style attribute of $node.
+     *
+     * Note: This method does not check whether $cssRule matches $node.
+     *
+     * @param \DOMElement $node
+     * @param string[][] $cssRule
+     *
+     * @return void
+     */
+    private function copyInlineableCssToStyleAttribute(\DOMElement $node, array $cssRule)
+    {
+        // if it has a style attribute, get it, process it, and append (overwrite) new stuff
+        if ($node->hasAttribute('style')) {
+            // break it up into an associative array
+            $oldStyleDeclarations = $this->parseCssDeclarationsBlock($node->getAttribute('style'));
+        } else {
+            $oldStyleDeclarations = [];
+        }
+        $newStyleDeclarations = $this->parseCssDeclarationsBlock($cssRule['declarationsBlock']);
+        $node->setAttribute(
+            'style',
+            $this->generateStyleStringFromDeclarationsArrays($oldStyleDeclarations, $newStyleDeclarations)
+        );
     }
 
     /**


### PR DESCRIPTION
This refactoring reduces the complexity of the process method.