### PR TITLE
[TASK] Test :nth-last-child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Test `:nth-last-child`
+  ([#747](https://github.com/MyIntervals/emogrifier/issues/747),
+  [#750](https://github.com/MyIntervals/emogrifier/pull/750))
 - Test general sibling combinator
   ([#723](https://github.com/MyIntervals/emogrifier/issues/723),
   [#745](https://github.com/MyIntervals/emogrifier/pull/745))

--- a/README.md
+++ b/README.md
@@ -347,8 +347,9 @@ Emogrifier currently supports the following
    * [first-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-child)
    * [last-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)
    * [not()](https://developer.mozilla.org/en-US/docs/Web/CSS/:not)
-   * [nth-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child)
-   * [nth-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type)
+   * [nth-child()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child)
+   * [nth-last-child()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-child)
+   * [nth-of-type()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type)
      (with a type, e.g. `p:nth-of-type(2n)` but not `*:nth-of-type(2n)` which
      will behave as `*:nth-child(2n)`)
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -77,7 +77,7 @@ class Emogrifier
      *
      * @var string
      */
-    const PSEUDO_CLASS_MATCHER = '[\\w\\-]+\\-(?:child|type\\()|not\\([[:ascii:]]*\\)';
+    const PSEUDO_CLASS_MATCHER = '(?:first|last|nth|only)-child|nth(?:-last)?+-of-type|not\\([[:ascii:]]*\\)';
 
     /**
      * @var string

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -51,7 +51,8 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @var string
      */
-    const PSEUDO_CLASS_MATCHER = '[\\w\\-]+\\-(?:child|type\\()|not\\([[:ascii:]]*\\)';
+    const PSEUDO_CLASS_MATCHER
+        = '(?:first|last|nth(?:-last)?+|only)-child|nth(?:-last)?+-of-type|not\\([[:ascii:]]*\\)';
 
     /**
      * @var bool[]

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -523,6 +523,46 @@ class CssInlinerTest extends TestCase
             ':nth-child(-n+3) => 2nd of many' => [':nth-child(-n+3) { %1$s }', '<p class="p-2" style="%1$s">'],
             ':nth-child(-n+3) => 3rd of many' => [':nth-child(-n+3) { %1$s }', '<div class="div-3" style="%1$s">'],
             'type & :nth-child(even) => 2nd of many' => ['p:nth-child(even) { %1$s }', '<p class="p-2" style="%1$s">'],
+            ':nth-last-child(even) => 2nd last of many' => [
+                ':nth-last-child(even) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
+            ':nth-last-child(even) => 4th last of many' => [
+                ':nth-last-child(even) { %1$s }',
+                '<p class="p-4" id="p4" style="%1$s">',
+            ],
+            ':nth-last-child(2n) => 2nd last of many' => [
+                ':nth-last-child(2n) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
+            ':nth-last-child(2n) => 4th last of many' => [
+                ':nth-last-child(2n) { %1$s }',
+                '<p class="p-4" id="p4" style="%1$s">',
+            ],
+            ':nth-last-child(3) => 3rd last of many' => [
+                ':nth-last-child(3) { %1$s }',
+                '<p class="p-5 additional-class" style="%1$s">',
+            ],
+            ':nth-last-child(2n+3) => 3rd last of many' => [
+                ':nth-last-child(2n+3) { %1$s }',
+                '<p class="p-5 additional-class" style="%1$s">',
+            ],
+            ':nth-last-child(2n+3) => 5th last of many' => [
+                ':nth-last-child(2n+3) { %1$s }',
+                '<div class="div-3" style="%1$s">',
+            ],
+            ':nth-last-child(-n+3) => 2nd last of many' => [
+                ':nth-last-child(-n+3) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
+            ':nth-last-child(-n+3) => 3rd last of many' => [
+                ':nth-last-child(-n+3) { %1$s }',
+                '<p class="p-5 additional-class" style="%1$s">',
+            ],
+            'type & :nth-last-child(even) => 2nd last of many' => [
+                'p:nth-last-child(even) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
             // broken: nth-of-type without preceding type
             'type & :nth-of-type(even) => 2nd of many of type' => [
                 'p:nth-of-type(even) { %1$s }',
@@ -734,6 +774,33 @@ class CssInlinerTest extends TestCase
             ':nth-child(2n+3) => not 4th of many' => [':nth-child(2n+3) { %1$s }', '<p class="p-4" id="p4">'],
             ':nth-child(-n+3) => not 4th of many' => [':nth-child(-n+3) { %1$s }', '<p class="p-4" id="p4">'],
             ':nth-child(-n+3) => not 5th of many' => [':nth-child(-n+3) { %1$s }', '<p class="p-5 additional-class">'],
+            ':nth-last-child(even) => not last of many' => [':nth-last-child(even) { %1$s }', '<p class="p-7">'],
+            ':nth-last-child(even) => not 3rd last of many' => [
+                ':nth-last-child(even) { %1$s }',
+                '<p class="p-5 additional-class">',
+            ],
+            ':nth-last-child(2n) => not last of many' => [':nth-last-child(2n) { %1$s }', '<p class="p-7">'],
+            ':nth-last-child(2n) => not 3rd last of many' => [
+                ':nth-last-child(2n) { %1$s }',
+                '<p class="p-5 additional-class">',
+            ],
+            ':nth-last-child(3) => not last of many' => [':nth-last-child(3) { %1$s }', '<p class="p-7">'],
+            ':nth-last-child(3) => not 2nd last of many' => [':nth-last-child(3) { %1$s }', '<p class="p-6">'],
+            ':nth-last-child(3) => not 4th last of many' => [':nth-last-child(3) { %1$s }', '<p class="p-4" id="p4">'],
+            ':nth-last-child(3) => not 6th last of many' => [':nth-last-child(3) { %1$s }', '<p class="p-2">'],
+            ':nth-last-child(2n+3) => not last of many' => [':nth-last-child(2n+3) { %1$s }', '<p class="p-7">'],
+            ':nth-last-child(2n+3) => not 4th last of many' => [
+                ':nth-last-child(2n+3) { %1$s }',
+                '<p class="p-4" id="p4">',
+            ],
+            ':nth-last-child(-n+3) => not 4th last of many' => [
+                ':nth-last-child(-n+3) { %1$s }',
+                '<p class="p-4" id="p4">',
+            ],
+            ':nth-last-child(-n+3) => not 5th last of many' => [
+                ':nth-last-child(-n+3) { %1$s }',
+                '<div class="div-3">',
+            ],
             'type & :nth-of-type(even) => not 1st of many of type' => [
                 'p:nth-of-type(even) { %1$s }',
                 '<p class="p-1">',

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -739,6 +739,7 @@ class EmogrifierTest extends TestCase
             ':nth-child(3) => 3rd of many' => ['*:nth-child(3) { %1$s }', '<div class="div-3" style="%1$s">'],
             // broken: nth-child(Xn+Y)
             'type & :nth-child(even) => 2nd of many' => ['p:nth-child(even) { %1$s }', '<p class="p-2" style="%1$s">'],
+            // broken: nth-last-child
             // broken: nth-of-type without preceding type
             'type & :nth-of-type(even) => 2nd of many of type' => [
                 'p:nth-of-type(even) { %1$s }',


### PR DESCRIPTION
Also updated the regex for supported pseudo-classes (`PSEUDO_CLASS_MATCHER`) so
that those supported are explicitly specified (rather than ‘anything ending with
`-child` or anything ending with `-type(`’), without acually affecting the valid
pseudo-class names it will match.  Except in the `Emogrifier` class – this
doesn’t support `:nth-last-child` so that has been removed (to the effect that
rules with it will now be copied to the `<style>` element rather than attempted
to be inlined).

And added `:nth-last-child` to the list of supported pseudo-classes in the
README.  (Also, for consistency, added `()` to the other `:nth…` pseudo-classes
in that section.)

Part of #747.