### PR TITLE
[TASK] Drop the `@version` PHPDoc annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   version 3.0 and removed for version 4.0.
 
 ### Removed
+- Drop the `@version` PHPDoc annotations
+  ([#637](https://github.com/MyIntervals/emogrifier/pull/637))
 - Drop the destructors
   ([#619](https://github.com/MyIntervals/emogrifier/pull/619))
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -7,8 +7,6 @@ namespace Pelago;
  *
  * For more information, please see the README.md file.
  *
- * @version 2.0.0
- *
  * @author Cameron Brooks
  * @author Jaime Prado
  * @author Oliver Klee <github@oliverklee.de>

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -12,8 +12,6 @@ use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
  *
  * For more information, please see the README.md file.
  *
- * @version 2.0.0
- *
  * @author Cameron Brooks
  * @author Jaime Prado
  * @author Oliver Klee <github@oliverklee.de>


### PR DESCRIPTION
Composer already has information about the currently installed version
of Emogrifier, and https://github.com/Ocramius/PackageVersions
provides a way to programmatically retrieve the version.

For visual inspection, there is `CHANGELOG.md`.

Closes #636