### PR TITLE
[TASK] Test descendant attribute prefix selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ignored, [#507](https://github.com/MyIntervals/emogrifier/pull/507))
 - Allow attribute selectors in descendants
   ([#506](https://github.com/MyIntervals/emogrifier/pull/506),
-  [#381](https://github.com/MyIntervals/emogrifier/issues/381))
+  [#381](https://github.com/MyIntervals/emogrifier/issues/381),
+  [#443](https://github.com/MyIntervals/emogrifier/issues/443))
 - Allow adjacent sibling CSS selector combinator in minified CSS
   ([#505](https://github.com/MyIntervals/emogrifier/pull/505))
 - Allow CSS property values containing newlines

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -390,6 +390,10 @@ class CssInlinerTest extends TestCase
                 'body span[title~="buenas"] { %1$s }',
                 '<span title="buenas dias" style="%1$s">',
             ],
+            'descendent type & attribute value with ^ => with type & attribute prefix match' => [
+                'p span[title^=bon] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
             'descendant of type & class: type & attribute exact value, no quotes => with type & exact match (#381)' => [
                 'p.p-2 span[title=bonjour] { %1$s }',
                 '<span title="bonjour" style="%1$s">',
@@ -621,6 +625,10 @@ class CssInlinerTest extends TestCase
             'child => not parent' => ['span > html { %1$s }', '<html>'],
             'descendant => not sibling' => ['span span { %1$s }', '<span>'],
             'descendant => not parent' => ['p body { %1$s }', '<body>'],
+            'descendent type & attribute value with ^ => not element with only substring match in attribute value' => [
+                'p span[title^=njo] { %1$s }',
+                '<span title="bonjour">',
+            ],
             'child of attribute presence with - in name => not child of parent without expected attribute' => [
                 'a[data-some-other] > #example-org { %1$s }',
                 '<span id="example-org">',

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -678,6 +678,10 @@ class EmogrifierTest extends TestCase
                 'body span[title~="buenas"] { %1$s }',
                 '<span title="buenas dias" style="%1$s">',
             ],
+            'descendent type & attribute value with ^ => with type & attribute prefix match' => [
+                'p span[title^=bon] { %1$s }',
+                '<span title="bonjour" style="%1$s">',
+            ],
             'descendant of type & class: type & attribute exact value, no quotes => with type & exact match (#381)' => [
                 'p.p-2 span[title=bonjour] { %1$s }',
                 '<span title="bonjour" style="%1$s">',
@@ -829,6 +833,10 @@ class EmogrifierTest extends TestCase
             'child => not parent' => ['span > html { %1$s }', '<html>'],
             'descendant => not sibling' => ['span span { %1$s }', '<span>'],
             'descendant => not parent' => ['p body { %1$s }', '<body>'],
+            'descendent type & attribute value with ^ => not element with only substring match in attribute value' => [
+                'p span[title^=njo] { %1$s }',
+                '<span title="bonjour">',
+            ],
             'type & :first-child => not 2nd of many' => ['p:first-child { %1$s }', '<p class="p-2">'],
             'type & :first-child => not last of many' => ['p:first-child { %1$s }', '<p class="p-7">'],
             'type & :last-child => not 1st of many' => ['p:last-child { %1$s }', '<p class="p-1">'],


### PR DESCRIPTION
Closes #443.  This was actually fixed by #506.  The tests added for `Emogrifier`
confirm this for the specific case; those (same) added for `CssInliner` confirm
there’s no similar issue with the Symfony CssSelector component.