### PR TITLE
[BUGFIX] Keep development files out of the Composer packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.github/ export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/CODE_OF_CONDUCT.md export-ignore
 /config/ export-ignore
 /phpcs.xml.dist export-ignore
 /tests/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/config/ export-ignore
+/phpcs.xml.dist export-ignore
+/tests/ export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Keep development files out of the Composer packages
+  ([#678](https://github.com/MyIntervals/emogrifier/pull/678))
 - Call all static methods statically in `CssConcatenator`
   ([#670](https://github.com/MyIntervals/emogrifier/pull/670))
 - Support all HTML5 self-closing tags, including `<embed>`, `<source>`,


### PR DESCRIPTION
Mark all development-only files and directories as `export-ignore`
via the `.gitattributes` file. This will keep them from being packaged
in the release ZIPs provided by GitHub and in the packages downloaded
by Composer with the `--prefer-dist` option (which is the default).