### PR TITLE
[BUGFIX] `Emogrifier`: Support HTML5 void tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Support all HTML5 self-closing tags, including `<embed>`, `<source>`,
+  `<track>` and `<wbr>`
+  ([#653](https://github.com/MyIntervals/emogrifier/pull/653))
 - Remove all ‘unprocessable’ (e.g. `<wbr>`) tags
   ([#650](https://github.com/MyIntervals/emogrifier/pull/650))
 - Correct translated xpath of `:nth-child` selector

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -86,6 +86,15 @@ class Emogrifier
     const DEFAULT_DOCUMENT_TYPE = '<!DOCTYPE html>';
 
     /**
+     * @var string Regular expression part to match tag names that PHP's DOMDocument implementation is not aware are
+     *      self-closing. These are mostly HTML5 elements, but for completeness <command> (obsolete) and <keygen>
+     *      (deprecated) are also included.
+     *
+     * @see https://bugs.php.net/bug.php?id=73175
+     */
+    const PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER = '(?:command|embed|keygen|source|track|wbr)';
+
+    /**
      * @var \DOMDocument
      */
     protected $domDocument = null;
@@ -321,7 +330,9 @@ class Emogrifier
      */
     protected function render()
     {
-        return $this->domDocument->saveHTML();
+        $htmlWithPossibleErroneousClosingTags = $this->domDocument->saveHTML();
+
+        return $this->removeSelfClosingTagsClosingTags($htmlWithPossibleErroneousClosingTags);
     }
 
     /**
@@ -331,9 +342,22 @@ class Emogrifier
      */
     protected function renderBodyContent()
     {
-        $bodyNodeHtml = $this->domDocument->saveHTML($this->getBodyElement());
+        $htmlWithPossibleErroneousClosingTags = $this->domDocument->saveHTML($this->getBodyElement());
+        $bodyNodeHtml = $this->removeSelfClosingTagsClosingTags($htmlWithPossibleErroneousClosingTags);
 
         return \str_replace(['<body>', '</body>'], '', $bodyNodeHtml);
+    }
+
+    /**
+     * Eliminates any invalid closing tags for void elements from the given HTML.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    private function removeSelfClosingTagsClosingTags($html)
+    {
+        return \preg_replace('%</' . static::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER . '>%', '', $html);
     }
 
     /**
@@ -450,7 +474,7 @@ class Emogrifier
     }
 
     /**
-     * Returns the HTML with added document type and Content-Type meta tag if needed,
+     * Returns the HTML with added document type, Content-Type meta tag, and self-closing slashes, if needed,
      * ensuring that the HTML will be good for creating a DOM document from it.
      *
      * @param string $html
@@ -459,7 +483,8 @@ class Emogrifier
      */
     private function prepareHtmlForDomConversion($html)
     {
-        $htmlWithDocumentType = $this->ensureDocumentType($html);
+        $htmlWithSelfClosingSlashes = $this->ensurePhpUnrecognizedSelfClosingTagsAreXml($html);
+        $htmlWithDocumentType = $this->ensureDocumentType($htmlWithSelfClosingSlashes);
 
         return $this->addContentTypeMetaTag($htmlWithDocumentType);
     }
@@ -1584,6 +1609,23 @@ class Emogrifier
         }
 
         return $reworkedHtml;
+    }
+
+    /**
+     * Makes sure that any self-closing tags not recognized as such by PHP's DOMDocument implementation have a
+     * self-closing slash.
+     *
+     * @param string $html
+     *
+     * @return string HTML with problematic tags converted.
+     */
+    private function ensurePhpUnrecognizedSelfClosingTagsAreXml($html)
+    {
+        return \preg_replace(
+            '%<' . static::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER . '\\b[^>]*+(?<!/)(?=>)%',
+            '$0/',
+            $html
+        );
     }
 
     /**


### PR DESCRIPTION
Added support to `Emogrifier` for HTML5 self-closing tags not recognized as such
by PHP’s `DOMDocument` implementation.

This is a port of the equivalent changes made for `AbstractHtmlProcessor`
in #651, with some differences in the tests:
- The tests employ `emogrify` and `emogrifyBodyContent` rather than `render` and
  `renderBodyContent`, as the latter are not public methods;
- Since, by default, `emogrify` removes `<wbr>` elements, an additional call to
  `removeUnprocessableHtmlTag()` is required in each test’s set-up;
- An additional separate test confirms `removeUnprocessableHtmlTag('wbr')`
  behaves as expected.