### PR TITLE
[CLEANUP] Clarify !important and @import in caveats in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,11 +431,11 @@ They will, however, be preserved and copied to a `<style>` element in the HTML:
   (such as `::after`) or dynamic pseudo-classes (such as `:hover`) – it is
   impossible.  However, such rules will be preserved and copied to a `<style>`
   element, as for `@media` rules.  The same caveat about the possible need for
-  the `!important` directive applies in these cases too.
+  the `!important` directive also applies with pseudo-classes.
 * Emogrifier will grab existing inline style attributes _and_ will
   grab `<style>` blocks from your HTML, but it will not grab CSS files
-  referenced in `<link>` elements (though it will leave them intact for email
-  clients that support them).
+  referenced in `<link>` elements or `@import` rules (though it will leave them
+  intact for email clients that support them).
 * Even with styles inline, certain CSS properties are ignored by certain email
   clients. For more information, refer to these resources:
     * [http://www.email-standards.org/](http://www.email-standards.org/)


### PR DESCRIPTION
- `!important` would not be needed for pseudo-elements – there can’t be any
  inline styles applied to them that need to be overridden because they don’t
  exist as elements in the DOM;
- Emogrifier will not grab CSS files from `@import` rules but will preserve
  them.