### PR TITLE
[TASK] Separate CssInliner::inlineCss and the rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Separate `CssInliner::inlineCss` and the rendering
+  ([#654](https://github.com/MyIntervals/emogrifier/pull/654))
 
 ### Deprecated
 


### PR DESCRIPTION
This is another step toward making `CssInliner` a `HtmlProcessor`.