### PR TITLE
[TASK] Test `:not(.class)` (as entire selector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Support `:not(…)` as an entire selector
+  ([#469](https://github.com/MyIntervals/emogrifier/pull/469),
+  [#725](https://github.com/MyIntervals/emogrifier/pull/725))
 - Add `HtmlPruner::removeRedundantClasses`
   ([#380](https://github.com/MyIntervals/emogrifier/issues/380),
   [#708](https://github.com/MyIntervals/emogrifier/pull/708))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - Support `:not(…)` as an entire selector
-  ([#469](https://github.com/MyIntervals/emogrifier/pull/469),
+  ([#469](https://github.com/MyIntervals/emogrifier/issues/469),
   [#725](https://github.com/MyIntervals/emogrifier/pull/725))
 - Add `HtmlPruner::removeRedundantClasses`
   ([#380](https://github.com/MyIntervals/emogrifier/issues/380),

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -524,9 +524,9 @@ class CssInlinerTest extends TestCase
                 'p:nth-of-type(-n+3) { %1$s }',
                 '<p class="p-4" id="p4" style="%1$s">',
             ],
-            // broken: :not with type => other type
-            // broken: :not with class => no class
-            // broken: :not with class => other class
+            ':not with type => other type' => [':not(p) { %1$s }', '<span style="%1$s">'],
+            ':not with class => no class' => [':not(.p-1) { %1$s }', '<span style="%1$s">'],
+            ':not with class => other class' => [':not(.p-1) { %1$s }', '<p class="p-2" style="%1$s">'],
             'type & :not with class => without class' => ['span:not(.foo) { %1$s }', '<span style="%1$s">'],
             'type & :not with class => with other class' => ['p:not(.foo) { %1$s }', '<p class="p-1" style="%1$s">'],
         ];
@@ -724,6 +724,8 @@ class CssInlinerTest extends TestCase
                 'p:nth-of-type(-n+3) { %1$s }',
                 '<p class="p-6">',
             ],
+            ':not with type => not that type' => [':not(p) { %1$s }', '<p class="p-1">'],
+            ':not with class => not that class' => [':not(.p-1) { %1$s }', '<p class="p-1">'],
             'type & :not with class => not with class' => ['p:not(.p-1) { %1$s }', '<p class="p-1">'],
         ];
     }


### PR DESCRIPTION
Also `:not(type)`.  There were placeholder comments “broken: …” for these tests.
The selectors are now supported by virtue of using the Symfony CssSelector
component.

Resolves #469.