### PR TITLE
[TASK] Update supported pseudo-classes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ Emogrifier currently supports the following
    * [first-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-child)
    * [last-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)
    * [not()](https://developer.mozilla.org/en-US/docs/Web/CSS/:not)
+   * [nth-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child)
+   * [nth-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type)
+     (with a type, e.g. `p:nth-of-type(2n)` but not `*:nth-of-type(2n)` which
+     will behave as `*:nth-child(2n)`)
 
 The following selectors are not implemented yet:
 


### PR DESCRIPTION
This updates the list to those that are supported **and** for which we have
tests.  There are some others that are (probably) supported but for which we
don’t yet have any tests – see #747 – these have not been added to the list …
yet.

Part of #723.