### PR TITLE
[BUGFIX] Fix the installation of PHP 5.5 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 sudo: false
 
+# This line allows compilation of PHP 5.5. It can be removed once we do not support
+# PHP 5.5 anymore.
+dist: trusty
+
 language: php
 
 php:
-- 5.5
-- 5.6
-- 7.0
-- 7.1
-- 7.2
-- 7.3
+- "5.5"
+- "5.6"
+- "7.0"
+- "7.1"
+- "7.2"
+- "7.3"
 
 cache:
   directories:


### PR DESCRIPTION
Also properly quote the PHP version strings in the `.travis.yml`.