### PR TITLE
[CLEANUP] Fix psalm issues in HtmlPruner

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -111,8 +111,7 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/HtmlProcessor/HtmlPruner.php">
-    <MixedArgument occurrences="2">
-      <code>$element-&gt;getAttribute('class')</code>
+    <MixedArgument occurrences="1">
       <code>$matches[1]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
@@ -121,12 +120,6 @@
     <RedundantCondition occurrences="1">
       <code>$parentNode !== null</code>
     </RedundantCondition>
-    <UndefinedMethod occurrences="4">
-      <code>getAttribute</code>
-      <code>setAttribute</code>
-      <code>removeAttribute</code>
-      <code>removeAttribute</code>
-    </UndefinedMethod>
   </file>
   <file src="src/Utilities/CssConcatenator.php">
     <MixedArgument occurrences="5">

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -90,7 +90,7 @@ class HtmlPruner extends AbstractHtmlProcessor
     {
         $classesToKeepIntersector = new ArrayIntersector($classesToKeep);
 
-        /** @var \DOMNode $element */
+        /** @var \DOMElement $element */
         foreach ($elements as $element) {
             $elementClasses = \preg_split('/\\s++/', \trim($element->getAttribute('class')));
             $elementClassesToKeep = $classesToKeepIntersector->intersectWith($elementClasses);
@@ -111,7 +111,7 @@ class HtmlPruner extends AbstractHtmlProcessor
      */
     private function removeClassAttributeFromElements(\DOMNodeList $elements)
     {
-        /** @var \DOMNode $element */
+        /** @var \DOMElement $element */
         foreach ($elements as $element) {
             $element->removeAttribute('class');
         }


### PR DESCRIPTION
This commit resolves the UndefinedMethod issues identified in
src/HtmlProcessor/HtmlPruner.php by altering the type hints to match
the child type of DOMNode more closely matching what is expected.

regarding: #537