### PR TITLE
[BUGFIX] Dynamic and static pseudo-class combined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#690](https://github.com/MyIntervals/emogrifier/pull/690))
 
 ### Fixed
+- Dynamic pseudo-class combined with static one (rules copied to `<style>`
+  element, [#746](https://github.com/MyIntervals/emogrifier/pull/746))
 - Descendant attribute selectors (such as `html input[disabled]`)
   ([#375](https://github.com/MyIntervals/emogrifier/pull/375),
   [#709](https://github.com/MyIntervals/emogrifier/pull/709))

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -77,7 +77,7 @@ class Emogrifier
      *
      * @var string
      */
-    const PSEUDO_CLASS_MATCHER = '\\S+\\-(?:child|type\\()|not\\([[:ascii:]]*\\)';
+    const PSEUDO_CLASS_MATCHER = '[\\w\\-]+\\-(?:child|type\\()|not\\([[:ascii:]]*\\)';
 
     /**
      * @var string

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -51,7 +51,7 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @var string
      */
-    const PSEUDO_CLASS_MATCHER = '\\S+\\-(?:child|type\\()|not\\([[:ascii:]]*\\)';
+    const PSEUDO_CLASS_MATCHER = '[\\w\\-]+\\-(?:child|type\\()|not\\([[:ascii:]]*\\)';
 
     /**
      * @var bool[]

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1894,6 +1894,8 @@ class CssInlinerTest extends TestCase
             'pseudo-class & pseudo-element' => ['a:hover::after { content: "bar"; }'],
             'pseudo-element & pseudo-class' => ['a::after:hover { content: "bar"; }'],
             'two pseudo-classes' => ['a:focus:hover { color: green; }'],
+            'dynamic and static pseudo-classes' => ['a:hover:first-child { color: green; }'],
+            'static and dynamic pseudo-classes' => ['a:first-child:hover { color: green; }'],
         ];
 
         return \array_merge($datasetsWithSelectorPseudoComponents, $datasetsWithCombinedPseudoSelectors);

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -2042,6 +2042,8 @@ class EmogrifierTest extends TestCase
             'pseudo-class & pseudo-element' => ['a:hover::after { content: "bar"; }'],
             'pseudo-element & pseudo-class' => ['a::after:hover { content: "bar"; }'],
             'two pseudo-classes' => ['a:focus:hover { color: green; }'],
+            'dynamic and static pseudo-classes' => ['a:hover:first-child { color: green; }'],
+            'static and dynamic pseudo-classes' => ['a:first-child:hover { color: green; }'],
         ];
 
         return \array_merge($datasetsWithSelectorPseudoComponents, $datasetsWithCombinedPseudoSelectors);


### PR DESCRIPTION
The regular expression in `PSEUDO_CLASS_MATCHER` would match, e.g.,
`:hover:first-child` as a supported pseudo-class because it was consuming any
non-space character as being valid in a pseudo-class name.  This has been
corrected so that it only consumes ‘word’ characters and hyphens.