### PR TITLE
[TASK] Consistently use the render() method

### DIFF
--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -317,6 +317,16 @@ class Emogrifier
     }
 
     /**
+     * Renders the normalized and processed HTML.
+     *
+     * @return string
+     */
+    protected function render()
+    {
+        return $this->domDocument->saveHTML();
+    }
+
+    /**
      * Applies $this->css to the given HTML and returns the HTML with the CSS
      * applied.
      *
@@ -332,7 +342,7 @@ class Emogrifier
 
         $this->process();
 
-        return $this->domDocument->saveHTML();
+        return $this->render();
     }
 
     /**
@@ -358,6 +368,8 @@ class Emogrifier
 
     /**
      * Checks that some HTML has been set, and throws an exception otherwise.
+     *
+     * @return void
      *
      * @throws \BadMethodCallException
      */

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -240,14 +240,13 @@ class CssInliner
      *
      * @return string
      *
-     * @throws \BadMethodCallException
      * @throws SyntaxErrorException
      */
     public function emogrify()
     {
         $this->process();
 
-        return $this->domDocument->saveHTML();
+        return $this->render();
     }
 
     /**
@@ -258,7 +257,6 @@ class CssInliner
      *
      * @return string
      *
-     * @throws \BadMethodCallException
      * @throws SyntaxErrorException
      */
     public function emogrifyBodyContent()

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -146,11 +146,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider contentWithoutHtmlTagDataProvider
      */
-    public function emogrifyAddsMissingHtmlTag($html)
+    public function renderAddsMissingHtmlTag($html)
     {
         $subject = $this->buildDebugSubject($html);
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<html>', $result);
     }
@@ -174,11 +174,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider contentWithoutHeadTagDataProvider
      */
-    public function emogrifyAddsMissingHeadTag($html)
+    public function renderAddsMissingHeadTag($html)
     {
         $subject = $this->buildDebugSubject($html);
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<head>', $result);
     }
@@ -202,11 +202,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider contentWithoutBodyTagDataProvider
      */
-    public function emogrifyAddsMissingBodyTag($html)
+    public function renderAddsMissingBodyTag($html)
     {
         $subject = $this->buildDebugSubject($html);
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<body>', $result);
     }
@@ -214,11 +214,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyPutsMissingBodyElementAroundBodyContent()
+    public function renderPutsMissingBodyElementAroundBodyContent()
     {
         $subject = $this->buildDebugSubject('<p>Hello</p>');
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<body><p>Hello</p></body>', $result);
     }
@@ -242,12 +242,12 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider specialCharactersDataProvider
      */
-    public function emogrifyKeepsSpecialCharacters($codeNotToBeChanged)
+    public function renderKeepsSpecialCharacters($codeNotToBeChanged)
     {
         $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
         $subject = $this->buildDebugSubject($html);
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains($codeNotToBeChanged, $result);
     }
@@ -294,12 +294,12 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider documentTypeDataProvider
      */
-    public function emogrifyForHtmlWithDocumentTypeKeepsDocumentType($documentType)
+    public function renderForHtmlWithDocumentTypeKeepsDocumentType($documentType)
     {
         $html = $documentType . '<html></html>';
         $subject = $this->buildDebugSubject($html);
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains($documentType, $result);
     }
@@ -307,11 +307,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyAddsMissingContentTypeMetaTag()
+    public function renderAddsMissingContentTypeMetaTag()
     {
         $subject = $this->buildDebugSubject('<p>Hello</p>');
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
     }
@@ -319,12 +319,12 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyNotAddsSecondContentTypeMetaTag()
+    public function renderNotAddsSecondContentTypeMetaTag()
     {
         $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>';
         $subject = $this->buildDebugSubject($html);
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
         static::assertSame(1, $numberOfContentTypeMetaTags);
@@ -2251,13 +2251,13 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider documentTypeDataProvider
      */
-    public function emogrifyConvertsXmlSelfClosingTagsToNonXmlSelfClosingTag($documentType)
+    public function renderConvertsXmlSelfClosingTagsToNonXmlSelfClosingTag($documentType)
     {
         $subject = $this->buildDebugSubject(
             $documentType . '<html><body><br/></body></html>'
         );
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<br>', $result);
     }
@@ -2265,11 +2265,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyAutomaticallyClosesUnclosedTag()
+    public function renderAutomaticallyClosesUnclosedTag()
     {
         $subject = $this->buildDebugSubject('<html><body><p></body></html>');
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertContains('<body><p></p></body>', $result);
     }
@@ -2277,11 +2277,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyReturnsCompleteHtmlDocument()
+    public function renderReturnsCompleteHtmlDocument()
     {
         $subject = $this->buildDebugSubject('<html><body><p></p></body></html>');
 
-        $result = $subject->emogrify();
+        $result = $subject->render();
 
         static::assertSame(
             $this->html5DocumentType . "\n" .


### PR DESCRIPTION
- Add a (protected) `render()` method to the `Emogrifier` class.
- Use the `render()` method where it can be used.
- Change the tests in `CssInlinerTest` to use `render()` instead of
  `emogrify` if they actually are about the rendering, not the
  emogrification.
- Streamline some PHPDoc annotations.

This change work towards splitting `emogrify()` into `inlineCss()` and
`render()`in `CssInliner`.

Part of #554.