### PR TITLE
[TASK] Test :nth-last-of-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Support and test `:nth-last-of-type`
+  ([#747](https://github.com/MyIntervals/emogrifier/issues/747),
+  [#751](https://github.com/MyIntervals/emogrifier/pull/751))
 - Support and test `:nth-last-child`
   ([#747](https://github.com/MyIntervals/emogrifier/issues/747),
   [#750](https://github.com/MyIntervals/emogrifier/pull/750))

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Emogrifier currently supports the following
    * [not()](https://developer.mozilla.org/en-US/docs/Web/CSS/:not)
    * [nth-child()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child)
    * [nth-last-child()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-child)
+   * [nth-last-of-type()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-of-type)
    * [nth-of-type()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type)
      (with a type, e.g. `p:nth-of-type(2n)` but not `*:nth-of-type(2n)` which
      will behave as `*:nth-child(2n)`)

--- a/README.md
+++ b/README.md
@@ -350,9 +350,10 @@ Emogrifier currently supports the following
    * [nth-child()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child)
    * [nth-last-child()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-child)
    * [nth-last-of-type()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-of-type)
+     (with a type, e.g. `p:nth-last-of-type(2n)` but not
+     `*:nth-last-of-type(2n)` which will behave as `*:nth-last-child(2n)`)
    * [nth-of-type()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type)
-     (with a type, e.g. `p:nth-of-type(2n)` but not `*:nth-of-type(2n)` which
-     will behave as `*:nth-child(2n)`)
+     (with a type)
 
 The following selectors are not implemented yet:
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -77,7 +77,7 @@ class Emogrifier
      *
      * @var string
      */
-    const PSEUDO_CLASS_MATCHER = '(?:first|last|nth|only)-child|nth(?:-last)?+-of-type|not\\([[:ascii:]]*\\)';
+    const PSEUDO_CLASS_MATCHER = '(?:first|last|nth|only)-child|nth-of-type|not\\([[:ascii:]]*\\)';
 
     /**
      * @var string

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -600,6 +600,43 @@ class CssInlinerTest extends TestCase
                 'p:nth-of-type(-n+3) { %1$s }',
                 '<p class="p-4" id="p4" style="%1$s">',
             ],
+            // broken: nth-last-of-type without preceding type
+            'type & :nth-last-of-type(even) => 2nd last of many of type' => [
+                'p:nth-last-of-type(even) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(even) => 4th last of many of type' => [
+                'p:nth-last-of-type(even) { %1$s }',
+                '<p class="p-4" id="p4" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(2n) => 2nd last of many of type' => [
+                'p:nth-last-of-type(2n) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(2n) => 4th last of many of type' => [
+                'p:nth-last-of-type(2n) { %1$s }',
+                '<p class="p-4" id="p4" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(3) => 3rd last of many of type' => [
+                'p:nth-last-of-type(3) { %1$s }',
+                '<p class="p-5 additional-class" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(2n+3) => 3rd last of many of type' => [
+                'p:nth-last-of-type(2n+3) { %1$s }',
+                '<p class="p-5 additional-class" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(2n+3) => 5th last of many of type' => [
+                'p:nth-last-of-type(2n+3) { %1$s }',
+                '<p class="p-2" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(-n+3) => 2nd last of many of type' => [
+                'p:nth-last-of-type(-n+3) { %1$s }',
+                '<p class="p-6" style="%1$s">',
+            ],
+            'type & :nth-last-of-type(-n+3) => 3rd last of many of type' => [
+                'p:nth-last-of-type(-n+3) { %1$s }',
+                '<p class="p-5 additional-class" style="%1$s">',
+            ],
             ':not with type => other type' => [':not(p) { %1$s }', '<span style="%1$s">'],
             ':not with class => no class' => [':not(.p-1) { %1$s }', '<span style="%1$s">'],
             ':not with class => other class' => [':not(.p-1) { %1$s }', '<p class="p-2" style="%1$s">'],
@@ -836,6 +873,54 @@ class CssInlinerTest extends TestCase
             'type & :nth-of-type(-n+3) => not 5th of many of type' => [
                 'p:nth-of-type(-n+3) { %1$s }',
                 '<p class="p-6">',
+            ],
+            'type & :nth-last-of-type(even) => not last of many of type' => [
+                'p:nth-last-of-type(even) { %1$s }',
+                '<p class="p-7">',
+            ],
+            'type & :nth-last-of-type(even) => not 3rd last of many of type' => [
+                'p:nth-last-of-type(even) { %1$s }',
+                '<p class="p-5 additional-class">',
+            ],
+            'type & :nth-last-of-type(2n) => not last of many of type' => [
+                'p:nth-last-of-type(2n) { %1$s }',
+                '<p class="p-7">',
+            ],
+            'type & :nth-last-of-type(2n) => not 3rd last of many of type' => [
+                'p:nth-last-of-type(2n) { %1$s }',
+                '<p class="p-5 additional-class">',
+            ],
+            'type & :nth-last-of-type(3) => not last of many of type' => [
+                'p:nth-last-of-type(3) { %1$s }',
+                '<p class="p-7">',
+            ],
+            'type & :nth-last-of-type(3) => not 2nd last of many of type' => [
+                'p:nth-last-of-type(3) { %1$s }',
+                '<p class="p-6">',
+            ],
+            'type & :nth-last-of-type(3) => not 4th last of many of type' => [
+                'p:nth-last-of-type(3) { %1$s }',
+                '<p class="p-4" id="p4">',
+            ],
+            'type & :nth-last-of-type(3) => not 6th last of many of type' => [
+                'p:nth-last-of-type(3) { %1$s }',
+                '<p class="p-1">',
+            ],
+            'type & :nth-last-of-type(2n+3) => not last of many of type' => [
+                'p:nth-last-of-type(2n+3) { %1$s }',
+                '<p class="p-7">',
+            ],
+            'type & :nth-last-of-type(2n+3) => not 4th last of many of type' => [
+                'p:nth-last-of-type(2n+3) { %1$s }',
+                '<p class="p-4" id="p4">',
+            ],
+            'type & :nth-last-of-type(-n+3) => not 4th last of many of type' => [
+                'p:nth-last-of-type(-n+3) { %1$s }',
+                '<p class="p-4" id="p4">',
+            ],
+            'type & :nth-last-of-type(-n+3) => not 5th last of many of type' => [
+                'p:nth-last-of-type(-n+3) { %1$s }',
+                '<p class="p-2">',
             ],
             ':not with type => not that type' => [':not(p) { %1$s }', '<p class="p-1">'],
             ':not with class => not that class' => [':not(.p-1) { %1$s }', '<p class="p-1">'],

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -762,6 +762,7 @@ class EmogrifierTest extends TestCase
                 '<p class="p-4" id="p4" style="%1$s">',
             ],
             // broken: nth-of-type(Xn+Y)
+            // broken: nth-last-of-type
             // broken: :not with type => other type
             // broken: :not with class => no class
             // broken: :not with class => other class


### PR DESCRIPTION
Also removed it from the regex for supported pseudo-classes
(`Emogrifier::PSEUDO_CLASS_MATCHER`) for the legacy `Emogrifier` class which
does not support it (to the effect that rules with it will now be copied to the
`<style>` element rather than attempted to be inlined).

And added `:nth-last-of-type` to the list of supported pseudo-classes in the
README.

Part of #747.