### PR TITLE
[BUGFIX] Allow `:not(:behavioural-pseudo-class)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#690](https://github.com/MyIntervals/emogrifier/pull/690))
 
 ### Fixed
+- Allow `:not(:behavioural-pseudo-class)` in selectors
+  ([#697](https://github.com/MyIntervals/emogrifier/pull/697))
 
 ## 2.2.0
 

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -680,26 +680,27 @@ class CssInliner extends AbstractHtmlProcessor
     }
 
     /**
-     * Helper for `removeUnmatchablePseudoComponents()` to replace/remove a selector `:not` component if its argument
+     * Helps `removeUnmatchablePseudoComponents()` replace or remove a selector `:not(...)` component if its argument
      * contains pseudo-elements or dynamic pseudo-classes.
      *
-     * @param string[] $matches Array of capturing groups matched by the regular expression.
-     *        Index 0 contains the full match ":not(...)", preceded by a whitespace character if present.
-     *        Index 1 contains any preceding whitespace character or an empty string if none present.
-     *        Index 2 contains the `:not` argument with the surrounding brackets (i.e. "(...)").
+     * @param string[] $matches array of elements matched by the regular expression
      *
      * @return string the full match if there were no unmatchable pseudo components within; otherwise, any preceding
      *         whitespace followed by "*", or an empty string if there was no preceding whitespace
      */
     private function replaceUnmatchableNotComponent(array $matches)
     {
-        if (\preg_match(
+        list($notComponentWithAnyPrecedingWhitespace, $anyPrecedingWhitespace, $notArgumentInBrackets) = $matches;
+
+        $hasUnmatchablePseudo = \preg_match(
             '/:(?!' . static::PSEUDO_CLASS_MATCHER . ')[\\w\\-:]/i',
-            $matches[2]
-        )) {
-            return $matches[1] !== '' ? $matches[1] . '*' : '';
+            $notArgumentInBrackets
+        );
+
+        if ($hasUnmatchablePseudo) {
+            return $anyPrecedingWhitespace !== '' ? $anyPrecedingWhitespace . '*' : '';
         } else {
-            return $matches[0];
+            return $notComponentWithAnyPrecedingWhitespace;
         }
     }
 

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1563,6 +1563,14 @@ class CssInlinerTest extends TestCase
                 'selectorPseudoComponent' => ':lang(en)',
                 'declarationsBlock' => 'color: green;',
             ],
+            'not with pseudo-class' => [
+                'selectorPseudoComponent' => ':not(:hover)',
+                'declarationsBlock' => 'color: green;',
+            ],
+            'nested not with pseudo-class' => [
+                'selectorPseudoComponent' => ':not(:not(:hover))',
+                'declarationsBlock' => 'color: green;',
+            ],
         ];
 
         $datasets = [];


### PR DESCRIPTION
This was causing an error because `removeUnmatchablePseudoComponents()` was
converting the selector to `:not()`, which is invalid.  The intention would have
been to convert it to `:not(*)`, but this is not correct either.  If a
behavioural pseudo-class is used within the `:not` argument, then the entire
`:not(…)` component should be stripped in order to test whether the selector
could match any DOM elements.