### PR TITLE
[FEATURE] Add CssInliner::render

### DIFF
--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -317,7 +317,7 @@ class Emogrifier
      */
     public function emogrify()
     {
-        return $this->createAndProcessXmlDocument()->saveHTML();
+        return $this->process($this->createXmlDocument())->saveHTML();
     }
 
     /**
@@ -332,20 +332,20 @@ class Emogrifier
      */
     public function emogrifyBodyContent()
     {
-        $xmlDocument = $this->createAndProcessXmlDocument();
+        $xmlDocument = $this->process($this->createXmlDocument());
         $bodyNodeHtml = $xmlDocument->saveHTML($this->getBodyElement($xmlDocument));
 
         return str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
     }
 
     /**
-     * Creates an XML document from $this->html and emogrifies ist.
+     * Creates an XML document from $this->html.
      *
      * @return \DOMDocument
      *
      * @throws \BadMethodCallException
      */
-    private function createAndProcessXmlDocument()
+    private function createXmlDocument()
     {
         if ($this->html === '') {
             throw new \BadMethodCallException('Please set some HTML first.', 1390393096);
@@ -353,7 +353,6 @@ class Emogrifier
 
         $xmlDocument = $this->createRawXmlDocument();
         $this->ensureExistenceOfBodyElement($xmlDocument);
-        $this->process($xmlDocument);
 
         return $xmlDocument;
     }
@@ -365,7 +364,7 @@ class Emogrifier
      *
      * @param \DOMDocument $xmlDocument
      *
-     * @return void
+     * @return \DOMDocument
      *
      * @throws \InvalidArgumentException
      */
@@ -421,6 +420,8 @@ class Emogrifier
         $this->copyUninlineableCssToStyleNode($xmlDocument, $xPath, $cssRules['uninlineable']);
 
         restore_error_handler();
+
+        return $xmlDocument;
     }
 
     /**

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -214,6 +214,16 @@ class CssInliner
     }
 
     /**
+     * Renders the normalized and processed HTML.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        return $this->createXmlDocument()->saveHTML();
+    }
+
+    /**
      * Applies $this->css to $this->html and returns the HTML with the CSS
      * applied.
      *
@@ -226,7 +236,7 @@ class CssInliner
      */
     public function emogrify()
     {
-        return $this->createAndProcessXmlDocument()->saveHTML();
+        return $this->process($this->createXmlDocument())->saveHTML();
     }
 
     /**
@@ -242,20 +252,20 @@ class CssInliner
      */
     public function emogrifyBodyContent()
     {
-        $xmlDocument = $this->createAndProcessXmlDocument();
+        $xmlDocument = $this->process($this->createXmlDocument());
         $bodyNodeHtml = $xmlDocument->saveHTML($this->getBodyElement($xmlDocument));
 
         return str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
     }
 
     /**
-     * Creates an XML document from $this->html and emogrifies ist.
+     * Creates an XML document from $this->html.
      *
      * @return \DOMDocument
      *
      * @throws \BadMethodCallException
      */
-    private function createAndProcessXmlDocument()
+    private function createXmlDocument()
     {
         if ($this->html === '') {
             throw new \BadMethodCallException('Please set some HTML first.', 1390393096);
@@ -263,7 +273,6 @@ class CssInliner
 
         $xmlDocument = $this->createRawXmlDocument();
         $this->ensureExistenceOfBodyElement($xmlDocument);
-        $this->process($xmlDocument);
 
         return $xmlDocument;
     }
@@ -275,7 +284,7 @@ class CssInliner
      *
      * @param \DOMDocument $xmlDocument
      *
-     * @return void
+     * @return \DOMDocument
      *
      * @throws SyntaxErrorException
      */
@@ -331,6 +340,8 @@ class CssInliner
         $this->copyUninlineableCssToStyleNode($xmlDocument, $xPath, $cssRules['uninlineable']);
 
         restore_error_handler();
+
+        return $xmlDocument;
     }
 
     /**

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -60,6 +60,27 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function renderFormatsGivenHtml()
+    {
+        $rawHtml = '<!DOCTYPE HTML>' .
+            '<html>' .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' .
+            '<body></body>' .
+            '</html>';
+        $formattedHtml = '<!DOCTYPE HTML>' . "\n" .
+            '<html>' . "\n" .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . "\n" .
+            '<body></body>' . "\n" .
+            '</html>' . "\n";
+
+        $subject = new CssInliner($rawHtml);
+
+        static::assertSame($formattedHtml, $subject->render());
+    }
+
+    /**
+     * @test
      *
      * @expectedException \BadMethodCallException
      */


### PR DESCRIPTION
This is the next step toward making `CssInliner` inherit from
`AbstractHtmlProcessor`.

Part of #554