### PR TITLE
[BUGFIX] Remove all ‘unprocessable’ tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove all ‘unprocessable’ (e.g. `<wbr>`) tags
+  ([#650](https://github.com/MyIntervals/emogrifier/pull/650))
 - Correct translated xpath of `:nth-child` selector
   ([#648](https://github.com/MyIntervals/emogrifier/pull/648))
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1518,7 +1518,11 @@ class Emogrifier
     private function removeUnprocessableTags()
     {
         foreach ($this->unprocessableHtmlTags as $tagName) {
-            $nodes = $this->domDocument->getElementsByTagName($tagName);
+            // Deleting nodes from a 'live' NodeList invalidates iteration on it, so a copy must be made to iterate.
+            $nodes = [];
+            foreach ($this->domDocument->getElementsByTagName($tagName) as $node) {
+                $nodes[] = $node;
+            }
             /** @var \DOMNode $node */
             foreach ($nodes as $node) {
                 $hasContent = $node->hasChildNodes() || $node->hasChildNodes();

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -1154,7 +1154,11 @@ class CssInliner
     private function removeUnprocessableTags()
     {
         foreach ($this->unprocessableHtmlTags as $tagName) {
-            $nodes = $this->domDocument->getElementsByTagName($tagName);
+            // Deleting nodes from a 'live' NodeList invalidates iteration on it, so a copy must be made to iterate.
+            $nodes = [];
+            foreach ($this->domDocument->getElementsByTagName($tagName) as $node) {
+                $nodes[] = $node;
+            }
             /** @var \DOMNode $node */
             foreach ($nodes as $node) {
                 $hasContent = $node->hasChildNodes() || $node->hasChildNodes();

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -370,11 +370,26 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test
+     * @return string[][]
      */
-    public function emogrifyByDefaultRemovesWbrTag()
+    public function wbrTagDataProvider()
     {
-        $html = '<html>foo<wbr/>bar</html>';
+        return [
+            'single <wbr> tag' => ['<body>foo<wbr/>bar</body>'],
+            'two sibling <wbr> tags' => ['<body>foo<wbr/>bar<wbr/>baz</body>'],
+            'two non-sibling <wbr> tags' => ['<body><p>foo<wbr/>bar</p><p>bar<wbr/>baz</p></body>'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $html
+     *
+     * @dataProvider wbrTagDataProvider
+     */
+    public function emogrifyByDefaultRemovesWbrTag($html)
+    {
         $subject = $this->buildDebugSubject($html);
 
         $result = $subject->emogrify();
@@ -387,7 +402,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function addUnprocessableTagRemovesEmptyTag()
     {
-        $subject = $this->buildDebugSubject('<html><p></p></html>');
+        $subject = $this->buildDebugSubject('<body><p></p></body>');
 
         $subject->addUnprocessableHtmlTag('p');
         $result = $subject->emogrify();
@@ -400,7 +415,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function addUnprocessableTagNotRemovesNonEmptyTag()
     {
-        $subject = $this->buildDebugSubject('<html><p>foobar</p></html>');
+        $subject = $this->buildDebugSubject('<body><p>foobar</p></body>');
 
         $subject->addUnprocessableHtmlTag('p');
         $result = $subject->emogrify();
@@ -413,7 +428,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function removeUnprocessableHtmlTagKeepsTagAgainAgain()
     {
-        $subject = $this->buildDebugSubject('<html><p></p></html>');
+        $subject = $this->buildDebugSubject('<body><p></p></body>');
 
         $subject->addUnprocessableHtmlTag('p');
         $subject->removeUnprocessableHtmlTag('p');

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -342,11 +342,26 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test
+     * @return string[][]
      */
-    public function emogrifyByDefaultRemovesWbrTag()
+    public function wbrTagDataProvider()
     {
-        $html = '<html>foo<wbr/>bar</html>';
+        return [
+            'single <wbr> tag' => ['<body>foo<wbr/>bar</body>'],
+            'two sibling <wbr> tags' => ['<body>foo<wbr/>bar<wbr/>baz</body>'],
+            'two non-sibling <wbr> tags' => ['<body><p>foo<wbr/>bar</p><p>bar<wbr/>baz</p></body>'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $html
+     *
+     * @dataProvider wbrTagDataProvider
+     */
+    public function emogrifyByDefaultRemovesWbrTag($html)
+    {
         $this->subject->setHtml($html);
 
         $result = $this->subject->emogrify();
@@ -359,7 +374,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addUnprocessableTagRemovesEmptyTag()
     {
-        $this->subject->setHtml('<html><p></p></html>');
+        $this->subject->setHtml('<body><p></p></body>');
 
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
@@ -372,7 +387,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addUnprocessableTagNotRemovesNonEmptyTag()
     {
-        $this->subject->setHtml('<html><p>foobar</p></html>');
+        $this->subject->setHtml('<body><p>foobar</p></body>');
 
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
@@ -385,7 +400,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function removeUnprocessableHtmlTagKeepsTagAgainAgain()
     {
-        $this->subject->setHtml('<html><p></p></html>');
+        $this->subject->setHtml('<body><p></p></body>');
 
         $this->subject->addUnprocessableHtmlTag('p');
         $this->subject->removeUnprocessableHtmlTag('p');


### PR DESCRIPTION
Not all ‘unprocessable’ tags (`<wbr>` by default) were being removed, because a
‘live’ NodeList was being iterated.  This was a regression as a result of #627.

Also modified related tests to include a `<body>` element in the input HTML.
Prior to #627, `removeUnprocessableTags()` did not behave as documented – if
elements had content it would still remove the tags (though not the content).
The tests did not pick this up because `DOMDocument::loadHTML()` creates a
`<body>` element if there isn’t one, and if there is text content (at the start)
not inside any element, wraps it in a `<p>` element
(https://secure.php.net/manual/en/domdocument.loadhtml.php#88864).  (It does not
create a `<p>` element if there is already a `<body>` element.)