### PR TITLE
[TASK] Sniff for FQN in global function calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,10 @@ script:
 
 - >
   echo;
-  if php -v | grep -Pq 'PHP\s++(?:[789]|\d{2})'; then
+  function version_gte() { test "$(printf '%s\n' "$@" | sort -n -t. -r | head -n 1)" = "$1"; };
+  if version_gte $(composer php:version) 7; then
     echo "Running PHP_CodeSniffer";
     composer ci:php:sniff;
   else
-    echo "Skipped PHP_CodeSniffer due to insufficient PHP version";
-    php -v | grep -Po 'PHP\s++[56]\.(\d++\.)*+\d++(?:-\w++)?+';
+    echo "Skipped PHP_CodeSniffer due to insufficient PHP version: $(composer php:version)";
   fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,10 @@ script:
 
 - >
   echo;
-  echo "Running PHP_CodeSniffer";
-  composer ci:php:sniff;
+  if php -v | grep -Pq 'PHP\s++(?:[789]|\d{2})'; then
+    echo "Running PHP_CodeSniffer";
+    composer ci:php:sniff;
+  else
+    echo "Skipped PHP_CodeSniffer due to insufficient PHP version";
+    php -v | grep -Po 'PHP\s++[56]\.(\d++\.)*+\d++(?:-\w++)?+';
+  fi;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Improve performance by using explicit namespaces for PHP functions
-  ([#573](https://github.com/MyIntervals/emogrifier/pull/573))
+  ([#573](https://github.com/MyIntervals/emogrifier/pull/573),
+  [#576](https://github.com/MyIntervals/emogrifier/pull/576))
 - Add type hint checking to the code sniffs
   ([#566](https://github.com/MyIntervals/emogrifier/pull/566))
 - Check the code with PHPMD

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.2.0",
+        "slevomat/coding-standard": "^4.0",
         "phpmd/phpmd": "^2.6.0",
         "phpunit/phpunit": "^4.8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         }
     },
     "scripts": {
+        "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
         "ci:php:lint": "find src/ tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
         "ci:php:sniff": "phpcs --standard=config/PhpCodeSniffer.xml src/ tests/",
         "ci:php:md": "phpmd src/ text config/phpmd.xml",

--- a/config/PhpCodeSniffer.xml
+++ b/config/PhpCodeSniffer.xml
@@ -5,6 +5,8 @@
         This standard requires PHP_CodeSniffer >= 3.2.0.
     </description>
 
+    <config name="installed_paths" value="../../slevomat/coding-standard"/>
+
     <!--The complete PSR-2 ruleset-->
     <rule ref="PSR2"/>
 
@@ -77,6 +79,7 @@
 
     <!-- Functions -->
     <rule ref="Generic.Functions.CallTimePassByReference"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
     <rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
     <rule ref="Squiz.Functions.GlobalFunction"/>
 

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -441,7 +441,7 @@ class CssInliner
             /** @var string[][] $matches */
             /** @var string[] $cssRule */
             foreach ($matches as $key => $cssRule) {
-                $cssDeclaration = trim($cssRule['declarations']);
+                $cssDeclaration = \trim($cssRule['declarations']);
                 if ($cssDeclaration === '') {
                     continue;
                 }

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -326,7 +326,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        $numberOfContentTypeMetaTags = substr_count($result, 'Content-Type');
+        $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
         static::assertSame(1, $numberOfContentTypeMetaTags);
     }
 

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -285,7 +285,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        $numberOfContentTypeMetaTags = substr_count($result, 'Content-Type');
+        $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
         static::assertSame(1, $numberOfContentTypeMetaTags);
     }
 

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -304,7 +304,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        $numberOfContentTypeMetaTags = substr_count($result, 'Content-Type');
+        $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
         static::assertSame(1, $numberOfContentTypeMetaTags);
     }
 
@@ -660,11 +660,11 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
         $this->subject->setHtml(static::COMMON_TEST_HTML);
-        $this->subject->setCss(sprintf($css, $cssDeclaration1, $cssDeclaration2));
+        $this->subject->setCss(\sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
+        static::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
     }
 
     /**


### PR DESCRIPTION
Also fully-qualified the global namespace in a few function call instances that
were missed in #573.

This change makes available all Slevomat PHPCS sniffs
(https://github.com/slevomat/coding-standard), via Composer and the config XML,
should any others of them also be desired in future.

However, as Slevomat requires PHP 7, PHPCS is now skipped for the CI build with
earlier PHP versions (it only really needs to run against one PHP version).

Part of #574.