### PR TITLE
[CLEANUP] Test universal selector with combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Test universal selector with combinators
+  ([#776](https://github.com/MyIntervals/emogrifier/pull/776))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,6 @@ Emogrifier currently supports the following
  * [class](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors)
  * [ID](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors)
  * [universal](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors)
-   (partial support)
  * [attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors):
     * presence
     * exact value match
@@ -324,12 +323,6 @@ Emogrifier currently supports the following
 
 The following selectors are not implemented yet:
 
- * [universal](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors):
-   * with
-     [child combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator)
-   * as ancestor with 
-     [descendant combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator)
-     (e.g. `p *` is supported but `* p` is not)
  * [case-insensitive attribute value](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#case-insensitive)
  * static [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes):
    * [first-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type)

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -394,12 +394,12 @@ class CssInlinerTest extends TestCase
             'universal general sibling => last of many' => ['.p-1 ~ * { %1$s }', '<p class="p-7" style="%1$s">'],
             'general sibling of universal => 2nd of many' => ['* ~ p { %1$s }', '<p class="p-2" style="%1$s">'],
             'general sibling of universal => last of many' => ['* ~ p { %1$s }', '<p class="p-7" style="%1$s">'],
-            // broken: child universal => direct child
-            // broken: child of universal => direct child
+            'child universal => direct child' => ['body > * { %1$s }', '<p class="p-1" style="%1$s">'],
+            'child of universal => direct child' => ['* > body { %1$s }', '<body style="%1$s">'],
             'descendent universal => child' => ['p * { %1$s }', '<span style="%1$s">'],
             'descendent universal => grandchild' => ['body * { %1$s }', '<span style="%1$s">'],
-            // broken: descandant of universal => child
-            // broken: descandant of universal => grandchild
+            'descendant of universal => child' => ['* body { %1$s }', '<body style="%1$s">'],
+            'descendant of universal => grandchild' => ['* p { %1$s }', '<p class="p-1" style="%1$s">'],
             'descendent attribute presence => with attribute' => [
                 'body [title] { %1$s }',
                 '<span title="bonjour" style="%1$s">',
@@ -780,8 +780,13 @@ class CssInlinerTest extends TestCase
             'universal general sibling => not 1st of many' => ['p ~ * { %1$s }', '<p class="p-1">'],
             'universal general sibling => not previous of many' => ['.p-2 ~ * { %1$s }', '<p class="p-1">'],
             'general sibling of universal => not 1st of many' => ['* ~ p { %1$s }', '<p class="p-1">'],
+            'child universal => not parent' => ['body > * { %1$s }', '<html>'],
+            'child universal => not self' => ['body > * { %1$s }', '<body>'],
+            'child universal => not grandchild' => ['body > * { %1$s }', '<span>'],
+            'child of universal => not root element' => ['* > html { %1$s }', '<html>'],
             'descendent universal => not parent' => ['p *', '<body>'],
             'descendent universal => not self' => ['p *', '<p class="p-1">'],
+            'descendant of universal => not root element' => ['* html { %1$s }', '<html>'],
             'descendent type & attribute value with ^ => not element with only substring match in attribute value' => [
                 'p span[title^=njo] { %1$s }',
                 '<span title="bonjour">',


### PR DESCRIPTION
Looks like I was initially mistaken in believing these were not supported with
Symfony CssSelector (#743).  Looking again, I find that they are, so have added
the missing tests and updated the README accordingly.