### PR TITLE
[FEATURE] Add a Composer script for PHP CS Fixer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,6 +98,12 @@ If you add new methods or fields, please add proper PHPDoc for the new
 methods/fields. Please use grammatically correct, complete sentences in the
 code documentation.
 
+You can autoformat your code using the following command:
+
+```shell
+composer php:fix
+```
+
 
 ## Git commits
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@
 .TemporaryItems
 .webprj
 nbproject
+/.php_cs.cache
 /vendor/
 composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add a Composer script for PHP CS Fixer 
+  ([#607](https://github.com/jjriv/emogrifier/pull/607))
 - Copy matching rules with dynamic pseudo-classes or pseudo-elements in
   selectors to the style element
   ([#280](https://github.com/MyIntervals/emogrifier/issues/280),

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/css-selector": "^3.4.0 || ^4.0.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.2.0",
         "squizlabs/php_codesniffer": "^3.3.0",
         "phpmd/phpmd": "^2.6.0",
         "phpunit/phpunit": "^4.8.0"
@@ -58,9 +59,10 @@
     },
     "scripts": {
         "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
-        "ci:php:lint": "find src/ tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-        "ci:php:sniff": "phpcs src/ tests/",
-        "ci:php:md": "phpmd src/ text config/phpmd.xml",
+        "php:fix": "php-cs-fixer --config=config/php-cs-fixer.php fix config/ src/ tests/",
+        "ci:php:lint": "find config src tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+        "ci:php:sniff": "phpcs config src tests",
+        "ci:php:md": "phpmd src text config/phpmd.xml",
         "ci:tests:unit": "phpunit tests/",
         "ci:tests": [
             "@ci:tests:unit"

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -1,0 +1,93 @@
+<?php
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+return \PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules(
+        [
+            // copied from the TYPO3 Core
+            '@PSR2' => true,
+            '@DoctrineAnnotation' => true,
+            'no_leading_import_slash' => true,
+            'no_trailing_comma_in_singleline_array' => true,
+            'no_singleline_whitespace_before_semicolons' => true,
+            'no_unused_imports' => true,
+            'concat_space' => ['spacing' => 'one'],
+            'no_whitespace_in_blank_line' => true,
+            'ordered_imports' => true,
+            'single_quote' => true,
+            'no_empty_statement' => true,
+            'no_extra_consecutive_blank_lines' => true,
+            'phpdoc_no_package' => true,
+            'phpdoc_scalar' => true,
+            'no_blank_lines_after_phpdoc' => true,
+            'array_syntax' => ['syntax' => 'short'],
+            'whitespace_after_comma_in_array' => true,
+            'function_typehint_space' => true,
+            'hash_to_slash_comment' => true,
+            'no_alias_functions' => true,
+            'lowercase_cast' => true,
+            'no_leading_namespace_whitespace' => true,
+            'native_function_casing' => true,
+            'no_short_bool_cast' => true,
+            'no_unneeded_control_parentheses' => true,
+            'phpdoc_trim' => true,
+            'no_superfluous_elseif' => true,
+            'no_useless_else' => true,
+            'phpdoc_types' => true,
+            'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+            'return_type_declaration' => ['space_before' => 'none'],
+            'cast_spaces' => ['space' => 'none'],
+            'declare_equal_normalize' => ['space' => 'single'],
+            'dir_constant' => true,
+
+            // additional rules
+            'combine_consecutive_issets' => true,
+            'combine_consecutive_unsets' => true,
+            'compact_nullable_typehint' => true,
+            // PHP >= 7.0
+            // 'declare_strict_types' => true,
+            'elseif' => true,
+            'encoding' => true,
+            'escape_implicit_backslashes' => ['single_quoted' => true],
+            'is_null' => true,
+            'linebreak_after_opening_tag' => true,
+            'magic_constant_casing' => true,
+            'method_separation' => true,
+            'modernize_types_casting' => true,
+            // not yet, but maybe later to improve performance
+            // 'native_function_invocation' => true,
+            'new_with_braces' => true,
+            'no_blank_lines_after_class_opening' => true,
+            'no_empty_comment' => true,
+            'no_empty_phpdoc' => true,
+            'no_extra_blank_lines' => true,
+            'no_multiline_whitespace_before_semicolons' => true,
+            'no_php4_constructor' => true,
+            'no_short_echo_tag' => true,
+            'no_spaces_after_function_name' => true,
+            'no_spaces_inside_parenthesis' => true,
+            'no_unneeded_curly_braces' => true,
+            'no_useless_return' => true,
+            'no_whitespace_before_comma_in_array' => true,
+            'php_unit_construct' => true,
+            'php_unit_fqcn_annotation' => true,
+            'php_unit_set_up_tear_down_visibility' => true,
+            'phpdoc_add_missing_param_annotation' => true,
+            'phpdoc_indent' => true,
+            'phpdoc_separation' => true,
+            'semicolon_after_instruction' => true,
+            'short_scalar_cast' => true,
+            'space_after_semicolon' => true,
+            'standardize_not_equals' => true,
+            'psr4' => true,
+            'ternary_operator_spaces' => true,
+            // PHP >= 7.0
+            // 'ternary_to_null_coalescing' => true,
+            'trailing_comma_in_multiline_array' => true,
+            'unary_operator_spaces' => true,
+        ]
+    );

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -179,7 +179,7 @@ class Emogrifier
         // classes, attributes, pseudo-classes (not pseudo-elements) except `:not`: worth 100
         '(?:\\.|\\[|(?<!:):(?!not\\())' => 100,
         // elements (not attribute values or `:not`), pseudo-elements: worth 1
-        '(?:(?<![="\':\\w\\-])|::)' => 1
+        '(?:(?<![="\':\\w\\-])|::)' => 1,
     ];
 
     /**
@@ -645,7 +645,7 @@ class Emogrifier
     private function mapWidthOrHeightProperty(\DOMElement $node, $value, $property)
     {
         // only parse values in px and %, but not values like "auto"
-        if (\preg_match('/^\d+(px|%)$/', $value)) {
+        if (\preg_match('/^\\d+(px|%)$/', $value)) {
             // Remove 'px'. This regex only conserves numbers and %.
             $number = \preg_replace('/[^0-9.%]/', '', $value);
             $node->setAttribute($property, $number);
@@ -1442,7 +1442,7 @@ class Emogrifier
      */
     private function createRawXmlDocument()
     {
-        $xmlDocument = new \DOMDocument;
+        $xmlDocument = new \DOMDocument();
         $xmlDocument->encoding = 'UTF-8';
         $xmlDocument->strictErrorChecking = false;
         $xmlDocument->formatOutput = true;
@@ -1691,7 +1691,7 @@ class Emogrifier
             $xPathWithIdAttributeAndClassMatchers
         );
         $finalXpath = \preg_replace_callback(
-            '/([^\\/]+):nth-of-type\\(\s*(odd|even|[+\\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
+            '/([^\\/]+):nth-of-type\\(\\s*(odd|even|[+\\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
             [$this, 'translateNthOfType'],
             $xPathWithIdAttributeAndClassMatchers
         );
@@ -1930,7 +1930,7 @@ class Emogrifier
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function handleXpathQueryWarnings( // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+    public function handleXpathQueryWarnings(// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
         $type,
         $message,
         $file,

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -159,7 +159,7 @@ class CssInliner
         // classes, attributes, pseudo-classes (not pseudo-elements) except `:not`: worth 100
         '(?:\\.|\\[|(?<!:):(?!not\\())' => 100,
         // elements (not attribute values or `:not`), pseudo-elements: worth 1
-        '(?:(?<![="\':\\w\\-])|::)' => 1
+        '(?:(?<![="\':\\w\\-])|::)' => 1,
     ];
 
     /**
@@ -1108,7 +1108,7 @@ class CssInliner
      */
     private function createRawXmlDocument()
     {
-        $xmlDocument = new \DOMDocument;
+        $xmlDocument = new \DOMDocument();
         $xmlDocument->encoding = 'UTF-8';
         $xmlDocument->strictErrorChecking = false;
         $xmlDocument->formatOutput = true;

--- a/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
@@ -72,7 +72,7 @@ abstract class AbstractHtmlProcessor
      */
     private function createXmlDocument($html)
     {
-        $xmlDocument = new \DOMDocument;
+        $xmlDocument = new \DOMDocument();
         $xmlDocument->strictErrorChecking = false;
         $xmlDocument->formatOutput = true;
         $libXmlState = \libxml_use_internal_errors(true);

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1841,7 +1841,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             foreach ($rulesComponents as $pseudoComponentDescription => $ruleComponents) {
                 $datasets[$precedingComponentDescription . ' ' . $pseudoComponentDescription] = [
                     $precedingSelectorComponent . $ruleComponents['selectorPseudoComponent']
-                    . ' { ' . $ruleComponents['declarationsBlock'] . ' }'
+                    . ' { ' . $ruleComponents['declarationsBlock'] . ' }',
                 ];
             }
         }

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -111,6 +111,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
      * @param string $html
      * @dataProvider contentWithoutHtmlTagDataProvider
      */
@@ -137,6 +138,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
      * @param string $html
      * @dataProvider contentWithoutHeadTagDataProvider
      */
@@ -163,6 +165,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
      * @param string $html
      * @dataProvider contentWithoutBodyTagDataProvider
      */
@@ -201,6 +204,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
      * @param string $codeNotToBeChanged
      * @dataProvider specialCharactersDataProvider
      */
@@ -250,6 +254,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
      * @param string $documentType
      * @dataProvider documentTypeDataProvider
      */

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1819,7 +1819,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             foreach ($rulesComponents as $pseudoComponentDescription => $ruleComponents) {
                 $datasets[$precedingComponentDescription . ' ' . $pseudoComponentDescription] = [
                     $precedingSelectorComponent . $ruleComponents['selectorPseudoComponent']
-                    . ' { ' . $ruleComponents['declarationsBlock'] . ' }'
+                    . ' { ' . $ruleComponents['declarationsBlock'] . ' }',
                 ];
             }
         }


### PR DESCRIPTION
As the fixer should fix the files in multiple directories, the
`--config` argument is required, which removes the benefits of
storing the configuration in the default `.php_cs.dist`.

Also autoformat the code with the fixer.