### PR TITLE
[CLEANUP] Mark PHP 5.6 as deprecated for 3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#691](https://github.com/MyIntervals/emogrifier/pull/691))
 
 ### Deprecated
+- Support for PHP 5.6 will be removed in Emogrifier 4.0.
 - Deprecate the `Emogrifier` class
   ([#701](https://github.com/MyIntervals/emogrifier/pull/701))
 


### PR DESCRIPTION
Copied the relevant CHANGELOG entry from previous releases into the ‘x.y.z’
section so that it will appear in the 3.0 release note.