### PR TITLE
[TASK] Drop the removal of unprocessable tags from CssInliner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the removal of unprocessable tags from `CssInliner`
+  ([#685](https://github.com/MyIntervals/emogrifier/pull/685))
 - Drop the removal of invisible nodes from `CssInliner`
   ([#684](https://github.com/MyIntervals/emogrifier/pull/684))
 

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -60,11 +60,6 @@ class CssInliner extends AbstractHtmlProcessor
     private $excludedSelectors = [];
 
     /**
-     * @var string[]
-     */
-    private $unprocessableHtmlTags = [];
-
-    /**
      * @var bool[]
      */
     private $allowedMediaTypes = ['all' => true, 'screen' => true, 'print' => true];
@@ -181,7 +176,6 @@ class CssInliner extends AbstractHtmlProcessor
         $this->purgeVisitedNodes();
 
         $xPath = new \DOMXPath($this->domDocument);
-        $this->removeUnprocessableTags();
         $this->normalizeStyleAttributesOfAllNodes($xPath);
 
         $combinedCss = $css;
@@ -430,38 +424,6 @@ class CssInliner extends AbstractHtmlProcessor
     {
         $this->visitedNodes = [];
         $this->styleAttributesForNodes = [];
-    }
-
-    /**
-     * Marks a tag for removal.
-     *
-     * There are some HTML tags that DOMDocument cannot process, and it will throw an error if it encounters them.
-     * In particular, DOMDocument will complain if you try to use HTML5 tags in an XHTML document.
-     *
-     * Note: The tags will not be removed if they have any content.
-     *
-     * @param string $tagName the tag name, e.g., "p"
-     *
-     * @return void
-     */
-    public function addUnprocessableHtmlTag($tagName)
-    {
-        $this->unprocessableHtmlTags[] = $tagName;
-    }
-
-    /**
-     * Drops a tag from the removal list.
-     *
-     * @param string $tagName the tag name, e.g., "p"
-     *
-     * @return void
-     */
-    public function removeUnprocessableHtmlTag($tagName)
-    {
-        $key = \array_search($tagName, $this->unprocessableHtmlTags, true);
-        if ($key !== false) {
-            unset($this->unprocessableHtmlTags[$key]);
-        }
     }
 
     /**
@@ -887,29 +849,6 @@ class CssInliner extends AbstractHtmlProcessor
             }
         }
         return $splitCss;
-    }
-
-    /**
-     * Removes empty unprocessable tags from the DOM document.
-     *
-     * @return void
-     */
-    private function removeUnprocessableTags()
-    {
-        foreach ($this->unprocessableHtmlTags as $tagName) {
-            // Deleting nodes from a 'live' NodeList invalidates iteration on it, so a copy must be made to iterate.
-            $nodes = [];
-            foreach ($this->domDocument->getElementsByTagName($tagName) as $node) {
-                $nodes[] = $node;
-            }
-            /** @var \DOMNode $node */
-            foreach ($nodes as $node) {
-                $hasContent = $node->hasChildNodes() || $node->hasChildNodes();
-                if (!$hasContent) {
-                    $node->parentNode->removeChild($node);
-                }
-            }
-        }
     }
 
     /**

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -98,7 +98,7 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider wbrTagDataProvider
      */
-    public function inlineCssByDefaultKeepsWbrTag($html)
+    public function inlineCssKeepsWbrTag($html)
     {
         $subject = $this->buildDebugSubject($html);
 
@@ -108,64 +108,6 @@ class CssInlinerTest extends \PHPUnit_Framework_TestCase
         $expectedWbrTagCount = \substr_count($html, '<wbr');
         $resultWbrTagCount = \substr_count($result, '<wbr');
         self::assertSame($expectedWbrTagCount, $resultWbrTagCount);
-    }
-
-    /**
-     * @test
-     *
-     * @param string $html
-     *
-     * @dataProvider wbrTagDataProvider
-     */
-    public function inlineCssAfterAddUnprocessableTagRemovesWbrTag($html)
-    {
-        $subject = $this->buildDebugSubject($html);
-        $subject->addUnprocessableHtmlTag('wbr');
-
-        $subject->inlineCss('');
-
-        $result = $subject->render();
-        self::assertNotContains('<wbr', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function addUnprocessableTagRemovesEmptyTag()
-    {
-        $subject = $this->buildDebugSubject('<body><p></p></body>');
-
-        $subject->addUnprocessableHtmlTag('p');
-
-        $result = $subject->inlineCss('')->render();
-        self::assertNotContains('<p>', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function addUnprocessableTagNotRemovesNonEmptyTag()
-    {
-        $subject = $this->buildDebugSubject('<body><p>foobar</p></body>');
-
-        $subject->addUnprocessableHtmlTag('p');
-
-        $result = $subject->inlineCss('')->render();
-        self::assertContains('<p>', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function removeUnprocessableHtmlTagKeepsTagAgainAgain()
-    {
-        $subject = $this->buildDebugSubject('<body><p></p></body>');
-
-        $subject->addUnprocessableHtmlTag('p');
-        $subject->removeUnprocessableHtmlTag('p');
-
-        $result = $subject->inlineCss('')->render();
-        self::assertContains('<p>', $result);
     }
 
     /**


### PR DESCRIPTION
Now that 'CssInliner' properly can handle HTML5 tags, this functionality
is not needed anymore.

Closes #682