### PR TITLE
[CLEANUP] AssertCss - whitespace around comma

### DIFF
--- a/tests/Support/Traits/AssertCss.php
+++ b/tests/Support/Traits/AssertCss.php
@@ -12,7 +12,7 @@ trait AssertCss
     /**
      * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
      * element added to the docuemnt, due to the way that certain parts are `trim`med.  Notably, whitespace either side
-     * of "{" and "}" or at the beginning of the CSS may be removed.
+     * of "{", "}" and "," or at the beginning of the CSS may be removed.
      *
      * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
      * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
@@ -25,10 +25,10 @@ trait AssertCss
     private static function getCssNeedleRegExp($needle)
     {
         $needleMatcher = preg_replace_callback(
-            '/\\s*+([{}])\\s*+|(^\\s++)|(>)\\s*+|(?:(?!\\s*+[{}]|^\\s)[^>])++/',
+            '/\\s*+([{},])\\s*+|(^\\s++)|(>)\\s*+|(?:(?!\\s*+[{},]|^\\s)[^>])++/',
             function (array $matches) {
                 if (isset($matches[1]) && $matches[1] !== '') {
-                    // matched possibly some whitespace, followed by "{" or "}", then possibly more whitespace
+                    // matched possibly some whitespace, followed by "{", "}" or ",", then possibly more whitespace
                     return '\\s*+' . preg_quote($matches[1], '/') . '\\s*+';
                 }
                 if (isset($matches[2]) && $matches[2] !== '') {

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -56,6 +56,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
         return [
             '"{" alone' => ['{', ''],
             '"}" alone' => ['}', ''],
+            '"," alone' => [',', ''],
             '"{" with non-special character' => ['{', 'a'],
             '"{" with two non-special characters' => ['{', 'a0'],
             '"{" with special character' => ['{', '.'],
@@ -125,11 +126,11 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
     public function needleFoundDataProvider()
     {
         $cssStrings = [
-            'unminified CSS' => 'body { color: green; }',
-            'minified CSS' => 'body{color: green;}',
-            'CSS with extra spaces' => '  body  {  color: green;  }',
-            'CSS with linefeeds' => "\nbody\n{\ncolor: green;\n}",
-            'CSS with Windows line endings' => "\r\nbody\r\n{\r\ncolor: green;\r\n}",
+            'unminified CSS' => 'html, body { color: green; }',
+            'minified CSS' => 'html,body{color: green;}',
+            'CSS with extra spaces' => '  html  ,  body  {  color: green;  }',
+            'CSS with linefeeds' => "\nhtml\n,\nbody\n{\ncolor: green;\n}",
+            'CSS with Windows line endings' => "\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor: green;\r\n}",
         ];
 
         $datasets = [];
@@ -154,6 +155,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
         return [
             'CSS part with "{" not in CSS' => ['p {', 'body { color: green; }'],
             'CSS part with "}" not in CSS' => ['color: red; }', 'body { color: green; }'],
+            'CSS part with "," not in CSS' => ['html, body', 'body { color: green; }'],
         ];
     }
 


### PR DESCRIPTION
Allow varying whitespace around commas (in selector list separators) in
`AssertContainsCss`, etc.

This will be required for testing that CSS rules with state-based pseudo-classes
are copied to the style element for #280.