### PR TITLE
[TASK] Relax the dependency on symfony/css-selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   [#698](https://github.com/MyIntervals/emogrifier/pull/698))
 
 ### Changed
+- Relax the dependency on `symfony/css-selector`
+  ([#762](https://github.com/MyIntervals/emogrifier/pull/762))
 - Rename `HtmlPruner::removeInvisibleNodes` to
   `HtmlPruner::removeElementsWithDisplayNone`
   ([#717](https://github.com/MyIntervals/emogrifier/issues/717),

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "symfony/css-selector": "^3.4.0 || ^4.0.0"
+        "symfony/css-selector": "^2.8 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15.3",


### PR DESCRIPTION
This reduces the probability of dependency conflicts with other packages.

`symfony/css-selector` 2.8 is the first version that provides the
functionality required by Emogrifier.