### PR TITLE
[BUGFIX] Consistently use the Composer dependencies preference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   function version_gte() { test "$(printf '%s\n' "$@" | sort -n -t. -r | head -n 1)" = "$1"; };
   if version_gte $(composer php:version) 7; then
     echo "Installing slevomat/coding-standard only for PHP 7.x";
-    composer require --dev slevomat/coding-standard ^4.0
+    composer require --dev slevomat/coding-standard:^4.0 --prefer-stable --prefer-dist $DEPENDENCIES_PREFERENCE;
     echo "Running PHP_CodeSniffer";
     composer ci:php:sniff;
   else


### PR DESCRIPTION
The switch for installing the oldest/newest dependencies should also
be applied when installing slevomat/coding-standard.