### PR TITLE
[BUGFIX] Don’t create empty `style` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#690](https://github.com/MyIntervals/emogrifier/pull/690))
 
 ### Fixed
+- Don't create empty `style` attributes for unparsable declarations
+  ([#259](https://github.com/MyIntervals/emogrifier/issues/259),
+  [#702](https://github.com/MyIntervals/emogrifier/pull/702))
 - Allow `:not(:behavioural-pseudo-class)` in selectors
   ([#697](https://github.com/MyIntervals/emogrifier/pull/697))
 
@@ -93,7 +96,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#633](https://github.com/MyIntervals/emogrifier/pull/633))
 - Add a `getDomDocument()` method
   ([#630](https://github.com/MyIntervals/emogrifier/pull/630))
-- Add a Composer script for PHP CS Fixer 
+- Add a Composer script for PHP CS Fixer
   ([#607](https://github.com/MyIntervals/emogrifier/pull/607))
 - Copy matching rules with dynamic pseudo-classes or pseudo-elements in
   selectors to the style element

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -958,6 +958,11 @@ class Emogrifier
      */
     private function copyInlineableCssToStyleAttribute(\DOMElement $node, array $cssRule)
     {
+        $newStyleDeclarations = $this->parseCssDeclarationsBlock($cssRule['declarationsBlock']);
+        if ($newStyleDeclarations === []) {
+            return;
+        }
+
         // if it has a style attribute, get it, process it, and append (overwrite) new stuff
         if ($node->hasAttribute('style')) {
             // break it up into an associative array
@@ -965,7 +970,6 @@ class Emogrifier
         } else {
             $oldStyleDeclarations = [];
         }
-        $newStyleDeclarations = $this->parseCssDeclarationsBlock($cssRule['declarationsBlock']);
         $node->setAttribute(
             'style',
             $this->generateStyleStringFromDeclarationsArrays($oldStyleDeclarations, $newStyleDeclarations)

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -714,6 +714,11 @@ class CssInliner extends AbstractHtmlProcessor
      */
     private function copyInlineableCssToStyleAttribute(\DOMElement $node, array $cssRule)
     {
+        $newStyleDeclarations = $this->parseCssDeclarationsBlock($cssRule['declarationsBlock']);
+        if ($newStyleDeclarations === []) {
+            return;
+        }
+
         // if it has a style attribute, get it, process it, and append (overwrite) new stuff
         if ($node->hasAttribute('style')) {
             // break it up into an associative array
@@ -721,7 +726,6 @@ class CssInliner extends AbstractHtmlProcessor
         } else {
             $oldStyleDeclarations = [];
         }
-        $newStyleDeclarations = $this->parseCssDeclarationsBlock($cssRule['declarationsBlock']);
         $node->setAttribute(
             'style',
             $this->generateStyleStringFromDeclarationsArrays($oldStyleDeclarations, $newStyleDeclarations)

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -905,7 +905,7 @@ class CssInlinerTest extends TestCase
 
         $subject->inlineCss('html {' . $cssDeclarationBlock . '}');
 
-        self::assertContains('<html style="">', $subject->render());
+        self::assertContains('<html>', $subject->render());
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1190,7 +1190,7 @@ class EmogrifierTest extends TestCase
 
         $result = $this->subject->emogrify();
 
-        self::assertContains('<html style="">', $result);
+        self::assertContains('<html>', $result);
     }
 
     /**


### PR DESCRIPTION
Although `parseCssRules()` drops rules with empty declarations blocks, those
which contain non-whitespace but no actual parsable declarations are retained,
as the declarations themselves are parsed later – (indirectly) by
`copyInlineableCssToStyleAttribute()`.  An additional check is now made in that
method.

(Also removed a trailing EOL whitespace in the CHANGELOG.)

Fixes #259.