### PR TITLE
[TASK] track issues relating to php 7.1

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -157,9 +157,9 @@
   <!-- NonStaticSelfCall is retained, to be reviewed with #792 -->
   <file src="tests/Support/Traits/AssertCss.php">
     <MixedArgument occurrences="3">
-      <code>$matches[1]</code>
-      <code>$matches[3]</code>
-      <code>$matches[0]</code>
+      <code>$matches[1]</code> <!-- retained, to be reviewed with #793  -->
+      <code>$matches[3]</code> <!-- retained, to be reviewed with #793  -->
+      <code>$matches[0]</code> <!-- retained, to be reviewed with #793  -->
     </MixedArgument>
     <NonStaticSelfCall occurrences="1"/>
   </file>


### PR DESCRIPTION
~This commit resolves a set of MixedArgument issues.
This commit *should* be type-hinting the closure parameter via
`@psalm-param array{0:string, 1:string, 2:string, 3:string} $matches`,
but as of vimeo/psalm 3.2.12, this raises a MixedArgumentTypeCoercion
issue.~

~regarding: #537, #793~

regarding: #806, https://github.com/MyIntervals/emogrifier/pull/802#pullrequestreview-298296128