### PR TITLE
[TASK] Add sniff for type hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#476](https://github.com/jjriv/emogrifier/pull/476))
 
 ### Changed
+- Add type hint checking to the code sniffs
+  ([#566](https://github.com/MyIntervals/emogrifier/pull/566))
 - Check the code with PHPMD
   ([#561](https://github.com/jjriv/emogrifier/pull/561))
 - Add the cyclomatic complexity to the checked code sniffs

--- a/config/PhpCodeSniffer.xml
+++ b/config/PhpCodeSniffer.xml
@@ -36,6 +36,26 @@
     <rule ref="PEAR.Commenting.InlineComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <!-- Allow PHP-5-compatible type hinting. -->
+        <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
+        <!-- Allow no comment for self-describing parameter and exception class names. -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
+        <!-- Allow "int" rather than "integer", etc., in PHPDoc. -->
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/>
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
+        <!-- Allow parameter type, name and comment not all vertically aligned. -->
+        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
+        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName"/>
+        <!-- Enable these rules after fixing the PHPDoc. -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+        <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital"/>
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop"/>
+    </rule>
     <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
 


### PR DESCRIPTION
Note:
`<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>`
would not be required if `<config name="php_version" value="50500"/>` was
present, but the latter would probably have further-reaching consquences and
PHP 5 support will be deprecated soon.

Closes #563.