### PR TITLE
[FEATURE] Add support for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 - "7.1"
 - "7.2"
 - "7.3"
+- "7.4"
 
 cache:
   directories:
@@ -24,13 +25,18 @@ before_install:
 
 install:
 - >
-  export IGNORE_PLATFORM_REQS="$(composer php:version |grep -q '^7.3' && printf -- --ignore-platform-reqs)";
+  export IGNORE_PLATFORM_REQS="$(composer php:version | grep -q '^7\.[34]' && printf -- --ignore-platform-reqs)";
   echo;
   echo "Updating the dependencies";
   composer update $IGNORE_PLATFORM_REQS --with-dependencies $DEPENDENCIES_PREFERENCE;
   composer show;
 
 script:
+- >
+  is_php_73() {
+    composer php:version | grep -q '^7\.3';
+  };
+
 - >
   echo;
   echo "Validating the composer.json";
@@ -47,23 +53,29 @@ script:
   composer ci:tests:unit;
 
 - >
-  echo;
-  echo "Running PHPMD";
-  composer ci:php:md;
+  if is_php_73; then
+    echo;
+    echo "Running PHPMD";
+    composer ci:php:md;
+  else
+    echo "Skipping PHPMD (will only be run on PHP 7.3).";
+  fi;
 
 - >
-  echo;
-  function version_gte() { test "$(printf '%s\n' "$@" | sort -n -t. -r | head -n 1)" = "$1"; };
-  if version_gte $(composer php:version) 7; then
+  if is_php_73; then
     echo "Installing slevomat/coding-standard only for PHP 7.x";
     composer require $IGNORE_PLATFORM_REQS --dev slevomat/coding-standard:^4.0 $DEPENDENCIES_PREFERENCE;
     echo "Running PHP_CodeSniffer";
     composer ci:php:sniff;
   else
-    echo "Skipped PHP_CodeSniffer due to insufficient PHP version: $(composer php:version)";
+    echo "Skipping PHP_CodeSniffer (will only be run on PHP 7.3).";
   fi;
 
 - >
-  echo;
-  echo "Running PHP-CS-Fixer";
-  composer ci:php:fixer;
+  if is_php_73; then
+    echo;
+    echo "Running PHP-CS-Fixer";
+    composer ci:php:fixer;
+  else
+    echo "Skipping PHP-CS-Fixer (will only be run on PHP 7.3).";
+  fi;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add support for PHP 7.4
+  ([#821](https://github.com/MyIntervals/emogrifier/pull/821),
+  [#829](https://github.com/MyIntervals/emogrifier/pull/829))
 
 ### Changed
 - Upgrade to Symfony 5.0

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "source": "https://github.com/MyIntervals/emogrifier"
     },
     "require": {
-        "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0",
+        "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4",
         "ext-dom": "*",
         "ext-libxml": "*",
         "symfony/css-selector": "^2.8 || ^3.0 || ^4.0 || ^5.0"


### PR DESCRIPTION
Also only run the CI tasks that do not depend on the PHP version
(i.e., everything except for the PHP linting and the unit tests)
on PHP 7.3 only to avoid problems with PHP 7.4.

Also ignore the platform reqs for PHP 7.3 and 7.4 during composer update
for the time being.

This is the 3.1 branch backport of #821.