### PR TITLE
[TASK] Switch the parallel linting to a maintained fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#776](https://github.com/MyIntervals/emogrifier/pull/776))
 
 ### Changed
+- Switch the parallel linting to a maintained fork
+  ([#842](https://github.com/MyIntervals/emogrifier/pull/842))
 - Move continuous integration from Travis CI to GitHub actions
   ([#832](https://github.com/MyIntervals/emogrifier/pull/832),
   [#834](https://github.com/MyIntervals/emogrifier/pull/834),

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15.3",
-        "jakub-onderka/php-parallel-lint": "^1.0",
+        "grogy/php-parallel-lint": "^1.1.0",
         "phpmd/phpmd": "^2.7.0",
         "phpunit/phpunit": "^6.5.14",
         "psalm/plugin-phpunit": "^0.5.8",


### PR DESCRIPTION
The package `jakub-onderka/php-parallel-lint` seems to not be
maintained anymore. Hence, we now use the well-maintained fork
`grogy/php-parallel-lint`.