### PR TITLE
[FEATURE] Add CssInliner::getMatchingUninlinableSelectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add `CssInliner::getMatchingUninlinableSelectors`
+  ([#380](https://github.com/MyIntervals/emogrifier/issues/380),
+  [#707](https://github.com/MyIntervals/emogrifier/pull/707))
 - Add tests for `:nth-child` and `:nth-of-type`
   ([#71](https://github.com/MyIntervals/emogrifier/issues/71),
   [#698](https://github.com/MyIntervals/emogrifier/pull/698))

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -627,6 +627,20 @@ class CssInliner extends AbstractHtmlProcessor
     }
 
     /**
+     * Gets the array of selectors present in the CSS provided to `inlineCss()` for which the declarations could not be
+     * applied as inline styles, but which may affect elements in the HTML.  The relevant CSS will have been placed in a
+     * `<style>` element.  The selectors may include those used within @media rules or those involving dynamic
+     * pseudo-classes (such as `:hover`) or pseudo-elements (such as `::after`).  `inlineCss()` must have been called
+     * first, otherwise an empty array is returned.
+     *
+     * @return string[]
+     */
+    public function getMatchingUninlinableSelectors()
+    {
+        return \array_column($this->matchingUninlinableCssRules, 'selector');
+    }
+
+    /**
      * Determines which of `$cssRules` actually apply to `$this->domDocument`, and sets them in
      * `$this->matchingUninlinableCssRules`.
      *

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -134,7 +134,7 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @var string[][]
      */
-    private $matchingUninlinableCssRules = [];
+    private $matchingUninlinableCssRules;
 
     /**
      * Emogrifier will throw Exceptions when it encounters an error instead of silently ignoring them.
@@ -629,14 +629,19 @@ class CssInliner extends AbstractHtmlProcessor
     /**
      * Gets the array of selectors present in the CSS provided to `inlineCss()` for which the declarations could not be
      * applied as inline styles, but which may affect elements in the HTML.  The relevant CSS will have been placed in a
-     * `<style>` element.  The selectors may include those used within @media rules or those involving dynamic
-     * pseudo-classes (such as `:hover`) or pseudo-elements (such as `::after`).  `inlineCss()` must have been called
-     * first, otherwise an empty array is returned.
+     * `<style>` element.  The selectors may include those used within `@media` rules or those involving dynamic
+     * pseudo-classes (such as `:hover`) or pseudo-elements (such as `::after`).
      *
      * @return string[]
+     *
+     * @throws \BadMethodCallException if `inlineCss` has not been called first
      */
     public function getMatchingUninlinableSelectors()
     {
+        if (!isset($this->matchingUninlinableCssRules)) {
+            throw new \BadMethodCallException('inlineCss must be called first', 1568385221);
+        }
+
         return \array_column($this->matchingUninlinableCssRules, 'selector');
     }
 

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -134,7 +134,7 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @var string[][]
      */
-    private $matchingUninlinableCssRules;
+    private $matchingUninlinableCssRules = null;
 
     /**
      * Emogrifier will throw Exceptions when it encounters an error instead of silently ignoring them.
@@ -638,7 +638,7 @@ class CssInliner extends AbstractHtmlProcessor
      */
     public function getMatchingUninlinableSelectors()
     {
-        if (!isset($this->matchingUninlinableCssRules)) {
+        if ($this->matchingUninlinableCssRules === null) {
             throw new \BadMethodCallException('inlineCss must be called first', 1568385221);
         }
 

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -2621,6 +2621,59 @@ class CssInlinerTest extends TestCase
     /**
      * @test
      */
+    public function getMatchingUninlinableSelectorsReturnsMatchingUninlinableSelector()
+    {
+        $subject = $this->buildDebugSubject('<html><p>foo</p></html>');
+        $subject->inlineCss('p:hover { color: green; }');
+
+        $result = $subject->getMatchingUninlinableSelectors();
+
+        static::assertContains('p:hover', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getMatchingUninlinableSelectorsReturnsMultipleMatchingUninlinableSelectors()
+    {
+        $subject = $this->buildDebugSubject('<html><p>foo</p></html>');
+        $subject->inlineCss('p:hover { color: green; } p::after { content: "bar"; }');
+
+        $result = $subject->getMatchingUninlinableSelectors();
+
+        static::assertContains('p:hover', $result);
+        static::assertContains('p::after', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getMatchingUninlinableSelectorsNotReturnsNonMatchingUninlinableSelector()
+    {
+        $subject = $this->buildDebugSubject('<html><p>foo</p></html>');
+        $subject->inlineCss('a:hover { color: red; }');
+
+        $result = $subject->getMatchingUninlinableSelectors();
+
+        static::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getMatchingUninlinableSelectorsNotReturnsMatchingInlinableSelector()
+    {
+        $subject = $this->buildDebugSubject('<html><p>foo</p></html>');
+        $subject->inlineCss('p { color: red; }');
+
+        $result = $subject->getMatchingUninlinableSelectors();
+
+        static::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
     public function copyUninlinableCssToStyleNodeHasNoSideEffects()
     {
         $subject = $this->buildDebugSubject('<html><a>foo</a><p>bar</p></html>');


### PR DESCRIPTION
Part of #380.

The basic functionality of the method is unit-tested.  More extensive unit tests
involving all kinds of CSS rules and HTML already exist for testing the full
content of the `<style>` element containing the uninlinable rules.