### PR TITLE
[TASK] Move the PHP code sniffing to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+on:
+  - pull_request
+  - push
+
+name: CI
+
+jobs:
+  php-code-sniffer:
+    name: PHP Code Sniffer
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - 7.3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: "Cache dependencies installed with composer"
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache
+          key: php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php${{ matrix.php-version }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress
+
+      - name: Run PHP Code Sniffer
+        run: composer ci:php:sniff

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,15 +72,6 @@ script:
 - >
   if is_php_73; then
     echo;
-    echo "Running PHP_CodeSniffer";
-    composer ci:php:sniff;
-  else
-    echo "Skipping PHP_CodeSniffer (will only be run on PHP 7.3).";
-  fi;
-
-- >
-  if is_php_73; then
-    echo;
     echo "Running PHP-CS-Fixer";
     composer ci:php:fixer;
   else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#776](https://github.com/MyIntervals/emogrifier/pull/776))
 
 ### Changed
+- Move the code sniffing from Travis CI to GitHub actions
+  ([#832](https://github.com/MyIntervals/emogrifier/pull/830)
 - Upgrade to Symfony 5.0
   ([#822](https://github.com/MyIntervals/emogrifier/pull/820)
 - Clean up the folder structure and autoloading configuration


### PR DESCRIPTION
This should speed up the build and reduce our hassle with Travis CI.

Part of #818.