### PR TITLE
[CLEANUP] Simplify and clean up the test case (part 9)

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1853,7 +1853,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function matchingSelectorWithPseudoComponentCssRuleDataProvider()
     {
-        return $this->getCssRuleDatasetsWithSelectorPseudoComponents(
+        $datasetsWithSelectorPseudoComponents = $this->getCssRuleDatasetsWithSelectorPseudoComponents(
             [
                 'lone' => '',
                 'type &' => 'a',
@@ -1864,12 +1864,15 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
                 'ancestor &' => 'p ',
                 'ancestor & type &' => 'p a',
             ]
-        ) + [
+        );
+        $datasetsWithCombinedPseudoSelectors = [
             'pseudo-class & descendant' => ['p:hover a { color: green; }'],
             'pseudo-class & pseudo-element' => ['a:hover::after { content: "bar"; }'],
             'pseudo-element & pseudo-class' => ['a::after:hover { content: "bar"; }'],
             'two pseudo-classes' => ['a:focus:hover { color: green; }'],
         ];
+
+        return \array_merge($datasetsWithSelectorPseudoComponents, $datasetsWithCombinedPseudoSelectors);
     }
 
     /**
@@ -1894,7 +1897,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function nonMatchingSelectorWithPseudoComponentCssRuleDataProvider()
     {
-        return $this->getCssRuleDatasetsWithSelectorPseudoComponents(
+        $datasetsWithSelectorPseudoComponents = $this->getCssRuleDatasetsWithSelectorPseudoComponents(
             [
                 'type &' => 'b',
                 'class &' => '.b',
@@ -1904,12 +1907,15 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
                 'ancestor &' => 'ul ',
                 'ancestor & type &' => 'p b',
             ]
-        ) + [
+        );
+        $datasetsWithCombinedPseudoSelectors = [
             'pseudo-class & descendant' => ['ul:hover a { color: green; }'],
             'pseudo-class & pseudo-element' => ['b:hover::after { content: "bar"; }'],
             'pseudo-element & pseudo-class' => ['b::after:hover { content: "bar"; }'],
             'two pseudo-classes' => ['input:focus:hover { color: green; }'],
         ];
+
+        return \array_merge($datasetsWithSelectorPseudoComponents, $datasetsWithCombinedPseudoSelectors);
     }
 
     /**
@@ -2186,12 +2192,12 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyByDefaultRemovesElementsWithDisplayNoneFromExternalCss()
     {
-        $this->subject->setHtml('<html><body><div class="bar"></div><div class="foo"></div></body></html>');
+        $this->subject->setHtml('<html><body><div class="foo"></div></body></html>');
         $this->subject->setCss('div.foo { display: none; }');
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<div class="bar"></div>', $result);
+        static::assertNotContains('<div class="foo"></div>', $result);
     }
 
     /**
@@ -2200,13 +2206,13 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     public function emogrifyByDefaultRemovesElementsWithDisplayNoneInStyleAttribute()
     {
         $this->subject->setHtml(
-            '<html><body><div class="bar"></div><div class="foobar" style="display: none;"></div>' .
+            '<html><body><div class="foobar" style="display: none;"></div>' .
             '</body></html>'
         );
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<div class="bar"></div>', $result);
+        static::assertNotContains('<div', $result);
     }
 
     /**
@@ -2214,7 +2220,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAfterDisableInvisibleNodeRemovalPreservesInvisibleElements()
     {
-        $this->subject->setHtml('<html><body><div class="bar"></div><div class="foo"></div></body></html>');
+        $this->subject->setHtml('<html><body><div class="foo"></div></body></html>');
         $this->subject->setCss('div.foo { display: none; }');
 
         $this->subject->disableInvisibleNodeRemoval();
@@ -2240,42 +2246,20 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
+     * @param string $documentType
+     *
+     * @dataProvider documentTypeDataProvider
      */
-    public function emogrifyForXhtmlDocumentTypeConvertsXmlSelfClosingTagsToNonXmlSelfClosingTag()
+    public function emogrifyConvertsXmlSelfClosingTagsToNonXmlSelfClosingTag($documentType)
     {
         $this->subject->setHtml(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" ' .
-            '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">' .
-            '<html><body><br/></body></html>'
+            $documentType . '<html><body><br/></body></html>'
         );
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body><br></body>', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function emogrifyForHtml5DocumentTypeKeepsNonXmlSelfClosingTagsAsNonXmlSelfClosing()
-    {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><br></body></html>');
-
-        $result = $this->subject->emogrify();
-
-        static::assertContains('<body><br></body>', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function emogrifyForHtml5DocumentTypeConvertXmlSelfClosingTagsToNonXmlSelfClosingTag()
-    {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><br/></body></html>');
-
-        $result = $this->subject->emogrify();
-
-        static::assertContains('<body><br></body>', $result);
+        static::assertContains('<br>', $result);
     }
 
     /**
@@ -2324,7 +2308,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyBodyContentReturnsBodyContentFromContent()
+    public function emogrifyBodyContentReturnsBodyContentFromPartialContent()
     {
         $this->subject->setHtml('<p></p>');
 
@@ -2337,6 +2321,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      * Sets HTML of subject to boilerplate HTML with a single `<p>` in `<body>` and empty `<head>`
      *
      * @param string $style Optional value for the style attribute of the `<p>` element
+     *
+     * @return void
      */
     private function setSubjectBoilerplateHtml($style = '')
     {
@@ -2377,7 +2363,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyHandlesImportantStyleTagCaseInsensitive()
+    public function importantIsCaseInsensitive()
     {
         $this->setSubjectBoilerplateHtml('margin: 2px;');
         $this->subject->setCss('p { margin: 1px !ImPorTant; }');
@@ -2397,10 +2383,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin: 2px;">',
-            $result
-        );
+        static::assertContains('<p style="margin: 2px;">', $result);
     }
 
     /**
@@ -2413,10 +2396,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin: 2px;">',
-            $result
-        );
+        static::assertContains('<p style="margin: 2px;">', $result);
     }
 
     /**
@@ -2429,10 +2409,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin: 1px;">',
-            $result
-        );
+        static::assertContains('<p style="margin: 1px;">', $result);
     }
 
     /**
@@ -2445,10 +2422,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin-top: 1px; margin: 2px;">',
-            $result
-        );
+        static::assertContains('<p style="margin-top: 1px; margin: 2px;">', $result);
     }
 
     /**
@@ -2461,10 +2435,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin: 2px; margin-top: 3px;">',
-            $result
-        );
+        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
     }
 
     /**
@@ -2477,10 +2448,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin: 2px; margin-top: 3px;">',
-            $result
-        );
+        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
     }
 
     /**
@@ -2493,10 +2461,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
-            '<p style="margin: 2px; margin-top: 3px;">',
-            $result
-        );
+        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
     }
 
     /**


### PR DESCRIPTION
Also restructure the code so that the PhpStorm code autoformatting
will not create any PHP_CodeSniffer warnings.

Part of #403