### PR TITLE
[BUGFIX] Actually use the specified PHP version on GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: "Cache dependencies installed with composer"
+      - name: Install PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Cache dependencies installed with composer
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
+- Actually use the specified PHP version on GitHub actions
+  ([#836](https://github.com/MyIntervals/emogrifier/pull/836))
 - Support `ci:php:lint` on Windows
   ([#740](https://github.com/MyIntervals/emogrifier/issues/740),
   [#780](https://github.com/MyIntervals/emogrifier/pull/780))


### PR DESCRIPTION
Providing the PHP version in the strategy matrix is not enough;
the PHP version also needs to be activated using a dedicated
action.

https://github.com/marketplace/actions/setup-php-action

Fixes #835