### PR TITLE
Support `ci:php:lint` on Windows, fixes #740

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
+- Support `ci:php:lint` on Windows
+  ([#740](https://github.com/MyIntervals/emogrifier/issues/740),
+  [#780](https://github.com/MyIntervals/emogrifier/pull/780))
 
 ## 3.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "squizlabs/php_codesniffer": "^3.5.0",
         "slevomat/coding-standard": "^4.0.0",
         "phpmd/phpmd": "^2.7.0",
-        "phpunit/phpunit": "^5.7.27"
+        "phpunit/phpunit": "^5.7.27",
+        "jakub-onderka/php-parallel-lint": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -68,7 +69,7 @@
     "scripts": {
         "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
         "php:fix": "php-cs-fixer --config=config/php-cs-fixer.php fix config/ src/ tests/",
-        "ci:php:lint": "find config src tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+        "ci:php:lint": "parallel-lint config src tests",
         "ci:php:sniff": "phpcs config src tests",
         "ci:php:fixer": "php-cs-fixer --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff config/ src/ tests/",
         "ci:php:md": "phpmd src text config/phpmd.xml",


### PR DESCRIPTION
uses jakub-onderka/php-parallel-lint to run `php -l` on windows without using the git for windows cli (git bash)