### PR TITLE
[TASK] Test :only-of-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Test that rules with `:only-of-type` are copied to the `<style>` element
+  ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
+  [#760](https://github.com/MyIntervals/emogrifier/pull/760))
 - Support `:last-of-type`
   ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
   [#758](https://github.com/MyIntervals/emogrifier/pull/758))

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ The following selectors are not implemented yet:
      will nonetheless be preserved and copied to a `<style>` element in the 
      HTML – including (but not necessarily limited to) the following:
      * [any-link](https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link)
+     * [only-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type)
      
 Rules involving the following selectors cannot be applied as inline styles.
 They will, however, be preserved and copied to a `<style>` element in the HTML:

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -582,6 +582,7 @@ class CssInlinerTest extends TestCase
                 'div:last-of-type { %1$s }',
                 '<div class="div-3" style="%1$s">',
             ],
+            // broken: only-of-type (https://github.com/symfony/symfony/issues/33773)
             // broken: nth-of-type without preceding type
             'type & :nth-of-type(even) => 2nd of many of type' => [
                 'p:nth-of-type(even) { %1$s }',
@@ -2085,6 +2086,7 @@ class CssInlinerTest extends TestCase
         ];
         $datasetsWithUnsupportedStaticPseudoClasses = [
             ':any-link' => ['a:any-link { color: green; }'],
+            ':only-of-type' => ['a:only-of-type { color: green; }'],
         ];
 
         return \array_merge(

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -2056,6 +2056,7 @@ class EmogrifierTest extends TestCase
             ':nth-last-child' => ['a:nth-last-child(2n+1) { color: green; }'],
             ':nth-last-of-type' => ['a:nth-last-of-type(2n+1) { color: green; }'],
             ':only-child' => ['a:only-child { color: green; }'],
+            ':only-of-type' => ['a:only-of-type { color: green; }'],
         ];
 
         return \array_merge(


### PR DESCRIPTION
Added a “broken: …” comment placeholder to indicate that support for
`:only-of-type` with the Symfony CssSelector component has been checked and
found to be broken (see https://github.com/symfony/symfony/issues/33773),
suggesting tests to be added when it is fixed.

(It does not make sense to support a feature that is broken the way it is – for
email clients that support `:only-of-type`, the desired result will currently
only be achieved if rules involving it are copied to a `<style>` element, rather
than being only partially inlined.)

Added test to confirm rules with `:only-of-type` are copied to a `<style>`
element.

In the README, added `:only-of-type` to the list of unsupported static
pseudo-classes that are copied to a `<style>` element rather than being inlined.

Part of #748.