### PR TITLE
[TASK] Add Japanese characters to the UTF8-relatet tests

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -301,7 +301,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
-            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
+            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau. イリノイ州シカゴにて、アイルランド系の家庭に、'],
             'HTML entities' => ['a &amp; b &gt; c'],
             'curly braces' => ['{Happy new year!}'],
         ];

--- a/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -202,7 +202,7 @@ class AbstractHtmlProcessorTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
-            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
+            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau. イリノイ州シカゴにて、アイルランド系の家庭に、'],
             'HTML entities' => ['a &amp; b &gt; c'],
             'curly braces' => ['{Happy new year!}'],
         ];

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -228,7 +228,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'template markers with dollar signs & square brackets' => ['$[USER:NAME]$'],
-            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau.'],
+            'UTF-8 umlauts' => ['Küss die Hand, schöne Frau. イリノイ州シカゴにて、アイルランド系の家庭に、'],
             'HTML entities' => ['a &amp; b &gt; c'],
             'curly braces' => ['{Happy new year!}'],
         ];


### PR DESCRIPTION
This makes sure that these characters are properly retained when reading
and re-creating the HTML.