### PR TITLE
Escape hyphens in regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Escape hyphens in regular expressions
+  ([#588](https://github.com/MyIntervals/emogrifier/pull/588))
 - Fix Travis for PHP 5.x
   ([#589](https://github.com/MyIntervals/emogrifier/pull/589))
 - Allow CSS between empty `@media` rule and another `@media` rule

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -179,7 +179,7 @@ class Emogrifier
         // classes, attributes, pseudo-classes (not pseudo-elements) except `:not`: worth 100
         '(?:\\.|\\[|(?<!:):(?!not\\())' => 100,
         // elements (not attribute values or `:not`), pseudo-elements: worth 1
-        '(?:(?<![="\':\\w-])|::)' => 1
+        '(?:(?<![="\':\\w\\-])|::)' => 1
     ];
 
     /**
@@ -191,15 +191,15 @@ class Emogrifier
         // type and attribute exact value
         '/(\\w)\\[(\\w+)\\=[\'"]?([\\w\\s]+)[\'"]?\\]/' => '\\1[@\\2="\\3"]',
         // type and attribute value with ~ (one word within a whitespace-separated list of words)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\~\\=[\\s]*[\'"]?([\\w-_\\/]+)[\'"]?\\]/'
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\~\\=[\\s]*[\'"]?([\\w\\-_\\/]+)[\'"]?\\]/'
         => '\\1[contains(concat(" ", @\\2, " "), concat(" ", "\\3", " "))]',
         // type and attribute value with | (either exact value match or prefix followed by a hyphen)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\|\\=[\\s]*[\'"]?([\\w-_\\s\\/]+)[\'"]?\\]/'
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\|\\=[\\s]*[\'"]?([\\w\\-_\\s\\/]+)[\'"]?\\]/'
         => '\\1[@\\2="\\3" or starts-with(@\\2, concat("\\3", "-"))]',
         // type and attribute value with ^ (prefix match)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\^\\=[\\s]*[\'"]?([\\w-_\\/]+)[\'"]?\\]/' => '\\1[starts-with(@\\2, "\\3")]',
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\^\\=[\\s]*[\'"]?([\\w\\-_\\/]+)[\'"]?\\]/' => '\\1[starts-with(@\\2, "\\3")]',
         // type and attribute value with * (substring match)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\*\\=[\\s]*[\'"]?([\\w-_\\s\\/:;]+)[\'"]?\\]/' => '\\1[contains(@\\2, "\\3")]',
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\*\\=[\\s]*[\'"]?([\\w\\-_\\s\\/:;]+)[\'"]?\\]/' => '\\1[contains(@\\2, "\\3")]',
         // adjacent sibling
         '/\\s*\\+\\s*/' => '/following-sibling::*[1]/self::',
         // child
@@ -214,7 +214,7 @@ class Emogrifier
         // The following matcher will break things if it is placed before the adjacent matcher.
         // So one of the matchers matches either too much or not enough.
         // type and attribute value with $ (suffix match)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\$\\=[\\s]*[\'"]?([\\w-_\\s\\/]+)[\'"]?\\]/'
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\$\\=[\\s]*[\'"]?([\\w\\-_\\s\\/]+)[\'"]?\\]/'
         => '\\1[substring(@\\2, string-length(@\\2) - string-length("\\3") + 1) = "\\3"]',
     ];
 
@@ -767,7 +767,7 @@ class Emogrifier
                     // only allow structural pseudo-classes
                     $hasPseudoElement = \strpos($selector, '::') !== false;
                     $hasUnsupportedPseudoClass = (bool)\preg_match(
-                        '/:(?!' . static::PSEUDO_CLASS_MATCHER . ')[\\w-]/i',
+                        '/:(?!' . static::PSEUDO_CLASS_MATCHER . ')[\\w\\-]/i',
                         $selector
                     );
                     $hasUnmatchablePseudo = $hasPseudoElement || $hasUnsupportedPseudoClass;
@@ -1235,7 +1235,7 @@ class Emogrifier
      */
     private function removeUnmatchablePseudoComponents($selector)
     {
-        $pseudoComponentMatcher = ':(?!' . static::PSEUDO_CLASS_MATCHER . '):?+[\\w-]++(?:\\([^\\)]*+\\))?+';
+        $pseudoComponentMatcher = ':(?!' . static::PSEUDO_CLASS_MATCHER . '):?+[\\w\\-]++(?:\\([^\\)]*+\\))?+';
         return \preg_replace(
             ['/(\\s|^)' . $pseudoComponentMatcher . '/i', '/' . $pseudoComponentMatcher . '/i'],
             ['$1*', ''],

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -159,7 +159,7 @@ class CssInliner
         // classes, attributes, pseudo-classes (not pseudo-elements) except `:not`: worth 100
         '(?:\\.|\\[|(?<!:):(?!not\\())' => 100,
         // elements (not attribute values or `:not`), pseudo-elements: worth 1
-        '(?:(?<![="\':\\w-])|::)' => 1
+        '(?:(?<![="\':\\w\\-])|::)' => 1
     ];
 
     /**
@@ -452,7 +452,7 @@ class CssInliner
                     // only allow structural pseudo-classes
                     $hasPseudoElement = \strpos($selector, '::') !== false;
                     $hasUnsupportedPseudoClass = (bool)\preg_match(
-                        '/:(?!' . static::PSEUDO_CLASS_MATCHER . ')[\\w-]/i',
+                        '/:(?!' . static::PSEUDO_CLASS_MATCHER . ')[\\w\\-]/i',
                         $selector
                     );
                     $hasUnmatchablePseudo = $hasPseudoElement || $hasUnsupportedPseudoClass;
@@ -875,7 +875,7 @@ class CssInliner
      */
     private function removeUnmatchablePseudoComponents($selector)
     {
-        $pseudoComponentMatcher = ':(?!' . static::PSEUDO_CLASS_MATCHER . '):?+[\\w-]++(?:\\([^\\)]*+\\))?+';
+        $pseudoComponentMatcher = ':(?!' . static::PSEUDO_CLASS_MATCHER . '):?+[\\w\\-]++(?:\\([^\\)]*+\\))?+';
         return \preg_replace(
             ['/(\\s|^)' . $pseudoComponentMatcher . '/i', '/' . $pseudoComponentMatcher . '/i'],
             ['$1*', ''],

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -36,7 +36,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
     public function getCssNeedleRegExpNotEscapesNonSpecialCharacters()
     {
         $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
-            . "\r\n\t `¬\"£%&_;'@#~,";
+            . "\r\n\t `¬\"£%&_;'@~,";
 
         $result = static::getCssNeedleRegExp($needle);
 


### PR DESCRIPTION
Hyphens need to be escaped in regular expressions. Because of that tests will be falling in PHP 7.3

Error from tests:
```
Warning: preg_replace(): Compilation failed: invalid range in character class at offset 39 in /builds/php/mailing/vendor/pelago/emogrifier/Classes/Emogrifier.php on line 1507
```

See:
https://stackoverflow.com/questions/26208622/preg-match-compilation-failed-invalid-range-in-character-class-at-offset-15?rq=1