### PR TITLE
[CLEANUP] Move the PHP_CodeSniffer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "scripts": {
         "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
         "ci:php:lint": "find src/ tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-        "ci:php:sniff": "phpcs --standard=config/PhpCodeSniffer.xml src/ tests/",
+        "ci:php:sniff": "phpcs src/ tests/",
         "ci:php:md": "phpmd src/ text config/phpmd.xml",
         "ci:tests:unit": "phpunit tests/",
         "ci:tests": [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="Emogrifier Coding Standard">
+<ruleset name="Coding Standard">
     <description>
-        This is the coding standard used for the Emogrifier code.
         This standard requires PHP_CodeSniffer >= 3.2.0.
     </description>
 


### PR DESCRIPTION
Now the file is in the default location, allowing it to be used without
explicitly specifying the standard.