### PR TITLE
[CLEANUP] Use self:: instead of static:: in the tests

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -76,6 +76,7 @@ return \PhpCsFixer\Config::create()
             'php_unit_construct' => true,
             'php_unit_fqcn_annotation' => true,
             'php_unit_set_up_tear_down_visibility' => true,
+            'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
             'phpdoc_add_missing_param_annotation' => true,
             'phpdoc_indent' => true,
             'phpdoc_separation' => true,

--- a/tests/Support/Traits/AssertCss.php
+++ b/tests/Support/Traits/AssertCss.php
@@ -55,8 +55,8 @@ trait AssertCss
      */
     private static function assertContainsCss($needle, $haystack)
     {
-        static::assertRegExp(
-            static::getCssNeedleRegExp($needle),
+        self::assertRegExp(
+            self::getCssNeedleRegExp($needle),
             $haystack,
             'Plain text needle: "' . $needle . '"'
         );
@@ -71,8 +71,8 @@ trait AssertCss
      */
     private static function assertNotContainsCss($needle, $haystack)
     {
-        static::assertNotRegExp(
-            static::getCssNeedleRegExp($needle),
+        self::assertNotRegExp(
+            self::getCssNeedleRegExp($needle),
             $haystack,
             'Plain text needle: "' . $needle . '"'
         );
@@ -91,9 +91,9 @@ trait AssertCss
         $needle,
         $haystack
     ) {
-        static::assertSame(
+        self::assertSame(
             $expectedCount,
-            \preg_match_all(static::getCssNeedleRegExp($needle), $haystack),
+            \preg_match_all(self::getCssNeedleRegExp($needle), $haystack),
             'Plain text needle: "' . $needle . "\"\nHaystack: \"" . $haystack . '"'
         );
     }

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -70,7 +70,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertSame($formattedHtml, $result);
+        self::assertSame($formattedHtml, $result);
     }
 
     /**
@@ -82,7 +82,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertSame('', $result);
+        self::assertSame('', $result);
     }
 
     /**
@@ -95,7 +95,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertSame($bodyContent, $result);
+        self::assertSame($bodyContent, $result);
     }
 
     /**
@@ -114,7 +114,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertNotContains('</' . $tagName, $result);
+        self::assertNotContains('</' . $tagName, $result);
     }
 
     /**
@@ -126,7 +126,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->getDomDocument();
 
-        static::assertInstanceOf(\DOMDocument::class, $result);
+        self::assertInstanceOf(\DOMDocument::class, $result);
     }
 
     /**
@@ -163,7 +163,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $voidElements = $domDocument->getElementsByTagName($tagName);
         foreach ($voidElements as $element) {
-            static::assertFalse($element->hasChildNodes());
+            self::assertFalse($element->hasChildNodes());
         }
     }
 
@@ -223,7 +223,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<html>', $result);
+        self::assertContains('<html>', $result);
     }
 
     /**
@@ -251,7 +251,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<head>', $result);
+        self::assertContains('<head>', $result);
     }
 
     /**
@@ -279,7 +279,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body>', $result);
+        self::assertContains('<body>', $result);
     }
 
     /**
@@ -291,7 +291,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body><p>Hello</p></body>', $result);
+        self::assertContains('<body><p>Hello</p></body>', $result);
     }
 
     /**
@@ -321,7 +321,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains($codeNotToBeChanged, $result);
+        self::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -333,7 +333,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<!DOCTYPE html>', $result);
+        self::assertContains('<!DOCTYPE html>', $result);
     }
 
     /**
@@ -350,7 +350,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertContains($codeNotToBeChanged, $result);
+        self::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -385,7 +385,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains($documentType, $result);
+        self::assertContains($documentType, $result);
     }
 
     /**
@@ -397,7 +397,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
+        self::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
     }
 
     /**
@@ -411,7 +411,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $result = $subject->render();
 
         $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
-        static::assertSame(1, $numberOfContentTypeMetaTags);
+        self::assertSame(1, $numberOfContentTypeMetaTags);
     }
 
     /**
@@ -451,7 +451,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContains('<wbr', $subject->render());
+        self::assertNotContains('<wbr', $subject->render());
     }
 
     /**
@@ -464,7 +464,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addUnprocessableHtmlTag('p');
 
         $result = $subject->inlineCss('')->render();
-        static::assertNotContains('<p>', $result);
+        self::assertNotContains('<p>', $result);
     }
 
     /**
@@ -477,7 +477,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addUnprocessableHtmlTag('p');
 
         $result = $subject->inlineCss('')->render();
-        static::assertContains('<p>', $result);
+        self::assertContains('<p>', $result);
     }
 
     /**
@@ -491,7 +491,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->removeUnprocessableHtmlTag('p');
 
         $result = $subject->inlineCss('')->render();
-        static::assertContains('<p>', $result);
+        self::assertContains('<p>', $result);
     }
 
     /**
@@ -792,11 +792,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
-        $subject = $this->buildDebugSubject(static::COMMON_TEST_HTML);
+        $subject = $this->buildDebugSubject(self::COMMON_TEST_HTML);
 
         $subject->inlineCss(\sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
-        static::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $subject->render());
+        self::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $subject->render());
     }
 
     /**
@@ -881,11 +881,11 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
-        $subject = $this->buildDebugSubject(static::COMMON_TEST_HTML);
+        $subject = $this->buildDebugSubject(self::COMMON_TEST_HTML);
 
         $subject->inlineCss(\sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
-        static::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $subject->render());
+        self::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $subject->render());
     }
 
     /**
@@ -977,7 +977,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $lessSpecificSelector,
         $moreSpecificSelector
     ) {
-        $subject = $this->buildDebugSubject(static::COMMON_TEST_HTML);
+        $subject = $this->buildDebugSubject(self::COMMON_TEST_HTML);
 
         $subject->inlineCss(
             $lessSpecificSelector . ' { color: red; } ' .
@@ -986,7 +986,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             $lessSpecificSelector . ' { background-color: red; }'
         );
 
-        static::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $subject->render());
+        self::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $subject->render());
     }
 
     /**
@@ -1059,7 +1059,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $selector1,
         $selector2
     ) {
-        $subject = $this->buildDebugSubject(static::COMMON_TEST_HTML);
+        $subject = $this->buildDebugSubject(self::COMMON_TEST_HTML);
 
         $subject->inlineCss(
             $selector1 . ' { color: red; } ' .
@@ -1068,7 +1068,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             $selector1 . ' { background-color: green; }'
         );
 
-        static::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $subject->render());
+        self::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $subject->render());
     }
 
     /**
@@ -1107,7 +1107,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('html {' . $cssDeclaration . '}');
 
-        static::assertContains('<html style="color: #000;">', $subject->render());
+        self::assertContains('<html style="color: #000;">', $subject->render());
     }
 
     /**
@@ -1159,7 +1159,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('html {' . $cssDeclarationBlock . '}');
 
-        static::assertContains('<html style="' . $expectedStyleAttributeContent . '">', $subject->render());
+        self::assertContains('<html style="' . $expectedStyleAttributeContent . '">', $subject->render());
     }
 
     /**
@@ -1188,7 +1188,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('html {' . $cssDeclarationBlock . '}');
 
-        static::assertContains('<html style="">', $subject->render());
+        self::assertContains('<html style="">', $subject->render());
     }
 
     /**
@@ -1201,7 +1201,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains($styleAttribute, $subject->render());
+        self::assertContains($styleAttribute, $subject->render());
     }
 
     /**
@@ -1216,7 +1216,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContains('style="' . $cssDeclarations . ' ' . $styleAttributeValue . '"', $subject->render());
+        self::assertContains('style="' . $cssDeclarations . ' ' . $styleAttributeValue . '"', $subject->render());
     }
 
     /**
@@ -1228,7 +1228,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p{color:blue;}html{color:red;}');
 
-        static::assertContains('<html style="color: red;">', $subject->render());
+        self::assertContains('<html style="color: red;">', $subject->render());
     }
 
     /**
@@ -1240,7 +1240,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('style="color: #ccc;"', $subject->render());
+        self::assertContains('style="color: #ccc;"', $subject->render());
     }
 
     /**
@@ -1252,7 +1252,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('html {mArGiN:0 2pX;}');
 
-        static::assertContains('style="margin: 0 2pX;"', $subject->render());
+        self::assertContains('style="margin: 0 2pX;"', $subject->render());
     }
 
     /**
@@ -1265,7 +1265,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p {' . $cssDeclaration . '}');
 
-        static::assertContains('<p style="' . $cssDeclaration . '">target</p>', $subject->render());
+        self::assertContains('<p style="' . $cssDeclaration . '">target</p>', $subject->render());
     }
 
     /**
@@ -1280,7 +1280,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('<p style="' . $cssDeclaration . '">target</p>', $subject->render());
+        self::assertContains('<p style="' . $cssDeclaration . '">target</p>', $subject->render());
     }
 
     /**
@@ -1292,7 +1292,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContains('<style', $subject->render());
+        self::assertNotContains('<style', $subject->render());
     }
 
     /**
@@ -1324,8 +1324,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('');
 
         $result = $subject->render();
-        static::assertContains('color: red', $result);
-        static::assertContains('background-color: blue', $result);
+        self::assertContains('color: red', $result);
+        self::assertContains('background-color: blue', $result);
     }
 
     /**
@@ -1341,8 +1341,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('');
 
         $result = $subject->render();
-        static::assertContains('color: red', $result);
-        static::assertContains('background-color: blue', $result);
+        self::assertContains('color: red', $result);
+        self::assertContains('background-color: blue', $result);
     }
 
     /**
@@ -1408,7 +1408,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($unneededCss);
 
-        static::assertNotContains($markerNotExpectedInHtml, $subject->render());
+        self::assertNotContains($markerNotExpectedInHtml, $subject->render());
     }
 
     /**
@@ -1424,7 +1424,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($unneededCss . ' body { color: green; }');
 
-        static::assertContains('<body style="color: green;">', $subject->render());
+        self::assertContains('<body style="color: green;">', $subject->render());
     }
 
     /**
@@ -1473,7 +1473,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCss($css, $subject->render());
+        self::assertContainsCss($css, $subject->render());
     }
 
     /**
@@ -1567,7 +1567,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($cssBefore . $rule1 . $cssBetween . $rule2 . $cssAfter);
 
-        static::assertContainsCss($rule1 . $rule2, $subject->render());
+        self::assertContainsCss($rule1 . $rule2, $subject->render());
     }
 
     /**
@@ -1581,7 +1581,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->removeAllowedMediaType('screen');
 
         $subject->inlineCss($css);
-        static::assertNotContains('@media', $subject->render());
+        self::assertNotContains('@media', $subject->render());
     }
 
     /**
@@ -1595,7 +1595,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addAllowedMediaType('braille');
 
         $subject->inlineCss($css);
-        static::assertContainsCss($css, $subject->render());
+        self::assertContainsCss($css, $subject->render());
     }
 
     /**
@@ -1607,7 +1607,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('@media all { html { some-property: value; } }');
 
-        static::assertContains('<!-- original content -->', $subject->render());
+        self::assertContains('<!-- original content -->', $subject->render());
     }
 
     /**
@@ -1620,7 +1620,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('@media all { html { some-property: value; } }');
 
-        static::assertContains('<style type="text/css">', $subject->render());
+        self::assertContains('<style type="text/css">', $subject->render());
     }
 
     /**
@@ -1634,7 +1634,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertRegExp('/<head>.*<style.*<\\/head>/s', $subject->render());
+        self::assertRegExp('/<head>.*<style.*<\\/head>/s', $subject->render());
     }
 
     /**
@@ -1648,7 +1648,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotRegExp('/<body>.*<style/s', $subject->render());
+        self::assertNotRegExp('/<body>.*<style/s', $subject->render());
     }
 
     /**
@@ -1703,7 +1703,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCss('<style type="text/css">' . $css . '</style>', $subject->render());
+        self::assertContainsCss('<style type="text/css">' . $css . '</style>', $subject->render());
     }
 
     /**
@@ -1723,7 +1723,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContains('<style type="text/css">' . $css . '</style>', $subject->render());
+        self::assertContains('<style type="text/css">' . $css . '</style>', $subject->render());
     }
 
     /**
@@ -1739,7 +1739,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContainsCss('<style type="text/css">' . $css . '</style>', $subject->render());
+        self::assertContainsCss('<style type="text/css">' . $css . '</style>', $subject->render());
     }
 
     /**
@@ -1755,7 +1755,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertNotContains('style=', $subject->render());
+        self::assertNotContains('style=', $subject->render());
     }
 
     /**
@@ -1789,7 +1789,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertNotContainsCss($css, $subject->render());
+        self::assertNotContainsCss($css, $subject->render());
     }
 
     /**
@@ -1805,7 +1805,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertNotContains('style=', $subject->render());
+        self::assertNotContains('style=', $subject->render());
     }
 
     /**
@@ -1821,7 +1821,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContainsCss($css, $subject->render());
+        self::assertNotContainsCss($css, $subject->render());
     }
 
     /**
@@ -1837,7 +1837,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContains('style=', $subject->render());
+        self::assertNotContains('style=', $subject->render());
     }
 
     /**
@@ -1850,8 +1850,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('@media screen {} @media tv { h1 { color: red; } }');
 
         $result = $subject->render();
-        static::assertNotContains('style=', $result);
-        static::assertNotContains('@media screen', $result);
+        self::assertNotContains('style=', $result);
+        self::assertNotContains('@media screen', $result);
     }
 
     /**
@@ -1864,8 +1864,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('@media screen { } @media tv { h1 { color: red; } }');
 
         $result = $subject->render();
-        static::assertNotContains('style=', $result);
-        static::assertNotContains('@media screen', $result);
+        self::assertNotContains('style=', $result);
+        self::assertNotContains('@media screen', $result);
     }
 
     /**
@@ -1892,7 +1892,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('@media ' . $emptyRuleMediaType . ' {} @media all { h1 { color: red; } }');
 
-        static::assertContainsCss('@media all { h1 { color: red; } }', $subject->render());
+        self::assertContainsCss('@media all { h1 { color: red; } }', $subject->render());
     }
 
     /**
@@ -1908,7 +1908,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('@media ' . $emptyRuleMediaType . ' {} @media speech { h1 { color: red; } }');
 
-        static::assertNotContains('@media', $subject->render());
+        self::assertNotContains('@media', $subject->render());
     }
 
     /**
@@ -2080,7 +2080,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCss($css, $subject->render());
+        self::assertContainsCss($css, $subject->render());
     }
 
     /**
@@ -2092,7 +2092,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p:hover, a:hover { color: green; }');
 
-        static::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $subject->render());
+        self::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $subject->render());
     }
 
     /**
@@ -2105,8 +2105,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('p, a:hover { color: green; }');
 
         $result = $subject->render();
-        static::assertContains('<p style="color: green;">', $result);
-        static::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $result);
+        self::assertContains('<p style="color: green;">', $result);
+        self::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $result);
     }
 
     /**
@@ -2139,7 +2139,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             . ' { h1 { color: red; } }'
         );
 
-        static::assertContains('<h1 style="color: green;">', $subject->render());
+        self::assertContains('<h1 style="color: green;">', $subject->render());
     }
 
     /**
@@ -2159,7 +2159,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
             . ' { h1 { color: red; } } h1 { font-size: 24px; }'
         );
 
-        static::assertContains('<h1 style="color: green; font-size: 24px;">', $subject->render());
+        self::assertContains('<h1 style="color: green; font-size: 24px;">', $subject->render());
     }
 
     /**
@@ -2174,7 +2174,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('<html style="' . $styleAttributeValue . '">', $subject->render());
+        self::assertContains('<html style="' . $styleAttributeValue . '">', $subject->render());
     }
 
     /**
@@ -2190,7 +2190,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContains('style=', $subject->render());
+        self::assertNotContains('style=', $subject->render());
     }
 
     /**
@@ -2207,7 +2207,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('<p style="' . $styleAttributeValue . '">', $subject->render());
+        self::assertContains('<p style="' . $styleAttributeValue . '">', $subject->render());
     }
 
     /**
@@ -2220,7 +2220,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContains('<html style', $subject->render());
+        self::assertNotContains('<html style', $subject->render());
     }
 
     /**
@@ -2237,7 +2237,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('<p style="' . $styleAttributeValue . '">', $subject->render());
+        self::assertContains('<p style="' . $styleAttributeValue . '">', $subject->render());
     }
 
     /**
@@ -2255,7 +2255,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('');
 
         $result = $subject->render();
-        static::assertContains('<p style="padding-bottom: 1px; padding-top: 0; text-align: center;">', $result);
+        self::assertContains('<p style="padding-bottom: 1px; padding-top: 0; text-align: center;">', $result);
     }
 
     /**
@@ -2272,7 +2272,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 0; padding-TOP: 0; PADDING-bottom: 1PX;}');
 
-        static::assertContains(
+        self::assertContains(
             '<p style="margin: 0; padding-bottom: 3px; padding-top: 1px; text-align: center;">',
             $subject->render()
         );
@@ -2290,7 +2290,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px; padding-bottom:0;}');
 
-        static::assertContains('<p style="margin: 0; padding-bottom: 1px; text-align: center;">', $subject->render());
+        self::assertContains('<p style="margin: 0; padding-bottom: 1px; text-align: center;">', $subject->render());
     }
 
     /**
@@ -2302,7 +2302,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('div.foo { display: none; }');
 
-        static::assertNotContains('<div class="foo"></div>', $subject->render());
+        self::assertNotContains('<div class="foo"></div>', $subject->render());
     }
 
     /**
@@ -2317,7 +2317,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertNotContains('<div', $subject->render());
+        self::assertNotContains('<div', $subject->render());
     }
 
     /**
@@ -2330,7 +2330,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->disableInvisibleNodeRemoval();
         $subject->inlineCss('div.foo { display: none; }');
 
-        static::assertContains('<div class="foo" style="display: none;">', $subject->render());
+        self::assertContains('<div class="foo" style="display: none;">', $subject->render());
     }
 
     /**
@@ -2342,7 +2342,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('@media only screen and (max-width: 480px) { body { color: #ffffff } /* some comment */ }');
 
-        static::assertContains('@media only screen and (max-width: 480px)', $subject->render());
+        self::assertContains('@media only screen and (max-width: 480px)', $subject->render());
     }
 
     /**
@@ -2436,7 +2436,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      */
     public function documentTypeAndSelfClosingTagDataProvider()
     {
-        return static::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
+        return self::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
     }
 
     /**
@@ -2459,7 +2459,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
+        self::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
     }
 
     /**
@@ -2478,7 +2478,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
+        self::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
     }
 
     /**
@@ -2497,7 +2497,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertNotContains('</' . $tagName, $result);
+        self::assertNotContains('</' . $tagName, $result);
     }
 
     /**
@@ -2509,7 +2509,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body><p></p></body>', $result);
+        self::assertContains('<body><p></p></body>', $result);
     }
 
     /**
@@ -2521,7 +2521,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertSame(
+        self::assertSame(
             $this->html5DocumentType . "\n" .
             "<html>\n" .
             '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . "\n" .
@@ -2540,7 +2540,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertSame('<p></p>', $result);
+        self::assertSame('<p></p>', $result);
     }
 
     /**
@@ -2552,7 +2552,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertSame('<p></p>', $result);
+        self::assertSame('<p></p>', $result);
     }
 
     /**
@@ -2582,7 +2582,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px !important; }');
 
-        static::assertContains('<p style="margin: 1px;">', $subject->render());
+        self::assertContains('<p style="margin: 1px;">', $subject->render());
     }
 
     /**
@@ -2594,7 +2594,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px !important; }');
 
-        static::assertContains('<p style="text-align: center; margin: 1px;">', $subject->render());
+        self::assertContains('<p style="text-align: center; margin: 1px;">', $subject->render());
     }
 
     /**
@@ -2606,7 +2606,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px !ImPorTant; }');
 
-        static::assertContains('<p style="margin: 1px !ImPorTant;">', $subject->render());
+        self::assertContains('<p style="margin: 1px !ImPorTant;">', $subject->render());
     }
 
     /**
@@ -2618,7 +2618,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px !important; } p { margin: 2px !important; }');
 
-        static::assertContains('<p style="margin: 2px;">', $subject->render());
+        self::assertContains('<p style="margin: 2px;">', $subject->render());
     }
 
     /**
@@ -2630,7 +2630,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px; } p { margin: 2px; }');
 
-        static::assertContains('<p style="margin: 2px;">', $subject->render());
+        self::assertContains('<p style="margin: 2px;">', $subject->render());
     }
 
     /**
@@ -2642,7 +2642,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px !important; } p { margin: 2px; }');
 
-        static::assertContains('<p style="margin: 1px;">', $subject->render());
+        self::assertContains('<p style="margin: 1px;">', $subject->render());
     }
 
     /**
@@ -2654,7 +2654,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin-top: 1px; } p { margin: 2px; }');
 
-        static::assertContains('<p style="margin-top: 1px; margin: 2px;">', $subject->render());
+        self::assertContains('<p style="margin-top: 1px; margin: 2px;">', $subject->render());
     }
 
     /**
@@ -2666,7 +2666,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin-top: 1px; } p { margin: 2px; } p { margin-top: 3px; }');
 
-        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $subject->render());
+        self::assertContains('<p style="margin: 2px; margin-top: 3px;">', $subject->render());
     }
 
     /**
@@ -2678,7 +2678,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin-top: 1px; } p { margin: 2px; }');
 
-        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $subject->render());
+        self::assertContains('<p style="margin: 2px; margin-top: 3px;">', $subject->render());
     }
 
     /**
@@ -2690,7 +2690,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin-top: 1px; }');
 
-        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $subject->render());
+        self::assertContains('<p style="margin: 2px; margin-top: 3px;">', $subject->render());
     }
 
     /**
@@ -2703,7 +2703,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($uselessQuery);
 
-        static::assertNotContains('@media', $subject->render());
+        self::assertNotContains('@media', $subject->render());
     }
 
     /**
@@ -2716,7 +2716,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($usefulQuery);
 
-        static::assertContainsCss($usefulQuery, $subject->render());
+        self::assertContainsCss($usefulQuery, $subject->render());
     }
 
     /**
@@ -2728,7 +2728,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('p { margin: 1px !important; padding: 1px;}');
 
-        static::assertContains('<p style="padding: 1px; text-align: center; margin: 2px;">', $subject->render());
+        self::assertContains('<p style="padding: 1px; text-align: center; margin: 2px;">', $subject->render());
     }
 
     /**
@@ -2741,7 +2741,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addExcludedSelector('p.x');
         $subject->inlineCss('p { margin: 0; }');
 
-        static::assertContains('<p class="x"></p>', $subject->render());
+        self::assertContains('<p class="x"></p>', $subject->render());
     }
 
     /**
@@ -2754,7 +2754,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addExcludedSelector(' p.x ');
         $subject->inlineCss('p { margin: 0; }');
 
-        static::assertContains('<p class="x"></p>', $subject->render());
+        self::assertContains('<p class="x"></p>', $subject->render());
     }
 
     /**
@@ -2767,7 +2767,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addExcludedSelector('p.x');
         $subject->inlineCss('p { margin: 0; }');
 
-        static::assertContains('<p style="margin: 0;"></p>', $subject->render());
+        self::assertContains('<p style="margin: 0;"></p>', $subject->render());
     }
 
     /**
@@ -2781,7 +2781,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->removeExcludedSelector('p.x');
         $subject->inlineCss('p { margin: 0; }');
 
-        static::assertContains('<p class="x" style="margin: 0;"></p>', $subject->render());
+        self::assertContains('<p class="x" style="margin: 0;"></p>', $subject->render());
     }
 
     /**
@@ -2809,7 +2809,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->addExcludedSelector('..p');
         $subject->inlineCss('');
 
-        static::assertContains('<p class="x"></p>', $subject->render());
+        self::assertContains('<p class="x"></p>', $subject->render());
     }
 
     /**
@@ -2826,9 +2826,9 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $subject->inlineCss('p { color: red };');
 
         $result = $subject->render();
-        static::assertContains('<p class="x"></p>', $result);
-        static::assertContains('<p class="y" style="color: red;"></p>', $result);
-        static::assertContains('<p class="z"></p>', $result);
+        self::assertContains('<p class="x"></p>', $result);
+        self::assertContains('<p class="y" style="color: red;"></p>', $result);
+        self::assertContains('<p class="z"></p>', $result);
     }
 
     /**
@@ -2841,7 +2841,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($emptyQuery);
 
-        static::assertNotContains('@media', $subject->render());
+        self::assertNotContains('@media', $subject->render());
     }
 
     /**
@@ -2862,7 +2862,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCssCount(1, $css, $subject->render());
+        self::assertContainsCssCount(1, $css, $subject->render());
     }
 
     /**
@@ -2883,7 +2883,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCssCount(1, $css, $subject->render());
+        self::assertContainsCssCount(1, $css, $subject->render());
     }
 
     /**
@@ -2908,7 +2908,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCssCount(1, $css, $subject->render());
+        self::assertContainsCssCount(1, $css, $subject->render());
     }
 
     /**
@@ -2944,7 +2944,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('html {' . $styleRule . '}');
 
-        static::assertContains('<html style="' . $styleRule . '">', $subject->render());
+        self::assertContains('<html style="' . $styleRule . '">', $subject->render());
     }
 
     /**
@@ -2956,7 +2956,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('div:last-child::after {float: right;}');
 
-        static::assertContains('<div></div>', $subject->render());
+        self::assertContains('<div></div>', $subject->render());
     }
 
     /**
@@ -2970,7 +2970,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('<p style="padding: 10px; padding-left: 20px;">', $subject->render());
+        self::assertContains('<p style="padding: 10px; padding-left: 20px;">', $subject->render());
     }
 
     /**
@@ -3038,7 +3038,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        static::assertContains('<p style="' . $expectedStyleAttributeContent . '">', $subject->render());
+        self::assertContains('<p style="' . $expectedStyleAttributeContent . '">', $subject->render());
     }
 
     /**
@@ -3065,6 +3065,6 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss($css);
 
-        static::assertContainsCss($css, $subject->render());
+        self::assertContainsCss($css, $subject->render());
     }
 }

--- a/tests/Unit/Emogrifier/CssConcatenatorTest.php
+++ b/tests/Unit/Emogrifier/CssConcatenatorTest.php
@@ -31,7 +31,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->subject->getCss();
 
-        static::assertSame('', $result);
+        self::assertSame('', $result);
     }
 
     /**
@@ -43,7 +43,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->getCss();
 
-        static::assertSame('p{color: green;}', $result);
+        self::assertSame('p{color: green;}', $result);
     }
 
     /**
@@ -55,7 +55,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->getCss();
 
-        static::assertSame('@media screen{p{color: green;}}', $result);
+        self::assertSame('@media screen{p{color: green;}}', $result);
     }
 
     /**
@@ -93,7 +93,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $expectedResult = \implode(',', $selectors1) . '{color: green;font-size: 16px;}';
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     /**
@@ -106,7 +106,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->getCss();
 
-        static::assertSame('p{color: green;font-size: 16px}', $result);
+        self::assertSame('p{color: green;font-size: 16px}', $result);
     }
 
     /**
@@ -174,7 +174,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $expectedResult = \implode(',', $combinedSelectors) . '{color: green;}';
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     /**
@@ -195,7 +195,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         $expectedResult = \implode(',', $selectors1) . '{color: green;}'
             . \implode(',', $selectors2) . '{font-size: 16px;}';
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     /**
@@ -208,7 +208,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->getCss();
 
-        static::assertSame('@media screen{p{color: green;}ul{font-size: 16px;}}', $result);
+        self::assertSame('@media screen{p{color: green;}ul{font-size: 16px;}}', $result);
     }
 
     /**
@@ -228,7 +228,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $expectedResult = '@media screen{' . \implode(',', $selectors1) . '{color: green;font-size: 16px;}}';
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     /**
@@ -252,7 +252,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $expectedResult = '@media screen{' . \implode(',', $combinedSelectors) . '{color: green;}}';
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     /**
@@ -265,7 +265,7 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->getCss();
 
-        static::assertSame('@media screen{p{color: green;}}@media print{p{color: green;}}', $result);
+        self::assertSame('@media screen{p{color: green;}}@media print{p{color: green;}}', $result);
     }
 
     /**
@@ -312,6 +312,6 @@ class CssConcatenatorTest extends \PHPUnit_Framework_TestCase
         }
         $expectedResult = $expectedRule1Css . '.intervening{-intervening-property: 0;}' . $expectedRule2Css;
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 }

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -17,7 +17,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function fixtureIsAbstractHtmlProcessor()
     {
-        static::assertInstanceOf(AbstractHtmlProcessor::class, new TestingHtmlProcessor('<html></html>'));
+        self::assertInstanceOf(AbstractHtmlProcessor::class, new TestingHtmlProcessor('<html></html>'));
     }
 
     /**
@@ -38,7 +38,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $subject = new TestingHtmlProcessor($rawHtml);
 
-        static::assertSame($formattedHtml, $subject->render());
+        self::assertSame($formattedHtml, $subject->render());
     }
 
     /**
@@ -94,7 +94,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
         $subject = new TestingHtmlProcessor($input);
         $result = $subject->render();
 
-        static::assertContains($expectedHtml, $result);
+        self::assertContains($expectedHtml, $result);
     }
 
     /**
@@ -124,7 +124,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<html>', $result);
+        self::assertContains('<html>', $result);
     }
 
     /**
@@ -152,7 +152,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<head>', $result);
+        self::assertContains('<head>', $result);
     }
 
     /**
@@ -180,7 +180,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body>', $result);
+        self::assertContains('<body>', $result);
     }
 
     /**
@@ -192,7 +192,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body><p>Hello</p></body>', $result);
+        self::assertContains('<body><p>Hello</p></body>', $result);
     }
 
     /**
@@ -222,7 +222,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains($codeNotToBeChanged, $result);
+        self::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -234,7 +234,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<!DOCTYPE html>', $result);
+        self::assertContains('<!DOCTYPE html>', $result);
     }
 
     /**
@@ -273,7 +273,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains($documentType, $result);
+        self::assertContains($documentType, $result);
     }
 
     /**
@@ -285,7 +285,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
+        self::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
     }
 
     /**
@@ -299,7 +299,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
         $result = $subject->render();
 
         $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
-        static::assertSame(1, $numberOfContentTypeMetaTags);
+        self::assertSame(1, $numberOfContentTypeMetaTags);
     }
 
     /**
@@ -393,7 +393,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function documentTypeAndSelfClosingTagDataProvider()
     {
-        return static::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
+        return self::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
     }
 
     /**
@@ -416,7 +416,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
+        self::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
     }
 
     /**
@@ -435,7 +435,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
+        self::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
     }
 
     /**
@@ -454,7 +454,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->render();
 
-        static::assertNotContains('</' . $tagName, $result);
+        self::assertNotContains('</' . $tagName, $result);
     }
 
     /**
@@ -466,7 +466,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertSame('', $result);
+        self::assertSame('', $result);
     }
 
     /**
@@ -479,7 +479,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertSame($bodyContent, $result);
+        self::assertSame($bodyContent, $result);
     }
 
     /**
@@ -498,7 +498,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $result = $subject->renderBodyContent();
 
-        static::assertNotContains('</' . $tagName, $result);
+        self::assertNotContains('</' . $tagName, $result);
     }
 
     /**
@@ -508,7 +508,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $subject = new TestingHtmlProcessor('<html></html>');
 
-        static::assertInstanceOf(\DOMDocument::class, $subject->getDomDocument());
+        self::assertInstanceOf(\DOMDocument::class, $subject->getDomDocument());
     }
 
     /**
@@ -545,7 +545,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $voidElements = $domDocument->getElementsByTagName($tagName);
         foreach ($voidElements as $element) {
-            static::assertFalse($element->hasChildNodes());
+            self::assertFalse($element->hasChildNodes());
         }
     }
 }

--- a/tests/Unit/Emogrifier/HtmlProcessor/CssToAttributeConverterTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/CssToAttributeConverterTest.php
@@ -17,7 +17,7 @@ class CssToAttributeConverterTest extends \PHPUnit_Framework_TestCase
      */
     public function classIsAbstractHtmlProcessor()
     {
-        static::assertInstanceOf(AbstractHtmlProcessor::class, new CssToAttributeConverter('<html></html>'));
+        self::assertInstanceOf(AbstractHtmlProcessor::class, new CssToAttributeConverter('<html></html>'));
     }
 
     /**
@@ -28,7 +28,7 @@ class CssToAttributeConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html style="text-align: right;"></html>';
         $subject = new CssToAttributeConverter($html);
 
-        static::assertContains('<html style="text-align: right;">', $subject->render());
+        self::assertContains('<html style="text-align: right;">', $subject->render());
     }
 
     /**
@@ -39,7 +39,7 @@ class CssToAttributeConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html style="text-align: right;"></html>';
         $subject = new CssToAttributeConverter($html);
 
-        static::assertSame($subject, $subject->convertCssToVisualAttributes());
+        self::assertSame($subject, $subject->convertCssToVisualAttributes());
     }
 
     /**
@@ -122,7 +122,7 @@ class CssToAttributeConverterTest extends \PHPUnit_Framework_TestCase
         $subject->convertCssToVisualAttributes();
         $html = $subject->render();
 
-        static::assertContains($attributes, $html);
+        self::assertContains($attributes, $html);
     }
 
     /**
@@ -161,6 +161,6 @@ class CssToAttributeConverterTest extends \PHPUnit_Framework_TestCase
         $subject->convertCssToVisualAttributes();
         $html = $subject->render();
 
-        static::assertContains($body, $html);
+        self::assertContains($body, $html);
     }
 }

--- a/tests/Unit/Emogrifier/HtmlProcessor/HtmlNormalizerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/HtmlNormalizerTest.php
@@ -17,6 +17,6 @@ class HtmlNormalizerTest extends \PHPUnit_Framework_TestCase
      */
     public function classIsAbstractHtmlProcessor()
     {
-        static::assertInstanceOf(AbstractHtmlProcessor::class, new HtmlNormalizer('<html></html>'));
+        self::assertInstanceOf(AbstractHtmlProcessor::class, new HtmlNormalizer('<html></html>'));
     }
 }

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -59,7 +59,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $subject = new Emogrifier('<html></html>');
 
-        static::assertInstanceOf(\DOMDocument::class, $subject->getDomDocument());
+        self::assertInstanceOf(\DOMDocument::class, $subject->getDomDocument());
     }
 
     /**
@@ -150,7 +150,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<html>', $result);
+        self::assertContains('<html>', $result);
     }
 
     /**
@@ -178,7 +178,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<head>', $result);
+        self::assertContains('<head>', $result);
     }
 
     /**
@@ -206,7 +206,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body>', $result);
+        self::assertContains('<body>', $result);
     }
 
     /**
@@ -218,7 +218,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body><p>Hello</p></body>', $result);
+        self::assertContains('<body><p>Hello</p></body>', $result);
     }
 
     /**
@@ -248,7 +248,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($codeNotToBeChanged, $result);
+        self::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -265,7 +265,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        static::assertContains($codeNotToBeChanged, $result);
+        self::assertContains($codeNotToBeChanged, $result);
     }
 
     /**
@@ -277,7 +277,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<!DOCTYPE html>', $result);
+        self::assertContains('<!DOCTYPE html>', $result);
     }
 
     /**
@@ -312,7 +312,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($documentType, $result);
+        self::assertContains($documentType, $result);
     }
 
     /**
@@ -324,7 +324,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
+        self::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
     }
 
     /**
@@ -338,7 +338,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $result = $this->subject->emogrify();
 
         $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
-        static::assertSame(1, $numberOfContentTypeMetaTags);
+        self::assertSame(1, $numberOfContentTypeMetaTags);
     }
 
     /**
@@ -366,7 +366,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<wbr', $result);
+        self::assertNotContains('<wbr', $result);
     }
 
     /**
@@ -384,7 +384,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->removeUnprocessableHtmlTag('wbr');
         $result = $this->subject->emogrify();
 
-        static::assertSame($numberOfWbrTags, \substr_count($result, '<wbr'));
+        self::assertSame($numberOfWbrTags, \substr_count($result, '<wbr'));
     }
 
     /**
@@ -397,7 +397,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<p>', $result);
+        self::assertNotContains('<p>', $result);
     }
 
     /**
@@ -410,7 +410,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p>', $result);
+        self::assertContains('<p>', $result);
     }
 
     /**
@@ -424,7 +424,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->removeUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p>', $result);
+        self::assertContains('<p>', $result);
     }
 
     /**
@@ -725,12 +725,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
-        $this->subject->setHtml(static::COMMON_TEST_HTML);
+        $this->subject->setHtml(self::COMMON_TEST_HTML);
         $this->subject->setCss(\sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
+        self::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
     }
 
     /**
@@ -815,12 +815,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
-        $this->subject->setHtml(static::COMMON_TEST_HTML);
+        $this->subject->setHtml(self::COMMON_TEST_HTML);
         $this->subject->setCss(\sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
+        self::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $result);
     }
 
     /**
@@ -912,7 +912,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $lessSpecificSelector,
         $moreSpecificSelector
     ) {
-        $this->subject->setHtml(static::COMMON_TEST_HTML);
+        $this->subject->setHtml(self::COMMON_TEST_HTML);
         $this->subject->setCss(
             $lessSpecificSelector . ' { color: red; } ' .
             $moreSpecificSelector . ' { color: green; } ' .
@@ -922,7 +922,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $result);
+        self::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $result);
     }
 
     /**
@@ -995,7 +995,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $selector1,
         $selector2
     ) {
-        $this->subject->setHtml(static::COMMON_TEST_HTML);
+        $this->subject->setHtml(self::COMMON_TEST_HTML);
         $this->subject->setCss(
             $selector1 . ' { color: red; } ' .
             $selector2 . ' { color: green; } ' .
@@ -1005,7 +1005,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $result);
+        self::assertContains($matchedTagPart . ' style="color: green; background-color: green;"', $result);
     }
 
     /**
@@ -1045,7 +1045,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<html style="color: #000;">', $result);
+        self::assertContains('<html style="color: #000;">', $result);
     }
 
     /**
@@ -1098,7 +1098,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<html style="' . $expectedStyleAttributeContent . '">', $result);
+        self::assertContains('<html style="' . $expectedStyleAttributeContent . '">', $result);
     }
 
     /**
@@ -1128,7 +1128,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<html style="">', $result);
+        self::assertContains('<html style="">', $result);
     }
 
     /**
@@ -1141,7 +1141,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains($styleAttribute, $result);
+        self::assertContains($styleAttribute, $result);
     }
 
     /**
@@ -1157,7 +1157,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('style="' . $cssDeclarations . ' ' . $styleAttributeValue . '"', $result);
+        self::assertContains('style="' . $cssDeclarations . ' ' . $styleAttributeValue . '"', $result);
     }
 
     /**
@@ -1170,7 +1170,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<html style="color: red;">', $result);
+        self::assertContains('<html style="color: red;">', $result);
     }
 
     /**
@@ -1182,7 +1182,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('style="color: #ccc;"', $result);
+        self::assertContains('style="color: #ccc;"', $result);
     }
 
     /**
@@ -1195,7 +1195,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('style="margin: 0 2pX;"', $result);
+        self::assertContains('style="margin: 0 2pX;"', $result);
     }
 
     /**
@@ -1209,7 +1209,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="' . $cssDeclaration . '">target</p>', $result);
+        self::assertContains('<p style="' . $cssDeclaration . '">target</p>', $result);
     }
 
     /**
@@ -1224,7 +1224,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="' . $cssDeclaration . '">target</p>', $result);
+        self::assertContains('<p style="' . $cssDeclaration . '">target</p>', $result);
     }
 
     /**
@@ -1236,7 +1236,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<style', $result);
+        self::assertNotContains('<style', $result);
     }
 
     /**
@@ -1269,8 +1269,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->subject->emogrify();
 
-        static::assertContains('color: red', $html);
-        static::assertContains('background-color: blue', $html);
+        self::assertContains('color: red', $html);
+        self::assertContains('background-color: blue', $html);
     }
 
     /**
@@ -1286,8 +1286,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $subject->setHtml($html);
 
         $html = $subject->emogrify();
-        static::assertContains('color: red', $html);
-        static::assertContains('background-color: blue', $html);
+        self::assertContains('color: red', $html);
+        self::assertContains('background-color: blue', $html);
     }
 
     /**
@@ -1354,7 +1354,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains($markerNotExpectedInHtml, $result);
+        self::assertNotContains($markerNotExpectedInHtml, $result);
     }
 
     /**
@@ -1371,7 +1371,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body style="color: green;">', $result);
+        self::assertContains('<body style="color: green;">', $result);
     }
 
     /**
@@ -1421,7 +1421,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss($css, $result);
+        self::assertContainsCss($css, $result);
     }
 
     /**
@@ -1516,7 +1516,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss($rule1 . $rule2, $result);
+        self::assertContainsCss($rule1 . $rule2, $result);
     }
 
     /**
@@ -1531,7 +1531,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('@media', $result);
+        self::assertNotContains('@media', $result);
     }
 
     /**
@@ -1546,7 +1546,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss($css, $result);
+        self::assertContainsCss($css, $result);
     }
 
     /**
@@ -1559,7 +1559,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<!-- original content -->', $result);
+        self::assertContains('<!-- original content -->', $result);
     }
 
     /**
@@ -1573,7 +1573,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<style type="text/css">', $result);
+        self::assertContains('<style type="text/css">', $result);
     }
 
     /**
@@ -1587,7 +1587,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertRegExp('/<head>.*<style.*<\\/head>/s', $result);
+        self::assertRegExp('/<head>.*<style.*<\\/head>/s', $result);
     }
 
     /**
@@ -1601,7 +1601,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotRegExp('/<body>.*<style/s', $result);
+        self::assertNotRegExp('/<body>.*<style/s', $result);
     }
 
     /**
@@ -1657,7 +1657,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss('<style type="text/css">' . $css . '</style>', $result);
+        self::assertContainsCss('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1679,7 +1679,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<style type="text/css">' . $css . '</style>', $result);
+        self::assertContains('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1695,7 +1695,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss('<style type="text/css">' . $css . '</style>', $result);
+        self::assertContainsCss('<style type="text/css">' . $css . '</style>', $result);
     }
 
     /**
@@ -1712,7 +1712,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style=', $result);
+        self::assertNotContains('style=', $result);
     }
 
     /**
@@ -1747,7 +1747,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContainsCss($css, $result);
+        self::assertNotContainsCss($css, $result);
     }
 
     /**
@@ -1764,7 +1764,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style=', $result);
+        self::assertNotContains('style=', $result);
     }
 
     /**
@@ -1780,7 +1780,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContainsCss($css, $result);
+        self::assertNotContainsCss($css, $result);
     }
 
     /**
@@ -1796,7 +1796,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style=', $result);
+        self::assertNotContains('style=', $result);
     }
 
     /**
@@ -1809,8 +1809,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style=', $result);
-        static::assertNotContains('@media screen', $result);
+        self::assertNotContains('style=', $result);
+        self::assertNotContains('@media screen', $result);
     }
 
     /**
@@ -1823,8 +1823,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style=', $result);
-        static::assertNotContains('@media screen', $result);
+        self::assertNotContains('style=', $result);
+        self::assertNotContains('@media screen', $result);
     }
 
     /**
@@ -1852,7 +1852,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss('@media all { h1 { color: red; } }', $result);
+        self::assertContainsCss('@media all { h1 { color: red; } }', $result);
     }
 
     /**
@@ -1869,7 +1869,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('@media', $result);
+        self::assertNotContains('@media', $result);
     }
 
     /**
@@ -2046,7 +2046,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss($css, $result);
+        self::assertContainsCss($css, $result);
     }
 
     /**
@@ -2059,7 +2059,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $result);
+        self::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $result);
     }
 
     /**
@@ -2072,8 +2072,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="color: green;">', $result);
-        static::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $result);
+        self::assertContains('<p style="color: green;">', $result);
+        self::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $result);
     }
 
     /**
@@ -2107,7 +2107,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<h1 style="color: green;">', $result);
+        self::assertContains('<h1 style="color: green;">', $result);
     }
 
     /**
@@ -2128,7 +2128,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<h1 style="color: green; font-size: 24px;">', $result);
+        self::assertContains('<h1 style="color: green; font-size: 24px;">', $result);
     }
 
     /**
@@ -2141,7 +2141,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<html style="' . $styleAttributeValue . '">', $result);
+        self::assertContains('<html style="' . $styleAttributeValue . '">', $result);
     }
 
     /**
@@ -2155,7 +2155,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('style=', $result);
+        self::assertNotContains('style=', $result);
     }
 
     /**
@@ -2172,7 +2172,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="' . $styleAttributeValue . '">', $result);
+        self::assertContains('<p style="' . $styleAttributeValue . '">', $result);
     }
 
     /**
@@ -2185,7 +2185,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<html style', $result);
+        self::assertNotContains('<html style', $result);
     }
 
     /**
@@ -2202,7 +2202,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="' . $styleAttributeValue . '">', $result);
+        self::assertContains('<p style="' . $styleAttributeValue . '">', $result);
     }
 
     /**
@@ -2219,7 +2219,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="padding-bottom: 1px; padding-top: 0; text-align: center;">', $result);
+        self::assertContains('<p style="padding-bottom: 1px; padding-top: 0; text-align: center;">', $result);
     }
 
     /**
@@ -2237,7 +2237,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
+        self::assertContains(
             '<p style="margin: 0; padding-bottom: 3px; padding-top: 1px; text-align: center;">',
             $result
         );
@@ -2256,7 +2256,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 0; padding-bottom: 1px; text-align: center;">', $result);
+        self::assertContains('<p style="margin: 0; padding-bottom: 1px; text-align: center;">', $result);
     }
 
     /**
@@ -2269,7 +2269,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<div class="foo"></div>', $result);
+        self::assertNotContains('<div class="foo"></div>', $result);
     }
 
     /**
@@ -2284,7 +2284,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('<div', $result);
+        self::assertNotContains('<div', $result);
     }
 
     /**
@@ -2298,7 +2298,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->disableInvisibleNodeRemoval();
         $result = $this->subject->emogrify();
 
-        static::assertContains('<div class="foo" style="display: none;">', $result);
+        self::assertContains('<div class="foo" style="display: none;">', $result);
     }
 
     /**
@@ -2313,7 +2313,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('@media only screen and (max-width: 480px)', $result);
+        self::assertContains('@media only screen and (max-width: 480px)', $result);
     }
 
     /**
@@ -2410,7 +2410,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function documentTypeAndSelfClosingTagDataProvider()
     {
-        return static::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
+        return self::joinDatasets($this->documentTypeDataProvider(), $this->selfClosingTagDataProvider());
     }
 
     /**
@@ -2436,7 +2436,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
+        self::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
     }
 
     /**
@@ -2457,7 +2457,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
+        self::assertContains('<body>' . $htmlWithNonXmlSelfClosingTags . '</body>', $result);
     }
 
     /**
@@ -2477,7 +2477,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('</' . $tagName, $result);
+        self::assertNotContains('</' . $tagName, $result);
     }
 
     /**
@@ -2499,7 +2499,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $voidElements = $domDocument->getElementsByTagName($tagName);
         foreach ($voidElements as $element) {
-            static::assertFalse($element->hasChildNodes());
+            self::assertFalse($element->hasChildNodes());
         }
     }
 
@@ -2512,7 +2512,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<body><p></p></body>', $result);
+        self::assertContains('<body><p></p></body>', $result);
     }
 
     /**
@@ -2524,7 +2524,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertSame(
+        self::assertSame(
             $this->html5DocumentType . "\n" .
             "<html>\n" .
             '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . "\n" .
@@ -2543,7 +2543,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        static::assertSame('<p></p>', $result);
+        self::assertSame('<p></p>', $result);
     }
 
     /**
@@ -2555,7 +2555,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        static::assertSame('<p></p>', $result);
+        self::assertSame('<p></p>', $result);
     }
 
     /**
@@ -2575,7 +2575,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrifyBodyContent();
 
-        static::assertNotContains('</' . $tagName, $result);
+        self::assertNotContains('</' . $tagName, $result);
     }
 
     /**
@@ -2605,7 +2605,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 1px;">', $result);
+        self::assertContains('<p style="margin: 1px;">', $result);
     }
 
     /**
@@ -2618,7 +2618,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="text-align: center; margin: 1px;">', $result);
+        self::assertContains('<p style="text-align: center; margin: 1px;">', $result);
     }
 
     /**
@@ -2631,7 +2631,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 1px !ImPorTant;">', $result);
+        self::assertContains('<p style="margin: 1px !ImPorTant;">', $result);
     }
 
     /**
@@ -2644,7 +2644,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 2px;">', $result);
+        self::assertContains('<p style="margin: 2px;">', $result);
     }
 
     /**
@@ -2657,7 +2657,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 2px;">', $result);
+        self::assertContains('<p style="margin: 2px;">', $result);
     }
 
     /**
@@ -2670,7 +2670,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 1px;">', $result);
+        self::assertContains('<p style="margin: 1px;">', $result);
     }
 
     /**
@@ -2683,7 +2683,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin-top: 1px; margin: 2px;">', $result);
+        self::assertContains('<p style="margin-top: 1px; margin: 2px;">', $result);
     }
 
     /**
@@ -2696,7 +2696,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
+        self::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
     }
 
     /**
@@ -2709,7 +2709,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
+        self::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
     }
 
     /**
@@ -2722,7 +2722,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
+        self::assertContains('<p style="margin: 2px; margin-top: 3px;">', $result);
     }
 
     /**
@@ -2736,7 +2736,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('@media', $result);
+        self::assertNotContains('@media', $result);
     }
 
     /**
@@ -2750,7 +2750,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss($usefulQuery, $result);
+        self::assertContainsCss($usefulQuery, $result);
     }
 
     /**
@@ -2763,7 +2763,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="padding: 1px; text-align: center; margin: 2px;">', $result);
+        self::assertContains('<p style="padding: 1px; text-align: center; margin: 2px;">', $result);
     }
 
     /**
@@ -2777,7 +2777,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addExcludedSelector('p.x');
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p class="x"></p>', $result);
+        self::assertContains('<p class="x"></p>', $result);
     }
 
     /**
@@ -2791,7 +2791,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addExcludedSelector(' p.x ');
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p class="x"></p>', $result);
+        self::assertContains('<p class="x"></p>', $result);
     }
 
     /**
@@ -2805,7 +2805,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->addExcludedSelector('p.x');
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="margin: 0;"></p>', $result);
+        self::assertContains('<p style="margin: 0;"></p>', $result);
     }
 
     /**
@@ -2821,7 +2821,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p class="x" style="margin: 0;"></p>', $result);
+        self::assertContains('<p class="x" style="margin: 0;"></p>', $result);
     }
 
     /**
@@ -2851,7 +2851,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p class="x"></p>', $result);
+        self::assertContains('<p class="x"></p>', $result);
     }
 
     /**
@@ -2869,9 +2869,9 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p class="x"></p>', $result);
-        static::assertContains('<p class="y" style="color: red;"></p>', $result);
-        static::assertContains('<p class="z"></p>', $result);
+        self::assertContains('<p class="x"></p>', $result);
+        self::assertContains('<p class="y" style="color: red;"></p>', $result);
+        self::assertContains('<p class="z"></p>', $result);
     }
 
     /**
@@ -2885,7 +2885,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertNotContains('@media', $result);
+        self::assertNotContains('@media', $result);
     }
 
     /**
@@ -2907,7 +2907,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCssCount(1, $css, $result);
+        self::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2929,7 +2929,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCssCount(1, $css, $result);
+        self::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2955,7 +2955,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCssCount(1, $css, $result);
+        self::assertContainsCssCount(1, $css, $result);
     }
 
     /**
@@ -2992,7 +2992,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains(
+        self::assertContains(
             '<html style="' . $styleRule . '">',
             $result
         );
@@ -3085,7 +3085,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->enableCssToHtmlMapping();
         $html = $this->subject->emogrify();
 
-        static::assertRegExp('/<' . \preg_quote($tagName, '/') . '[^>]+' . \preg_quote($attributes, '/') . '/', $html);
+        self::assertRegExp('/<' . \preg_quote($tagName, '/') . '[^>]+' . \preg_quote($attributes, '/') . '/', $html);
     }
 
     /**
@@ -3142,7 +3142,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $this->subject->enableCssToHtmlMapping();
         $html = $this->subject->emogrify();
 
-        static::assertNotContains(
+        self::assertNotContains(
             $attribute . '=',
             $html
         );
@@ -3158,7 +3158,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->subject->emogrify();
 
-        static::assertNotContains(
+        self::assertNotContains(
             'align=',
             $html
         );
@@ -3174,7 +3174,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->subject->emogrify();
 
-        static::assertContains('<div></div>', $html);
+        self::assertContains('<div></div>', $html);
     }
 
     /**
@@ -3188,7 +3188,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="padding: 10px; padding-left: 20px;">', $result);
+        self::assertContains('<p style="padding: 10px; padding-left: 20px;">', $result);
     }
 
     /**
@@ -3200,7 +3200,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     private function assertHtmlStringContainsTagWithAttribute($html, $tagName, $attribute)
     {
-        static::assertTrue(
+        self::assertTrue(
             \preg_match('/<' . \preg_quote($tagName, '/') . '[^>]+' . \preg_quote($attribute, '/') . '/', $html) > 0
         );
     }
@@ -3233,7 +3233,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p class="autoWidth" style="width: auto;">', $result);
+        self::assertContains('<p class="autoWidth" style="width: auto;">', $result);
     }
 
     /**
@@ -3301,7 +3301,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContains('<p style="' . $expectedStyleAttributeContent . '">', $result);
+        self::assertContains('<p style="' . $expectedStyleAttributeContent . '">', $result);
     }
 
     /**
@@ -3332,6 +3332,6 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->subject->emogrify();
 
-        static::assertContainsCss($css, $result);
+        self::assertContainsCss($css, $result);
     }
 }

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -20,11 +20,11 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
     {
         $needle = '.\\+*?[^]$(){}=!<>|:-/';
 
-        $result = static::getCssNeedleRegExp($needle);
+        $result = self::getCssNeedleRegExp($needle);
 
         $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
 
-        static::assertSame(
+        self::assertSame(
             '/' . \preg_quote($needle, '/') . '/',
             $resultWithWhitespaceMatchersRemoved
         );
@@ -38,11 +38,11 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
         $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
             . "\r\n\t `¬\"£%&_;'@~,";
 
-        $result = static::getCssNeedleRegExp($needle);
+        $result = self::getCssNeedleRegExp($needle);
 
         $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
 
-        static::assertSame(
+        self::assertSame(
             '/' . $needle . '/',
             $resultWithWhitespaceMatchersRemoved
         );
@@ -75,13 +75,13 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function getCssNeedleRegExpInsertsOptionalWhitespace($contentToInsertAround, $otherContent)
     {
-        $result = static::getCssNeedleRegExp($otherContent . $contentToInsertAround . $otherContent);
+        $result = self::getCssNeedleRegExp($otherContent . $contentToInsertAround . $otherContent);
 
         $quotedOtherContent = \preg_quote($otherContent, '/');
         $expectedResult = '/' . $quotedOtherContent . '\\s*+' . \preg_quote($contentToInsertAround, '/') . '\\s*+'
             . $quotedOtherContent . '/';
 
-        static::assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     /**
@@ -89,9 +89,9 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function getCssNeedleRegExpReplacesWhitespaceAtStartWithOptionalWhitespace()
     {
-        $result = static::getCssNeedleRegExp(' a');
+        $result = self::getCssNeedleRegExp(' a');
 
-        static::assertSame('/\\s*+a/', $result);
+        self::assertSame('/\\s*+a/', $result);
     }
 
     /**
@@ -117,9 +117,9 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function getCssNeedleRegExpInsertsOptionalWhitespaceAfterStyleTag($needle)
     {
-        $result = static::getCssNeedleRegExp($needle);
+        $result = self::getCssNeedleRegExp($needle);
 
-        static::assertSame('/\\<style\\>\\s*+a/', $result);
+        self::assertSame('/\\<style\\>\\s*+a/', $result);
     }
 
     /**
@@ -171,7 +171,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssPassesTestIfNeedleFound($needle, $haystack)
     {
-        static::assertContainsCss($needle, $haystack);
+        self::assertContainsCss($needle, $haystack);
     }
 
     /**
@@ -186,7 +186,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssFailsTestIfNeedleNotFound($needle, $haystack)
     {
-        static::assertContainsCss($needle, $haystack);
+        self::assertContainsCss($needle, $haystack);
     }
 
     /**
@@ -199,7 +199,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertNotContainsCssPassesTestIfNeedleNotFound($needle, $haystack)
     {
-        static::assertNotContainsCss($needle, $haystack);
+        self::assertNotContainsCss($needle, $haystack);
     }
 
     /**
@@ -214,7 +214,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertNotContainsCssFailsTestIfNeedleFound($needle, $haystack)
     {
-        static::assertNotContainsCss($needle, $haystack);
+        self::assertNotContainsCss($needle, $haystack);
     }
 
     /**
@@ -227,7 +227,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountPassesTestExpectingZeroIfNeedleNotFound($needle, $haystack)
     {
-        static::assertContainsCssCount(0, $needle, $haystack);
+        self::assertContainsCssCount(0, $needle, $haystack);
     }
 
     /**
@@ -242,7 +242,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountFailsTestExpectingZeroIfNeedleFound($needle, $haystack)
     {
-        static::assertContainsCssCount(0, $needle, $haystack);
+        self::assertContainsCssCount(0, $needle, $haystack);
     }
 
     /**
@@ -255,7 +255,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountPassesTestExpectingOneIfNeedleFound($needle, $haystack)
     {
-        static::assertContainsCssCount(1, $needle, $haystack);
+        self::assertContainsCssCount(1, $needle, $haystack);
     }
 
     /**
@@ -270,7 +270,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountFailsTestExpectingOneIfNeedleNotFound($needle, $haystack)
     {
-        static::assertContainsCssCount(1, $needle, $haystack);
+        self::assertContainsCssCount(1, $needle, $haystack);
     }
 
     /**
@@ -285,7 +285,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountFailsTestExpectingOneIfNeedleFoundTwice($needle, $haystack)
     {
-        static::assertContainsCssCount(1, $needle, $haystack . $haystack);
+        self::assertContainsCssCount(1, $needle, $haystack . $haystack);
     }
 
     /**
@@ -298,7 +298,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountPassesTestExpectingTwoIfNeedleFoundTwice($needle, $haystack)
     {
-        static::assertContainsCssCount(2, $needle, $haystack . $haystack);
+        self::assertContainsCssCount(2, $needle, $haystack . $haystack);
     }
 
     /**
@@ -313,7 +313,7 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountFailsTestExpectingTwoIfNeedleNotFound($needle, $haystack)
     {
-        static::assertContainsCssCount(2, $needle, $haystack);
+        self::assertContainsCssCount(2, $needle, $haystack);
     }
 
     /**
@@ -328,6 +328,6 @@ class AssertCssTest extends \PHPUnit_Framework_TestCase
      */
     public function assertContainsCssCountFailsTestExpectingTwoIfNeedleFoundOnlyOnce($needle, $haystack)
     {
-        static::assertContainsCssCount(2, $needle, $haystack);
+        self::assertContainsCssCount(2, $needle, $haystack);
     }
 }


### PR DESCRIPTION
This communicates that the test classes are not intented to be subclassed.
(Also, it is a bit shorter.)