### PR TITLE
[FEATURE] Add a renderBodyContent() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add a `renderBodyContent()` method
+  ([#633](https://github.com/MyIntervals/emogrifier/pull/633))
 - Add a `getDomDocument()` method
   ([#630](https://github.com/MyIntervals/emogrifier/pull/630))
 - Add a Composer script for PHP CS Fixer 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -327,6 +327,30 @@ class Emogrifier
     }
 
     /**
+     * Renders the content of the BODY element of the normalized and processed HTML.
+     *
+     * @return string
+     */
+    protected function renderBodyContent()
+    {
+        $bodyNodeHtml = $this->domDocument->saveHTML($this->getBodyElement());
+
+        return \str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
+    }
+
+    /**
+     * Returns the BODY element.
+     *
+     * This method assumes that there always is a BODY element.
+     *
+     * @return \DOMElement
+     */
+    private function getBodyElement()
+    {
+        return $this->domDocument->getElementsByTagName('body')->item(0);
+    }
+
+    /**
      * Applies $this->css to the given HTML and returns the HTML with the CSS
      * applied.
      *
@@ -361,9 +385,7 @@ class Emogrifier
 
         $this->process();
 
-        $bodyNodeHtml = $this->domDocument->saveHTML($this->getBodyElement());
-
-        return \str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
+        return $this->renderBodyContent();
     }
 
     /**
@@ -1400,28 +1422,6 @@ class Emogrifier
 
         $htmlElement = $this->domDocument->getElementsByTagName('html')->item(0);
         $htmlElement->appendChild($this->domDocument->createElement('body'));
-    }
-
-    /**
-     * Returns the BODY element.
-     *
-     * This method assumes that there always is a BODY element.
-     *
-     * @return \DOMElement
-     *
-     * @throws \BadMethodCallException
-     */
-    private function getBodyElement()
-    {
-        $bodyElement = $this->domDocument->getElementsByTagName('body')->item(0);
-        if ($bodyElement === null) {
-            throw new \BadMethodCallException(
-                'getBodyElement method may only be called after ensureExistenceOfBodyElement has been called.',
-                1508173775
-            );
-        }
-
-        return $bodyElement;
     }
 
     /**

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -233,6 +233,30 @@ class CssInliner
     }
 
     /**
+     * Renders the content of the BODY element of the normalized and processed HTML.
+     *
+     * @return string
+     */
+    public function renderBodyContent()
+    {
+        $bodyNodeHtml = $this->domDocument->saveHTML($this->getBodyElement());
+
+        return \str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
+    }
+
+    /**
+     * Returns the BODY element.
+     *
+     * This method assumes that there always is a BODY element.
+     *
+     * @return \DOMElement
+     */
+    private function getBodyElement()
+    {
+        return $this->domDocument->getElementsByTagName('body')->item(0);
+    }
+
+    /**
      * Applies $this->css to the given HTML and returns the HTML with the CSS
      * applied.
      *
@@ -262,9 +286,8 @@ class CssInliner
     public function emogrifyBodyContent()
     {
         $this->process();
-        $bodyNodeHtml = $this->domDocument->saveHTML($this->getBodyElement());
 
-        return \str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
+        return $this->renderBodyContent();
     }
 
     /**
@@ -1033,28 +1056,6 @@ class CssInliner
 
         $htmlElement = $this->domDocument->getElementsByTagName('html')->item(0);
         $htmlElement->appendChild($this->domDocument->createElement('body'));
-    }
-
-    /**
-     * Returns the BODY element.
-     *
-     * This method assumes that there always is a BODY element.
-     *
-     * @return \DOMElement
-     *
-     * @throws \BadMethodCallException
-     */
-    private function getBodyElement()
-    {
-        $bodyElement = $this->domDocument->getElementsByTagName('body')->item(0);
-        if ($bodyElement === null) {
-            throw new \BadMethodCallException(
-                'getBodyElement method may only be called after ensureExistenceOfBodyElement has been called.',
-                1508173775
-            );
-        }
-
-        return $bodyElement;
     }
 
     /**

--- a/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
@@ -76,6 +76,30 @@ abstract class AbstractHtmlProcessor
     }
 
     /**
+     * Renders the content of the BODY element of the normalized and processed HTML.
+     *
+     * @return string
+     */
+    public function renderBodyContent()
+    {
+        $bodyNodeHtml = $this->domDocument->saveHTML($this->getBodyElement());
+
+        return \str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
+    }
+
+    /**
+     * Returns the BODY element.
+     *
+     * This method assumes that there always is a BODY element.
+     *
+     * @return \DOMElement
+     */
+    private function getBodyElement()
+    {
+        return $this->domDocument->getElementsByTagName('body')->item(0);
+    }
+
+    /**
      * Creates a DOM document from the given HTML and stores it in $this->domDocument.
      *
      * The DOM document will always have a BODY element and a document type.

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -75,6 +75,31 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function renderBodyContentForEmptyBodyReturnsEmptyString()
+    {
+        $subject = $this->buildDebugSubject('<html><body></body></html>');
+
+        $result = $subject->renderBodyContent();
+
+        static::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function renderBodyContentReturnsBodyContent()
+    {
+        $bodyContent = '<p>Hello world</p>';
+        $subject = $this->buildDebugSubject('<html><body>' . $bodyContent . '</body></html>');
+
+        $result = $subject->renderBodyContent();
+
+        static::assertSame($bodyContent, $result);
+    }
+
+    /**
+     * @test
+     */
     public function getDomDocumentReturnsDomDocument()
     {
         $subject = new CssInliner('<html></html>');
@@ -118,6 +143,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      *
      * @param mixed $html
+     *
      * @dataProvider nonHtmlDataProvider
      */
     public function constructorWithNoHtmlDataThrowsException($html)

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -60,6 +60,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      *
      * @param mixed $html
+     *
      * @dataProvider nonHtmlDataProvider
      */
     public function constructorWithNoHtmlDataThrowsException($html)
@@ -85,6 +86,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $input
      * @param string $expectedHtml
+     *
      * @dataProvider invalidHtmlDataProvider
      */
     public function renderRepairsBrokenHtml($input, $expectedHtml)
@@ -113,6 +115,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $html
+     *
      * @dataProvider contentWithoutHtmlTagDataProvider
      */
     public function addsMissingHtmlTag($html)
@@ -140,6 +143,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $html
+     *
      * @dataProvider contentWithoutHeadTagDataProvider
      */
     public function addsMissingHeadTag($html)
@@ -167,6 +171,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $html
+     *
      * @dataProvider contentWithoutBodyTagDataProvider
      */
     public function addsMissingBodyTag($html)
@@ -206,6 +211,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $codeNotToBeChanged
+     *
      * @dataProvider specialCharactersDataProvider
      */
     public function keepsSpecialCharacters($codeNotToBeChanged)
@@ -256,6 +262,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $documentType
+     *
      * @dataProvider documentTypeDataProvider
      */
     public function keepsExistingDocumentType($documentType)
@@ -298,6 +305,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $documentType
+     *
      * @dataProvider documentTypeDataProvider
      */
     public function convertsXmlSelfClosingTagsToNonXmlSelfClosingTag($documentType)
@@ -313,15 +321,41 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @param string $documentType
+     *
      * @dataProvider documentTypeDataProvider
      */
-    public function keepsNonMmlSelfClosingTags($documentType)
+    public function keepsNonXmlSelfClosingTags($documentType)
     {
         $subject = new TestingHtmlProcessor($documentType . '<html><body><br></body></html>');
 
         $result = $subject->render();
 
         static::assertContains('<body><br></body>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function renderBodyContentForEmptyBodyReturnsEmptyString()
+    {
+        $subject = new TestingHtmlProcessor('<html><body></body></html>');
+
+        $result = $subject->renderBodyContent();
+
+        static::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function renderBodyContentReturnsBodyContent()
+    {
+        $bodyContent = '<p>Hello world</p>';
+        $subject = new TestingHtmlProcessor('<html><body>' . $bodyContent . '</body></html>');
+
+        $result = $subject->renderBodyContent();
+
+        static::assertSame($bodyContent, $result);
     }
 
     /**


### PR DESCRIPTION
For `CssInliner` and `AbstractHtmlProcessor`, this method is part of the
public API. For `Emogrifier`, it is internal.

This is part of #554.

Also autoformat the changed classes, fix a typo in a test name, and remove
the check for the existence of the BODY element from `getBodyElement()`
(as this always is ensured and hence will never happen).