### PR TITLE
[TASK] Test descendant attribute selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#690](https://github.com/MyIntervals/emogrifier/pull/690))
 
 ### Fixed
+- Descendant attribute selectors (such as `html input[disabled]`)
+  ([#375](https://github.com/MyIntervals/emogrifier/pull/375),
+  [#709](https://github.com/MyIntervals/emogrifier/pull/709))
 - Attribute selectors with hyphen in attribute name
   ([#284](https://github.com/MyIntervals/emogrifier/issues/284),
   [#540](https://github.com/MyIntervals/emogrifier/pull/540),

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -34,7 +34,7 @@ class CssInlinerTest extends TestCase
                     href="https://example.org/"
                     data-ascii-1="! &quot; # $ % &amp; &#039; ( ) * + , - . / : ; &lt; = &gt; ?"
                     data-ascii-2="@ [ \ ] ^ _ ` { | } ~"
-                ><span id="example-org">link text</span></a></p>
+                ><span id="example-org">link text</span></a><input disabled></p>
             </body>
         </html>
     ';
@@ -351,9 +351,22 @@ class CssInlinerTest extends TestCase
             'child (without space before or after >) => direct child' => ['p>span { %1$s }', '<span style="%1$s">'],
             'descendant => child' => ['p span { %1$s }', '<span style="%1$s">'],
             'descendant => grandchild' => ['body span { %1$s }', '<span style="%1$s">'],
-            // broken: descendent attribute presence => with attribute
-            // broken: descendent attribute exact value => with exact attribute match
-            // broken: descendent type & attribute presence => with type & attribute
+            'descendent attribute presence => with attribute' => [
+                'body [title] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
+            'descendent attribute exact value => with exact attribute match' => [
+                'body [title="bonjour"] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
+            'descendent type & attribute presence => with type & attribute' => [
+                'body span[title] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
+            'descendent type & Boolean attribute presence => with type & attribute' => [
+                'html input[disabled] { %1$s }',
+                '<input disabled style="%1$s">',
+            ],
             'descendent type & attribute exact value => with type & exact attribute match' => [
                 'body span[title="bonjour"] { %1$s }',
                 '<span title="bonjour" style="%1$s">',


### PR DESCRIPTION
Implemented these tests that were previously commented as “broken”, and added a
test for presence of a Boolean attribute.  They have been fixed by virtue of
using the Symfony CssSelector component.

Resolves #375.