### PR TITLE
[BUGFIX] Restore PHP 7.0 compatibility in the dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpmd/phpmd": "^2.7.0",
         "phpunit/phpunit": "^6.5.14",
         "psalm/plugin-phpunit": "^0.5.8",
-        "slevomat/coding-standard": "^4.8.7",
+        "slevomat/coding-standard": "^4.0.0",
         "squizlabs/php_codesniffer": "^3.5.1",
         "vimeo/psalm": "^3.2.12"
     },


### PR DESCRIPTION
The package "slevomat/coding-standard" in version >= 4 requires
PHP >= 7.1. Due to a stale Composer cache in Travis CI, the build for
PHP 7.0 still passed with that requirement.

Now Emogrifier uses version 3.3 of that package, allowing the dev
dependencies to install again.