### PR TITLE
[TASK] Also sniff the code against the PSR-12 standard

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,10 @@
 
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
 
-    <!--The complete PSR-2 ruleset-->
-    <rule ref="PSR2"/>
+    <!-- The complete PSR-12 ruleset (excluding a rule that requires PHP >= 7.1 -->
+    <rule ref="PSR12">
+        <exclude name="PSR12.Properties.ConstantVisibility"/>
+    </rule>
 
     <!-- Arrays -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,9 @@
 
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
 
-    <!-- The complete PSR-12 ruleset (excluding a rule that requires PHP >= 7.1 -->
+    <!-- The complete PSR-12 ruleset -->
     <rule ref="PSR12">
+        <!-- Exclude a rule that requires PHP >= 7.1. -->
         <exclude name="PSR12.Properties.ConstantVisibility"/>
     </rule>
 

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -906,7 +906,8 @@ class Emogrifier
             }
 
             $newAttributeValue = $newStyles[$attributeName];
-            if ($this->attributeValueIsImportant($attributeValue)
+            if (
+                $this->attributeValueIsImportant($attributeValue)
                 && !$this->attributeValueIsImportant($newAttributeValue)
             ) {
                 unset($newStyles[$attributeName]);
@@ -1209,11 +1210,13 @@ class Emogrifier
         $possiblyModifiedCss = $css;
         $importRules = '';
 
-        while (\preg_match(
-            '/^\\s*+(@((?i)import(?-i)|charset)\\s[^;]++;\\s*+)/',
-            $possiblyModifiedCss,
-            $matches
-        )) {
+        while (
+            \preg_match(
+                '/^\\s*+(@((?i)import(?-i)|charset)\\s[^;]++;\\s*+)/',
+                $possiblyModifiedCss,
+                $matches
+            )
+        ) {
             list($fullMatch, $atRuleAndFollowingWhitespace, $atRuleName) = $matches;
 
             if (\strtolower($atRuleName) === 'import') {

--- a/src/Emogrifier/CssInliner.php
+++ b/src/Emogrifier/CssInliner.php
@@ -493,11 +493,13 @@ class CssInliner extends AbstractHtmlProcessor
         $possiblyModifiedCss = $css;
         $importRules = '';
 
-        while (\preg_match(
-            '/^\\s*+(@((?i)import(?-i)|charset)\\s[^;]++;\\s*+)/',
-            $possiblyModifiedCss,
-            $matches
-        )) {
+        while (
+            \preg_match(
+                '/^\\s*+(@((?i)import(?-i)|charset)\\s[^;]++;\\s*+)/',
+                $possiblyModifiedCss,
+                $matches
+            )
+        ) {
             list($fullMatch, $atRuleAndFollowingWhitespace, $atRuleName) = $matches;
 
             if (\strtolower($atRuleName) === 'import') {
@@ -825,7 +827,8 @@ class CssInliner extends AbstractHtmlProcessor
             }
 
             $newAttributeValue = $newStyles[$attributeName];
-            if ($this->attributeValueIsImportant($attributeValue)
+            if (
+                $this->attributeValueIsImportant($attributeValue)
                 && !$this->attributeValueIsImportant($newAttributeValue)
             ) {
                 unset($newStyles[$attributeName]);

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1608,13 +1608,18 @@ class CssInlinerTest extends TestCase
                 foreach ($possibleSurroundingCss as $descriptionAfter => $cssAfter) {
                     // every combination would be a ridiculous c.1000 datasets - choose a select few
                     // test all possible CSS before once
-                    if (($cssBetween === '' && $cssAfter === '')
+                    if (
+                        ($cssBetween === ''
+                        && $cssAfter === '')
                         // test all possible CSS between once
-                        || ($cssBefore === '' && $cssAfter === '')
+                        || ($cssBefore === ''
+                        && $cssAfter === '')
                         // test all possible CSS after once
-                        || ($cssBefore === '' && $cssBetween === '')
+                        || ($cssBefore === ''
+                        && $cssBetween === '')
                         // test with each possible CSS in all three positions
-                        || ($cssBefore === $cssBetween && $cssBetween === $cssAfter)
+                        || ($cssBefore === $cssBetween
+                        && $cssBetween === $cssAfter)
                     ) {
                         $description = ' with ' . $descriptionBefore . ' before, '
                             . $descriptionBetween . ' between, '

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -1549,13 +1549,18 @@ class EmogrifierTest extends TestCase
                 foreach ($possibleSurroundingCss as $descriptionAfter => $cssAfter) {
                     // every combination would be a ridiculous c.1000 datasets - choose a select few
                     // test all possible CSS before once
-                    if (($cssBetween === '' && $cssAfter === '')
+                    if (
+                        ($cssBetween === ''
+                        && $cssAfter === '')
                         // test all possible CSS between once
-                        || ($cssBefore === '' && $cssAfter === '')
+                        || ($cssBefore === ''
+                        && $cssAfter === '')
                         // test all possible CSS after once
-                        || ($cssBefore === '' && $cssBetween === '')
+                        || ($cssBefore === ''
+                        && $cssBetween === '')
                         // test with each possible CSS in all three positions
-                        || ($cssBefore === $cssBetween && $cssBetween === $cssAfter)
+                        || ($cssBefore === $cssBetween
+                        && $cssBetween === $cssAfter)
                     ) {
                         $description = ' with ' . $descriptionBefore . ' before, '
                             . $descriptionBetween . ' between, '


### PR DESCRIPTION
The latest version of PHP_CodeSniffer now supports PSR-12,
which supersedes PSR-2.