### PR TITLE
[WIP][FEATURE] Allow dependency injection in case of helper classes

### DIFF
--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -269,6 +269,13 @@ class Emogrifier
     private $debug = false;
 
     /**
+     * Holds the eventually injected CSS concatenator dependency.
+     *
+     * @var Emogrifier\CssConcatenator
+     */
+    private $cssConcatenator = null;
+
+    /**
      * @param string $unprocessedHtml the HTML to process, must be UTF-8-encoded
      * @param string $css the CSS to merge, must be UTF-8-encoded
      */
@@ -1338,17 +1345,20 @@ class Emogrifier
             return;
         }
 
-        // support use without autoload
-        if (!\class_exists('Pelago\\Emogrifier\\CssConcatenator')) {
-            require_once __DIR__ . '/Emogrifier/CssConcatenator.php';
+        // When there is no explicitly injected dependency, just use the default one.
+        if (is_null($this->cssConcatenator)) {
+            // support use without autoload
+            if (!\class_exists('Pelago\\Emogrifier\\CssConcatenator')) {
+                require_once __DIR__ . '/Emogrifier/CssConcatenator.php';
+            }
+            $this->cssConcatenator = new Emogrifier\CssConcatenator();
         }
 
-        $cssConcatenator = new Emogrifier\CssConcatenator();
         foreach ($cssRulesRelevantForDocument as $cssRule) {
-            $cssConcatenator->append([$cssRule['selector']], $cssRule['declarationsBlock'], $cssRule['media']);
+            $this->cssConcatenator->append([$cssRule['selector']], $cssRule['declarationsBlock'], $cssRule['media']);
         }
 
-        $this->addStyleElementToDocument($cssConcatenator->getCss());
+        $this->addStyleElementToDocument($this->cssConcatenator->getCss());
     }
 
     /**
@@ -2060,5 +2070,15 @@ class Emogrifier
     public function setDebug($debug)
     {
         $this->debug = $debug;
+    }
+
+    /**
+     * Inject a custom CSS concatenator.
+     *
+     * @param Emogrifier\CssConcatenator $cssConcatenator Must be compatible with the default CssConcatenator.
+     */
+    public function setCssConcatenator($cssConcatenator)
+    {
+        $this->cssConcatenator = $cssConcatenator;
     }
 }

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1346,7 +1346,7 @@ class Emogrifier
         }
 
         // When there is no explicitly injected dependency, just use the default one.
-        if (is_null($this->cssConcatenator)) {
+        if (\is_null($this->cssConcatenator)) {
             // support use without autoload
             if (!\class_exists('Pelago\\Emogrifier\\CssConcatenator')) {
                 require_once __DIR__ . '/Emogrifier/CssConcatenator.php';
@@ -2077,7 +2077,7 @@ class Emogrifier
      *
      * @param Emogrifier\CssConcatenator $cssConcatenator Must be compatible with the default CssConcatenator.
      */
-    public function setCssConcatenator($cssConcatenator)
+    public function setCssConcatenator(Emogrifier\CssConcatenator $cssConcatenator)
     {
         $this->cssConcatenator = $cssConcatenator;
     }

--- a/src/Emogrifier/CssConcatenator.php
+++ b/src/Emogrifier/CssConcatenator.php
@@ -49,7 +49,7 @@ class CssConcatenator
      *
      * @var \stdClass[]
      */
-    private $mediaRules = [];
+    protected $mediaRules = [];
 
     /**
      * Appends a declaration block to the CSS.


### PR DESCRIPTION
Recently had to briefly customize the functionality `CssConcatenator` and there was no way to do it without modifying the "core" `Emogrifier.php` file in the `vendor` folder.

Hence my proposal to make the used "helper" classes inject-able:
- Made the modification in a single place only, just to showcase it;
- It allows users of the library to inject a custom subclass of `CssConcatenator`;
- It falls back to the default implementation, when there is no explicit injection of a custom implementation;
- Also modified the visibility of `$mediaRules` property (from `private` to `protected`) in `CssConcatenator`, so sub-classes have access to it.

How to use it:
```php
class CustomCssConcatenator extends CssConcatenator
{
    // Override / implement additional logic
}

...

$emogrifier = new \Pelago\Emogrifier($html);
$emogrifier->setCssConcatenator(new CustomCssConcatenator());
...
```

- Should we use interfaces (like `CssConcatenatorInterface` would declare two methods - `append()` and `getCss()`), which will be used as the argument type of the injector method and all implementations (starting with the default ones ofc) will implement those interfaces. Otherwise all additional implementations must extend the default ones provided by Emogrifier.

What do you think? Let's discuss.

Thanks!