### PR TITLE
[FEATURE] Composer script for PHPUnit with --stop-on-failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Composer script to run tests with `--stop-on-failure`
+  ([#782](https://github.com/MyIntervals/emogrifier/pull/782))
 - Test universal selector with combinators
   ([#776](https://github.com/MyIntervals/emogrifier/pull/776))
 

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "ci:php:fixer": "php-cs-fixer --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff config/ src/ tests/",
         "ci:php:md": "phpmd src text config/phpmd.xml",
         "ci:tests:unit": "phpunit tests/",
+        "ci:tests:sof": "phpunit tests/ --stop-on-failure",
         "ci:tests": [
             "@ci:tests:unit"
         ],


### PR DESCRIPTION
During development, if something is a bit awry, it’s likely that a whole bunch
of tests will fail, producing reams of output about all the failures.  In this
situation, it’s preferable to be able to run the tests so that they will stop on
the first failure.

The name of the script is deliberaly short – it needs to be manually typed (at
least once), often in frustration!