### PR TITLE
[BUGFIX] Increase PHP_CodeSniffer version for PHP compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=5.4.0,<=7.2.99"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "2.6.0",
+        "squizlabs/php_codesniffer": "^3.3.0",
         "phpunit/phpunit": "4.8.27"
     },
     "autoload": {


### PR DESCRIPTION
This is the 1.2.x backport of #602.