### PR TITLE
Fix invalid output of `translateNthChild`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+## 2.2.0
+### Fixed
+- Correct translated xpath of `:nth-child` selector
+  ([#648](https://github.com/MyIntervals/emogrifier/pull/648))
+
 ## 2.1.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-
-## 2.2.0
-### Fixed
 - Correct translated xpath of `:nth-child` selector
   ([#648](https://github.com/MyIntervals/emogrifier/pull/648))
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1784,21 +1784,21 @@ class Emogrifier
             if ($parseResult[static::MULTIPLIER] < 0) {
                 $parseResult[static::MULTIPLIER] = \abs($parseResult[static::MULTIPLIER]);
                 $xPathExpression = \sprintf(
-                    '*[(last() - position()) mod %1%u = %2$u]/static::%3$s',
+                    '*[(last() - position()) mod %1%u = %2$u]/self::%3$s',
                     $parseResult[static::MULTIPLIER],
                     $parseResult[static::INDEX],
                     $match[1]
                 );
             } else {
                 $xPathExpression = \sprintf(
-                    '*[position() mod %1$u = %2$u]/static::%3$s',
+                    '*[position() mod %1$u = %2$u]/self::%3$s',
                     $parseResult[static::MULTIPLIER],
                     $parseResult[static::INDEX],
                     $match[1]
                 );
             }
         } else {
-            $xPathExpression = \sprintf('*[%1$u]/static::%2$s', $parseResult[static::INDEX], $match[1]);
+            $xPathExpression = \sprintf('*[%1$u]/self::%2$s', $parseResult[static::INDEX], $match[1]);
         }
 
         return $xPathExpression;


### PR DESCRIPTION
This looks like a victim of find and replace when static attribute
accessor was changed from `self` to `static`
https://github.com/MyIntervals/emogrifier/commit/d11de626d94593c4933e2f172e0ba0dcf846befb#diff-cc9a3a01aba196708dfca8c47b5fd06eR1587