### PR TITLE
[CLEANUP] Stop setting DOMDocument->encoding

### DIFF
--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -461,7 +461,6 @@ class Emogrifier
     private function createRawDomDocument($html)
     {
         $domDocument = new \DOMDocument();
-        $domDocument->encoding = 'UTF-8';
         $domDocument->strictErrorChecking = false;
         $domDocument->formatOutput = true;
         $libXmlState = \libxml_use_internal_errors(true);

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -300,7 +300,6 @@ class CssInliner
     private function createRawDomDocument($html)
     {
         $domDocument = new \DOMDocument();
-        $domDocument->encoding = 'UTF-8';
         $domDocument->strictErrorChecking = false;
         $domDocument->formatOutput = true;
         $libXmlState = \libxml_use_internal_errors(true);


### PR DESCRIPTION
The encoding will be reset a few lines later with the
`loadHTML` call anyway.