### PR TITLE
Fix Travis for PHP 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ script:
   echo;
   function version_gte() { test "$(printf '%s\n' "$@" | sort -n -t. -r | head -n 1)" = "$1"; };
   if version_gte $(composer php:version) 7; then
+    echo "Installing slevomat/coding-standard only for PHP 7.x";
+    composer require --dev slevomat/coding-standard ^4.0
     echo "Running PHP_CodeSniffer";
     composer ci:php:sniff;
   else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix Travis for PHP 5.x
+  ([#589](https://github.com/MyIntervals/emogrifier/pull/589))
 - Allow CSS between empty `@media` rule and another `@media` rule
   ([#534](https://github.com/MyIntervals/emogrifier/pull/534))
 - Allow additional whitespace in media-query-list of disallowed `@media` rules

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.2.0",
-        "slevomat/coding-standard": "^4.0",
         "phpmd/phpmd": "^2.6.0",
         "phpunit/phpunit": "^4.8.0"
     },

--- a/config/PhpCodeSniffer.xml
+++ b/config/PhpCodeSniffer.xml
@@ -117,7 +117,6 @@
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
     <rule ref="Squiz.PHP.DiscouragedFunctions"/>
     <rule ref="Squiz.PHP.Eval"/>
-    <rule ref="Squiz.PHP.ForbiddenFunctions"/>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.Heredoc"/>
     <rule ref="Squiz.PHP.InnerFunctions"/>


### PR DESCRIPTION
- Install `slevomat/coding-standard` only for PHP 7.x in Travis.
- Delete `Squiz.PHP.ForbiddenFunctions` (`Generic.PHP.ForbiddenFunctions`)
- Enable installation on `~7.3.0`

Releated issue: #585