### PR TITLE
[FEATURE] Keep `display:none` elements with `-emogrifier-keep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Preserve `display: none` elements with `-emogrifier-keep` class
+  ([#252](https://github.com/MyIntervals/emogrifier/issues/252),
+  [#737](https://github.com/MyIntervals/emogrifier/pull/737))
 - Preserve valid `@import` rules
   ([#338](https://github.com/MyIntervals/emogrifier/issues/338),
   [#334](https://github.com/MyIntervals/emogrifier/pull/334),

--- a/README.md
+++ b/README.md
@@ -189,6 +189,24 @@ $prunedHtml = HtmlPruner::fromDomDocument($cssInliner->getDomDocument())
   ->removeRedundantClassesAfterCssInlined($cssInliner)->render();
 ```
 
+The `removeElementsWithDisplayNone` method will not remove any elements which
+have the class `-emogrifier-keep`.  So if, for example, there are elements which
+by default have `display: none` but are revealed by an `@media` rule, or which
+are intended as a preheader, you can add that class to those elements.  The
+paragraph in this HTML snippet will not be removed even though it has
+`display: none` (which has presumably been applied by `CssInliner::inlineCss()`
+from a CSS rule `.preheader { display: none; }`):
+
+```html
+<p class="preheader -emogrifier-keep" style="display: none;">
+	Hello World!
+</p>
+```
+
+The `removeRedundantClassesAfterCssInlined` (or `removeRedundantClasses`)
+method, if invoked after `removeElementsWithDisplayNone`, will remove the
+`-emogrifier-keep` class.
+
 ### Options
 
 There are several options that you can set on the `CssInliner` instance before

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ from a CSS rule `.preheader { display: none; }`):
 
 ```html
 <p class="preheader -emogrifier-keep" style="display: none;">
-	Hello World!
+  Hello World!
 </p>
 ```
 

--- a/src/Emogrifier/HtmlProcessor/HtmlPruner.php
+++ b/src/Emogrifier/HtmlProcessor/HtmlPruner.php
@@ -21,7 +21,9 @@ class HtmlPruner extends AbstractHtmlProcessor
      *
      * @var string
      */
-    const DISPLAY_NONE_MATCHER = '//*[contains(translate(translate(@style," ",""),"NOE","noe"),"display:none")]';
+    const DISPLAY_NONE_MATCHER
+        = '//*[@style and contains(translate(translate(@style," ",""),"NOE","noe"),"display:none")'
+        . ' and not(@class and contains(concat(" ", normalize-space(@class), " "), " -emogrifier-keep "))]';
 
     /**
      * Removes elements that have a "display: none;" style.

--- a/tests/Unit/Emogrifier/HtmlProcessor/HtmlPrunerTest.php
+++ b/tests/Unit/Emogrifier/HtmlProcessor/HtmlPrunerTest.php
@@ -89,6 +89,36 @@ class HtmlPrunerTest extends TestCase
     }
 
     /**
+     * @return string[][]
+     */
+    public function provideEmogrifierKeepClassAttribute()
+    {
+        return [
+            'special class alone' => ['-emogrifier-keep'],
+            'special class after another' => ['preheader -emogrifier-keep'],
+            'special class before another' => ['-emogrifier-keep preheader'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $classAttributeValue
+     *
+     * @dataProvider provideEmogrifierKeepClassAttribute
+     */
+    public function removeElementsWithDisplayNoneNotRemovesElementsWithClassEmogrifierKeep($classAttributeValue)
+    {
+        $subject = HtmlPruner::fromHtml(
+            '<html><body><div class="' . $classAttributeValue . '" style="display: none;"></div></body></html>'
+        );
+
+        $subject->removeElementsWithDisplayNone();
+
+        self::assertContains('<div', $subject->render());
+    }
+
+    /**
      * @test
      */
     public function removeRedundantClassesProvidesFluentInterface()


### PR DESCRIPTION
The additional part of the XPath expression was obtained by running
`:not(.-emogrifier-keep)` through `CssSelectorConverter::toXPath()`.  It tests
for attribute presence before checking the value, presumably as an omptimization
to avoid unnecessary processing of a null/empty value.  On the presumed basis
that this is a good idea, a similar check has been added for the `style`
attribute.

Resolves #252.