### PR TITLE
[TASK] Test :optional and :required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Test that rules with `:optional` or `:required` are copied to the `<style>`
+  element ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
+  [#764](https://github.com/MyIntervals/emogrifier/pull/764))
 - Test that rules with `:only-of-type` are copied to the `<style>` element
   ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
   [#760](https://github.com/MyIntervals/emogrifier/pull/760))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Test that rules with `:optional` or `:required` are copied to the `<style>`
   element ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
-  [#764](https://github.com/MyIntervals/emogrifier/pull/764))
+  [#765](https://github.com/MyIntervals/emogrifier/pull/765))
 - Test that rules with `:only-of-type` are copied to the `<style>` element
   ([#748](https://github.com/MyIntervals/emogrifier/issues/748),
   [#760](https://github.com/MyIntervals/emogrifier/pull/760))

--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ The following selectors are not implemented yet:
      HTML – including (but not necessarily limited to) the following:
      * [any-link](https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link)
      * [only-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type)
+     * [optional](https://developer.mozilla.org/en-US/docs/Web/CSS/:optional)
+     * [required](https://developer.mozilla.org/en-US/docs/Web/CSS/:required)
      
 Rules involving the following selectors cannot be applied as inline styles.
 They will, however, be preserved and copied to a `<style>` element in the HTML:

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -354,6 +354,8 @@ class CssInlinerTest extends TestCase
             // broken: type & attribute value with ^, case insensitive => with case insensitive prefix math
             // broken: type & attribute value with $, case insensitive => with case insensitive suffix math
             // broken: type & attribute value with *, case insensitive => with case insensitive substring math
+            // broken: :required
+            // broken: :optional
             'adjacent => 2nd of many' => ['p + p { %1$s }', '<p class="p-2" style="%1$s">'],
             'adjacent => last of many' => ['p + p { %1$s }', '<p class="p-7" style="%1$s">'],
             'adjacent (without space after +) => last of many' => ['p +p { %1$s }', '<p class="p-7" style="%1$s">'],
@@ -2095,6 +2097,8 @@ class CssInlinerTest extends TestCase
         $datasetsWithUnsupportedStaticPseudoClasses = [
             ':any-link' => ['a:any-link { color: green; }'],
             ':only-of-type' => ['a:only-of-type { color: green; }'],
+            ':optional' => ['input:optional { color: green; }'],
+            ':required' => ['input:required { color: green; }'],
         ];
 
         return \array_merge(
@@ -2113,7 +2117,7 @@ class CssInlinerTest extends TestCase
      */
     public function inlineCssKeepsRuleWithPseudoComponentInMatchingSelector($css)
     {
-        $subject = $this->buildDebugSubject('<html><p><a id="a" class="a" href="a">foo</a></p></html>');
+        $subject = $this->buildDebugSubject('<html><p><a id="a" class="a" href="a">foo</a><input></p></html>');
 
         $subject->inlineCss($css);
 

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -2117,7 +2117,9 @@ class CssInlinerTest extends TestCase
      */
     public function inlineCssKeepsRuleWithPseudoComponentInMatchingSelector($css)
     {
-        $subject = $this->buildDebugSubject('<html><p><a id="a" class="a" href="a">foo</a><input></p></html>');
+        $subject = $this->buildDebugSubject(
+            '<html><p><a id="a" class="a" href="a">foo</a><input type="text" name="test"/></p></html>'
+        );
 
         $subject->inlineCss($css);
 

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -2057,6 +2057,8 @@ class EmogrifierTest extends TestCase
             ':nth-last-of-type' => ['a:nth-last-of-type(2n+1) { color: green; }'],
             ':only-child' => ['a:only-child { color: green; }'],
             ':only-of-type' => ['a:only-of-type { color: green; }'],
+            ':optional' => ['input:optional { color: green; }'],
+            ':required' => ['input:required { color: green; }'],
         ];
 
         return \array_merge(
@@ -2075,7 +2077,7 @@ class EmogrifierTest extends TestCase
      */
     public function emogrifyKeepsRuleWithPseudoComponentInMatchingSelector($css)
     {
-        $this->subject->setHtml('<html><p><a id="a" class="a" href="a">foo</a></p></html>');
+        $this->subject->setHtml('<html><p><a id="a" class="a" href="a">foo</a><input></p></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -2077,7 +2077,9 @@ class EmogrifierTest extends TestCase
      */
     public function emogrifyKeepsRuleWithPseudoComponentInMatchingSelector($css)
     {
-        $this->subject->setHtml('<html><p><a id="a" class="a" href="a">foo</a><input></p></html>');
+        $this->subject->setHtml(
+            '<html><p><a id="a" class="a" href="a">foo</a><input type="text" name="test"/></p></html>'
+        );
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();


### PR DESCRIPTION
Added a “broken: …” comment placeholder to indicate that support for `:required`
and `:optional` with the Symfony CssSelector component has been checked and
found to be lacking, suggesting tests to be added if and when it is supported in
future.

Added tests to confirm rules with `:required` or `:optional` are nonetheless
copied to a `<style>` element.

In the README, added `:required` and `:optional` to the list of unsupported
static pseudo-classes that are copied to a `<style>` element rather than being
inlined.

Closes #748.