### PR TITLE
[TASK] Test :any-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Test that rules with `:any-link` are copied to the `<style>` element
+  ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
+  [#755](https://github.com/MyIntervals/emogrifier/pull/755))
 - Support and test `:only-child`
   ([#747](https://github.com/MyIntervals/emogrifier/issues/747),
   [#754](https://github.com/MyIntervals/emogrifier/pull/754))

--- a/README.md
+++ b/README.md
@@ -372,7 +372,8 @@ The following selectors are not implemented yet:
      without a type (will behave as `:nth-child()`)
    * any pseudo-classes not listed above as supported – rules involving them
      will nonetheless be preserved and copied to a `<style>` element in the 
-     HTML.
+     HTML – including (but not necessarily limited to) the following:
+     * [any-link](https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link)
      
 Rules involving the following selectors cannot be applied as inline styles.
 They will, however, be preserved and copied to a `<style>` element in the HTML:

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -648,6 +648,7 @@ class CssInlinerTest extends TestCase
             ':not with class => other class' => [':not(.p-1) { %1$s }', '<p class="p-2" style="%1$s">'],
             'type & :not with class => without class' => ['span:not(.foo) { %1$s }', '<span style="%1$s">'],
             'type & :not with class => with other class' => ['p:not(.foo) { %1$s }', '<p class="p-1" style="%1$s">'],
+            // broken: child of :any-link => child of anchor with href
         ];
     }
 
@@ -2061,8 +2062,15 @@ class CssInlinerTest extends TestCase
             'dynamic and static pseudo-classes' => ['a:hover:first-child { color: green; }'],
             'static and dynamic pseudo-classes' => ['a:first-child:hover { color: green; }'],
         ];
+        $datasetsWithUnsupportedStaticPseudoClasses = [
+            ':any-link' => ['a:any-link { color: green; }'],
+        ];
 
-        return \array_merge($datasetsWithSelectorPseudoComponents, $datasetsWithCombinedPseudoSelectors);
+        return \array_merge(
+            $datasetsWithSelectorPseudoComponents,
+            $datasetsWithCombinedPseudoSelectors,
+            $datasetsWithUnsupportedStaticPseudoClasses
+        );
     }
 
     /**

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -2048,8 +2048,18 @@ class EmogrifierTest extends TestCase
             'dynamic and static pseudo-classes' => ['a:hover:first-child { color: green; }'],
             'static and dynamic pseudo-classes' => ['a:first-child:hover { color: green; }'],
         ];
+        $datasetsWithUnsupportedStaticPseudoClasses = [
+            ':any-link' => ['a:any-link { color: green; }'],
+            ':nth-last-child' => ['a:nth-last-child(2n+1) { color: green; }'],
+            ':nth-last-of-type' => ['a:nth-last-of-type(2n+1) { color: green; }'],
+            ':only-child' => ['a:only-child { color: green; }'],
+        ];
 
-        return \array_merge($datasetsWithSelectorPseudoComponents, $datasetsWithCombinedPseudoSelectors);
+        return \array_merge(
+            $datasetsWithSelectorPseudoComponents,
+            $datasetsWithCombinedPseudoSelectors,
+            $datasetsWithUnsupportedStaticPseudoClasses
+        );
     }
 
     /**


### PR DESCRIPTION
Added a “broken: …” comment placeholder to indicate that support for `:any-link`
with the Symfony CssSelector component has been checked and found to be lacking,
suggesting tests to be added if and when it is supported in future.

Added test to confirm rules with `:any-link` are nonetheless copied to a
`<style>` element.  Also added similar tests for `:nth-last-child`,
`:nth-last-of-type` and `:only-child` with the `Emogrifier` class (these are
fully supported only with the `CssInliner` class).

In the README, added `:any-link` to a list of unsupported static pseudo-classes
that are copied to a `<style>` element rather than being inlined.

Part of #748.