### PR TITLE
[CLEANUP] Move the prefer-stable/dist to `composer.json`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 - >
   echo;
   echo "Updating the dependencies";
-  composer update --with-dependencies --prefer-stable --prefer-dist $DEPENDENCIES_PREFERENCE;
+  composer update --with-dependencies $DEPENDENCIES_PREFERENCE;
   composer show;
 
 script:
@@ -55,7 +55,7 @@ script:
   function version_gte() { test "$(printf '%s\n' "$@" | sort -n -t. -r | head -n 1)" = "$1"; };
   if version_gte $(composer php:version) 7; then
     echo "Installing slevomat/coding-standard only for PHP 7.x";
-    composer require --dev slevomat/coding-standard:^4.0 --prefer-stable --prefer-dist $DEPENDENCIES_PREFERENCE;
+    composer require --dev slevomat/coding-standard:^4.0 $DEPENDENCIES_PREFERENCE;
     echo "Running PHP_CodeSniffer";
     composer ci:php:sniff;
   else

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,12 @@
             "Pelago\\Tests\\": "tests/"
         }
     },
+    "prefer-stable": true,
+    "config": {
+        "preferred-install": {
+            "*": "dist"
+        }
+    },
     "scripts": {
         "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
         "php:fix": "php-cs-fixer --config=config/php-cs-fixer.php fix config/ src/ tests/",


### PR DESCRIPTION
This reduces the amount of typing required for Composer updates.

This does not affect projects that use Emogrifier as a library,
but only stand-alone installations of Emogrifier (usually for
development).