### PR TITLE
[CLEANUP] Call static methods statically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Call all static methods statically in `CssConcatenator`
+  ([#670](https://github.com/MyIntervals/emogrifier/pull/670))
 - Support all HTML5 self-closing tags, including `<embed>`, `<source>`,
   `<track>` and `<wbr>`
   ([#653](https://github.com/MyIntervals/emogrifier/pull/653))

--- a/src/Emogrifier/CssConcatenator.php
+++ b/src/Emogrifier/CssConcatenator.php
@@ -87,7 +87,7 @@ class CssConcatenator
      */
     public function getCss()
     {
-        return \implode('', \array_map([$this, 'getMediaRuleCss'], $this->mediaRules));
+        return \implode('', \array_map([static::class, 'getMediaRuleCss'], $this->mediaRules));
     }
 
     /**


### PR DESCRIPTION
In `CssConcatenator`, create `callable` for `static` method using `static::class` not `$this`.

(Spotted in #669.  Instances of `static` methods being called through `$this` were previously corrected in #525.)