### PR TITLE
[CLEANUP] Allow PHPDoc without full sentences

### DIFF
--- a/config/PhpCodeSniffer.xml
+++ b/config/PhpCodeSniffer.xml
@@ -53,7 +53,7 @@
         <!-- Allow parameter type, name and comment not all vertically aligned. -->
         <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
         <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName"/>
-        <!-- Enable these rules after fixing the PHPDoc. -->
+        <!-- Allow parameter and exception descriptions which are not full sentences. -->
         <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
         <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
         <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital"/>


### PR DESCRIPTION
This change just updates the comment in the PHPCS config XML to indicate that
@param and @throws descriptions which are not full sentences (and thus do not
have a capital letter or full stop) are allowed - rather than something to be
fixed.

Related to #574.