### PR TITLE
[BUGFIX] Add required DOM PHP extension to `composer.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add required DOM PHP extension to `composer.json`
+  ([#595](https://github.com/MyIntervals/emogrifier/pull/595))
 - Escape hyphens in regular expressions
   ([#588](https://github.com/MyIntervals/emogrifier/pull/588))
 - Fix Travis for PHP 5.x

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     },
     "require": {
         "php": "^5.5.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
+        "ext-dom": "*",
         "symfony/css-selector": "^3.4.0 || ^4.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
This makes sure that composer will only install Emogrifier if the
library is present.