### PR TITLE
[TASK] `CssInliner`: Keep `<wbr>` tags by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Keep `<wbr>` elements by default with `CssInliner`
+  ([#665](https://github.com/MyIntervals/emogrifier/pull/665))
 - Make the CssInliner inherit AbstractHtmlProcessor
   ([#660](https://github.com/MyIntervals/emogrifier/pull/660))
 - Separate `CssInliner::inlineCss` and the rendering

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -62,7 +62,7 @@ class CssInliner extends AbstractHtmlProcessor
     /**
      * @var string[]
      */
-    private $unprocessableHtmlTags = ['wbr'];
+    private $unprocessableHtmlTags = [];
 
     /**
      * @var bool[]

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -445,9 +445,28 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider wbrTagDataProvider
      */
-    public function inlineCssByDefaultRemovesWbrTag($html)
+    public function inlineCssByDefaultNotRemovesWbrTag($html)
     {
         $subject = $this->buildDebugSubject($html);
+
+        $subject->inlineCss('');
+
+        $expectedWbrTagCount = \substr_count($html, '<wbr');
+        $resultWbrTagCount = \substr_count($subject->render(), '<wbr');
+        self::assertSame($expectedWbrTagCount, $resultWbrTagCount);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $html
+     *
+     * @dataProvider wbrTagDataProvider
+     */
+    public function inlineCssAfterAddUnprocessableTagRemovesWbrTag($html)
+    {
+        $subject = $this->buildDebugSubject($html);
+        $subject->addUnprocessableHtmlTag('wbr');
 
         $subject->inlineCss('');
 

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -445,14 +445,15 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider wbrTagDataProvider
      */
-    public function inlineCssByDefaultNotRemovesWbrTag($html)
+    public function inlineCssByDefaultKeepsWbrTag($html)
     {
         $subject = $this->buildDebugSubject($html);
 
         $subject->inlineCss('');
 
+        $result = $subject->render();
         $expectedWbrTagCount = \substr_count($html, '<wbr');
-        $resultWbrTagCount = \substr_count($subject->render(), '<wbr');
+        $resultWbrTagCount = \substr_count($result, '<wbr');
         self::assertSame($expectedWbrTagCount, $resultWbrTagCount);
     }
 
@@ -470,7 +471,8 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
 
         $subject->inlineCss('');
 
-        self::assertNotContains('<wbr', $subject->render());
+        $result = $subject->render();
+        self::assertNotContains('<wbr', $result);
     }
 
     /**


### PR DESCRIPTION
Following #651/#652, there is now no need to remove `<wbr>` elements by default
as they are now correctly processed.  For backwards compatibility, the behaviour
is not changed for `Emogrifier`; it is only changed for `CssInliner` which is a
new class.