### PR TITLE
[BUGFIX] Lower the slevomat/coding-standard requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15.3",
         "squizlabs/php_codesniffer": "^3.5.0",
-        "slevomat/coding-standard": "^5.0.4",
+        "slevomat/coding-standard": "^4.0.0",
         "phpmd/phpmd": "^2.7.0",
         "phpunit/phpunit": "^5.7.27"
     },


### PR DESCRIPTION
The required version of that package needs to work with PHP 7.0
as long as run out tests with PHP 7.0.