### PR TITLE
[BUGFIX] `AbstractHtmlProcessor`: HTML5 void tags

### DIFF
--- a/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/Emogrifier/HtmlProcessor/AbstractHtmlProcessor.php
@@ -25,7 +25,7 @@ abstract class AbstractHtmlProcessor
 
     /**
      * @var string Regular expression part to match tag names that PHP's DOMDocument implementation is not aware are
-     *      self-closing.  These are mostly HTML5 elements, but for completeness <command> (obsolete) and <keygen>
+     *      self-closing. These are mostly HTML5 elements, but for completeness <command> (obsolete) and <keygen>
      *      (deprecated) are also included.
      *
      * @see https://bugs.php.net/bug.php?id=73175

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -359,20 +359,41 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Concatenates pairs of datasets (in a similar way to SQL `JOIN`) such that each new dataset consists of a 'row'
+     * from a left-hand-side dataset joined with a 'row' from a right-hand-side dataset.
+     *
+     * @param string[][] $leftDatasets
+     * @param string[][] $rightDatasets
+     *
+     * @return string[][] The new datasets comprise the first dataset from the left-hand side with each of the datasets
+     * from the right-hand side, and the each of the remaining datasets from the left-hand side with the first dataset
+     * from the right-hand side.
+     */
+    public static function joinDatasets(array $leftDatasets, array $rightDatasets)
+    {
+        $datasets = [];
+        $doneFirstLeft = false;
+        foreach ($leftDatasets as $leftDatasetName => $leftDataset) {
+            foreach ($rightDatasets as $rightDatasetName => $rightDataset) {
+                $datasets[$leftDatasetName . ' & ' . $rightDatasetName]
+                    = \array_merge($leftDataset, $rightDataset);
+                if ($doneFirstLeft) {
+                    // Not all combinations are required,
+                    // just all of 'right' with one of 'left' and all of 'left' with one of 'right'.
+                    break;
+                }
+            }
+            $doneFirstLeft = true;
+        }
+        return $datasets;
+    }
+
+    /**
      * @return string[][]
      */
     public function documentTypeAndSelfClosingTagDataProvider()
     {
-        $documentTypeDatasets = $this->documentTypeDataProvider();
-        $selfClosingTagDatasets = $this->selfClosingTagDataProvider();
-        $datasets = [];
-        foreach ($documentTypeDatasets as $documentTypeDatasetName => $documentTypeDataset) {
-            foreach ($selfClosingTagDatasets as $selfClosingTagDatasetName => $selfClosingTagDataset) {
-                $datasets[$documentTypeDatasetName . ' & ' . $selfClosingTagDatasetName]
-                    = \array_merge($documentTypeDataset, $selfClosingTagDataset);
-            }
-        }
-        return $datasets;
+        return static::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
     }
 
     /**


### PR DESCRIPTION
Added support to `AbstractHtmlProcessor` for HTML5 self-closing tags not
recognized as such by PHP’s `DOMDocument` implementation.  In effect this is a
workaround for the issue reported in https://bugs.php.net/bug.php?id=73175.

Affected tags require a self-closing slash in the HTML input to `DOMDocument`
(e.g. `<wbr/>` rather than `<wbr>`), and their invalid corresponding closing tag
(e.g. `</wbr>`) removing from its HTML output.

Follows from discussion in #650.