### PR TITLE
[BUGFIX] Allow `:not(:pseudo)` with `Emogrifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Allow `:not(:behavioural-pseudo-class)` in selectors
-  ([#697](https://github.com/MyIntervals/emogrifier/pull/697))
+  ([#697](https://github.com/MyIntervals/emogrifier/pull/697),
+  [#703](https://github.com/MyIntervals/emogrifier/pull/703))
 
 ## 2.2.0
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1012,6 +1012,7 @@ class Emogrifier
 
     /**
      * Removes pseudo-elements and dynamic pseudo-classes from a CSS selector, replacing them with "*" if necessary.
+     * If such a pseudo-component is within the argument of `:not`, the entire `:not` component is removed or replaced.
      *
      * @param string $selector
      *
@@ -1020,12 +1021,45 @@ class Emogrifier
      */
     private function removeUnmatchablePseudoComponents($selector)
     {
+        // The regex allows nested brackets via `(?2)`.
+        // A space is temporarily prepended because the callback can't determine if the match was at the very start.
+        $selectorWithoutNots = \ltrim(\preg_replace_callback(
+            '/(\\s?+):not(\\([^\\(\\)]*+(?:(?2)[^\\(\\)]*+)*+\\))/i',
+            [$this, 'replaceUnmatchableNotComponent'],
+            ' ' . $selector
+        ));
+
         $pseudoComponentMatcher = ':(?!' . static::PSEUDO_CLASS_MATCHER . '):?+[\\w\\-]++(?:\\([^\\)]*+\\))?+';
         return \preg_replace(
             ['/(\\s|^)' . $pseudoComponentMatcher . '/i', '/' . $pseudoComponentMatcher . '/i'],
             ['$1*', ''],
-            $selector
+            $selectorWithoutNots
         );
+    }
+
+    /**
+     * Helps `removeUnmatchablePseudoComponents()` replace or remove a selector `:not(...)` component if its argument
+     * contains pseudo-elements or dynamic pseudo-classes.
+     *
+     * @param string[] $matches array of elements matched by the regular expression
+     *
+     * @return string the full match if there were no unmatchable pseudo components within; otherwise, any preceding
+     *         whitespace followed by "*", or an empty string if there was no preceding whitespace
+     */
+    private function replaceUnmatchableNotComponent(array $matches)
+    {
+        list($notComponentWithAnyPrecedingWhitespace, $anyPrecedingWhitespace, $notArgumentInBrackets) = $matches;
+
+        $hasUnmatchablePseudo = \preg_match(
+            '/:(?!' . static::PSEUDO_CLASS_MATCHER . ')[\\w\\-:]/i',
+            $notArgumentInBrackets
+        );
+
+        if ($hasUnmatchablePseudo) {
+            return $anyPrecedingWhitespace !== '' ? $anyPrecedingWhitespace . '*' : '';
+        } else {
+            return $notComponentWithAnyPrecedingWhitespace;
+        }
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1968,6 +1968,14 @@ class EmogrifierTest extends TestCase
                 'selectorPseudoComponent' => ':lang(en)',
                 'declarationsBlock' => 'color: green;',
             ],
+            'not with pseudo-class' => [
+                'selectorPseudoComponent' => ':not(:hover)',
+                'declarationsBlock' => 'color: green;',
+            ],
+            'nested not with pseudo-class' => [
+                'selectorPseudoComponent' => ':not(:not(:hover))',
+                'declarationsBlock' => 'color: green;',
+            ],
         ];
 
         $datasets = [];


### PR DESCRIPTION
This is a port of #697 to the `Emogrifier` class.