### PR TITLE
[TASK] Drop support for PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-- "5.6"
 - "7.0"
 - "7.1"
 - "7.2"
@@ -53,15 +52,8 @@ script:
 
 - >
   echo;
-  function version_gte() { test "$(printf '%s\n' "$@" | sort -n -t. -r | head -n 1)" = "$1"; };
-  if version_gte $(composer php:version) 7; then
-    echo "Installing slevomat/coding-standard only for PHP 7.x";
-    composer require $IGNORE_PLATFORM_REQS --dev slevomat/coding-standard:^4.0 $DEPENDENCIES_PREFERENCE;
-    echo "Running PHP_CodeSniffer";
-    composer ci:php:sniff;
-  else
-    echo "Skipped PHP_CodeSniffer due to insufficient PHP version: $(composer php:version)";
-  fi;
+  echo "Running PHP_CodeSniffer";
+  composer ci:php:sniff;
 
 - >
   echo;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Deprecated
+- Support for PHP 7.0 will be removed in Emogrifier 5.0.
 
 ### Removed
+- Drop support for PHP 5.6
+  ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15.3",
         "squizlabs/php_codesniffer": "^3.5.0",
-        "slevomat/coding-standard": "5.0.4",
+        "slevomat/coding-standard": "^5.0.4",
         "phpmd/phpmd": "^2.7.0",
         "phpunit/phpunit": "^5.7.27"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "source": "https://github.com/MyIntervals/emogrifier"
     },
     "require": {
-        "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0",
+        "php": "~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "symfony/css-selector": "^2.8 || ^3.0 || ^4.0"
@@ -45,6 +45,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15.3",
         "squizlabs/php_codesniffer": "^3.5.0",
+        "slevomat/coding-standard": "5.0.4",
         "phpmd/phpmd": "^2.7.0",
         "phpunit/phpunit": "^5.7.27"
     },


### PR DESCRIPTION
Now PHP >= 7.0 is required.

Changes to the code and to the php-cs-fixer configuration will come
in separate changes.