### PR TITLE
[CLEANUP] Stop calling DOMDocument->normalizeDocument

### DIFF
--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -467,7 +467,6 @@ class Emogrifier
         $domDocument->loadHTML($this->prepareHtmlForDomConversion($html));
         \libxml_clear_errors();
         \libxml_use_internal_errors($libXmlState);
-        $domDocument->normalizeDocument();
 
         $this->domDocument = $domDocument;
     }

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -306,7 +306,6 @@ class CssInliner
         $domDocument->loadHTML($this->prepareHtmlForDomConversion($html));
         \libxml_clear_errors();
         \libxml_use_internal_errors($libXmlState);
-        $domDocument->normalizeDocument();
 
         $this->domDocument = $domDocument;
     }


### PR DESCRIPTION
This call is not needed directly after the call to `loadHTML` as the
latter call normalized the HTML, too.