### PR TITLE
[TASK] Drop the removal of invisible nodes from CssInliner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#674](https://github.com/MyIntervals/emogrifier/pull/674))
 - Keep `<wbr>` elements by default with `CssInliner`
   ([#665](https://github.com/MyIntervals/emogrifier/pull/665))
-- Make the CssInliner inherit AbstractHtmlProcessor
+- Make the `CssInliner` inherit `AbstractHtmlProcessor`
   ([#660](https://github.com/MyIntervals/emogrifier/pull/660))
 - Separate `CssInliner::inlineCss` and the rendering
   ([#654](https://github.com/MyIntervals/emogrifier/pull/654))
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the removal of invisible nodes from `CssInliner`
+  ([#684](https://github.com/MyIntervals/emogrifier/pull/684))
 
 ### Fixed
 - Remove opening `<body>` tag from `body` content when element has attribute(s)

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -120,14 +120,6 @@ class CssInliner extends AbstractHtmlProcessor
     private $isStyleBlocksParsingEnabled = true;
 
     /**
-     * Determines whether elements with the `display: none` property are
-     * removed from the DOM.
-     *
-     * @var bool
-     */
-    private $shouldRemoveInvisibleNodes = true;
-
-    /**
      * For calculating selector precedence order.
      * Keys are a regular expression part to match before a CSS name.
      * Values are a multiplier factor per match to weight specificity.
@@ -224,27 +216,12 @@ class CssInliner extends AbstractHtmlProcessor
         if ($this->isInlineStyleAttributesParsingEnabled) {
             $this->fillStyleAttributesWithMergedStyles();
         }
-        $this->postProcess($xPath);
 
         $this->removeImportantAnnotationFromAllInlineStyles($xPath);
 
         $this->copyUninlineableCssToStyleNode($xPath, $cssRules['uninlineable']);
 
         return $this;
-    }
-
-    /**
-     * Applies some optional post-processing to the HTML in the DOM document.
-     *
-     * @param \DOMXPath $xPath
-     *
-     * @return void
-     */
-    private function postProcess(\DOMXPath $xPath)
-    {
-        if ($this->shouldRemoveInvisibleNodes) {
-            $this->removeInvisibleNodes($xPath);
-        }
     }
 
     /**
@@ -430,18 +407,6 @@ class CssInliner extends AbstractHtmlProcessor
     }
 
     /**
-     * Disables the removal of elements with `display: none` properties.
-     *
-     * @return void
-     *
-     * @deprecated will be removed in Emogrifier 3.0, use the HtmlPruner class instead
-     */
-    public function disableInvisibleNodeRemoval()
-    {
-        $this->shouldRemoveInvisibleNodes = false;
-    }
-
-    /**
      * Clears all caches.
      *
      * @return void
@@ -550,36 +515,6 @@ class CssInliner extends AbstractHtmlProcessor
     {
         if (isset($this->excludedSelectors[$selector])) {
             unset($this->excludedSelectors[$selector]);
-        }
-    }
-
-    /**
-     * This removes styles from your email that contain display:none.
-     * We need to look for display:none, but we need to do a case-insensitive search. Since DOMDocument only
-     * supports XPath 1.0, lower-case() isn't available to us. We've thus far only set attributes to lowercase,
-     * not attribute values. Consequently, we need to translate() the letters that would be in 'NONE' ("NOE")
-     * to lowercase.
-     *
-     * @param \DOMXPath $xPath
-     *
-     * @return void
-     */
-    private function removeInvisibleNodes(\DOMXPath $xPath)
-    {
-        $nodesWithStyleDisplayNone = $xPath->query(
-            '//*[contains(translate(translate(@style," ",""),"NOE","noe"),"display:none")]'
-        );
-        if ($nodesWithStyleDisplayNone->length === 0) {
-            return;
-        }
-
-        // The checks on parentNode and is_callable below ensure that if we've deleted the parent node,
-        // we don't try to call removeChild on a nonexistent child node
-        /** @var \DOMNode $node */
-        foreach ($nodesWithStyleDisplayNone as $node) {
-            if ($node->parentNode && \is_callable([$node->parentNode, 'removeChild'])) {
-                $node->parentNode->removeChild($node);
-            }
         }
     }
 

--- a/src/Emogrifier/HtmlProcessor/HtmlPruner.php
+++ b/src/Emogrifier/HtmlProcessor/HtmlPruner.php
@@ -10,6 +10,11 @@ namespace Pelago\Emogrifier\HtmlProcessor;
 class HtmlPruner extends AbstractHtmlProcessor
 {
     /**
+     * We need to look for display:none, but we need to do a case-insensitive search. Since DOMDocument only
+     * supports XPath 1.0, lower-case() isn't available to us. We've thus far only set attributes to lowercase,
+     * not attribute values. Consequently, we need to translate() the letters that would be in 'NONE' ("NOE")
+     * to lowercase.
+     *
      * @var string
      */
     const DISPLAY_NONE_MATCHER = '//*[contains(translate(translate(@style," ",""),"NOE","noe"),"display:none")]';

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1970,46 +1970,6 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function inlineCssByDefaultRemovesElementsWithDisplayNoneFromExternalCss()
-    {
-        $subject = $this->buildDebugSubject('<html><body><div class="foo"></div></body></html>');
-
-        $subject->inlineCss('div.foo { display: none; }');
-
-        self::assertNotContains('<div class="foo"></div>', $subject->render());
-    }
-
-    /**
-     * @test
-     */
-    public function inlineCssByDefaultRemovesElementsWithDisplayNoneInStyleAttribute()
-    {
-        $subject = $this->buildDebugSubject(
-            '<html><body><div class="foobar" style="display: none;"></div>' .
-            '</body></html>'
-        );
-
-        $subject->inlineCss('');
-
-        self::assertNotContains('<div', $subject->render());
-    }
-
-    /**
-     * @test
-     */
-    public function inlineCssAfterDisableInvisibleNodeRemovalPreservesInvisibleElements()
-    {
-        $subject = $this->buildDebugSubject('<html><body><div class="foo"></div></body></html>');
-
-        $subject->disableInvisibleNodeRemoval();
-        $subject->inlineCss('div.foo { display: none; }');
-
-        self::assertContains('<div class="foo" style="display: none;">', $subject->render());
-    }
-
-    /**
-     * @test
-     */
     public function inlineCssKeepsCssMediaQueriesWithCssCommentAfterMediaQuery()
     {
         $subject = $this->buildDebugSubject('<html><body></body></html>');


### PR DESCRIPTION
Also copy the comment that explains the used XPath expression from the
removed method to the corresponding constant in `HtmlPruner`.

Also add some missing code markup to a recently added line in the
changelog.