### PR TITLE
[TASK] Add test for keeping curly braces in text nodes

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -258,6 +258,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
             'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
             'HTML entities' => ['a &amp; b &gt; c'],
+            'curly braces' => ['{Happy new year!}'],
         ];
     }
 
@@ -268,7 +269,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider specialCharactersDataProvider
      */
-    public function renderKeepsSpecialCharacters($codeNotToBeChanged)
+    public function renderKeepsSpecialCharactersInTextNodes($codeNotToBeChanged)
     {
         $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
         $subject = $this->buildDebugSubject($html);
@@ -297,7 +298,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider specialCharactersDataProvider
      */
-    public function emogrifyBodyContentKeepsSpecialCharacters($codeNotToBeChanged)
+    public function emogrifyBodyContentKeepsSpecialCharactersInTextNodes($codeNotToBeChanged)
     {
         $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
         $subject = $this->buildDebugSubject($html);

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -204,6 +204,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
             'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
             'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
             'HTML entities' => ['a &amp; b &gt; c'],
+            'curly braces' => ['{Happy new year!}'],
         ];
     }
 
@@ -214,7 +215,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider specialCharactersDataProvider
      */
-    public function keepsSpecialCharacters($codeNotToBeChanged)
+    public function keepsSpecialCharactersInTextNodes($codeNotToBeChanged)
     {
         $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
         $subject = new TestingHtmlProcessor($html);

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -230,6 +230,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
             'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
             'HTML entities' => ['a &amp; b &gt; c'],
+            'curly braces' => ['{Happy new year!}'],
         ];
     }
 
@@ -240,7 +241,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider specialCharactersDataProvider
      */
-    public function emogrifyKeepsSpecialCharacters($codeNotToBeChanged)
+    public function emogrifyKeepsSpecialCharactersInTextNodes($codeNotToBeChanged)
     {
         $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
         $this->subject->setHtml($html);
@@ -257,7 +258,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider specialCharactersDataProvider
      */
-    public function emogrifyBodyContentKeepsSpecialCharacters($codeNotToBeChanged)
+    public function emogrifyBodyContentKeepsSpecialCharactersInTextNodes($codeNotToBeChanged)
     {
         $html = '<html><p>' . $codeNotToBeChanged . '</p></html>';
         $this->subject->setHtml($html);


### PR DESCRIPTION
The new test shows that issue #646 only affects attribute values, not text
nodes.