### PR TITLE
[TASK] Show XPath expression for test failures

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -6,6 +6,7 @@ use Pelago\Emogrifier\CssInliner;
 use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 use Pelago\Tests\Support\Traits\AssertCss;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
 
 /**
@@ -679,11 +680,18 @@ class CssInlinerTest extends TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
+        $needleExpected = \sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2);
+
         $subject = $this->buildDebugSubject(self::COMMON_TEST_HTML);
 
         $subject->inlineCss(\sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
-        self::assertContains(\sprintf($expectedHtml, $cssDeclaration1, $cssDeclaration2), $subject->render());
+        $result = $subject->render();
+        $selector = \trim(\strtok($css, '{'));
+        $cssSelectorConverter = new CssSelectorConverter();
+        $xPathExpression = $cssSelectorConverter->toXPath($selector);
+        $message = 'with converted XPath expression `' . $xPathExpression . '`';
+        self::assertContains($needleExpected, $result, $message);
     }
 
     /**


### PR DESCRIPTION
This will help more quickly diagnose why a particular test might have failed.