### PR TITLE
[BUGFIX] Make the static analysis steps visible again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,10 @@ jobs:
     strategy:
       matrix:
         command:
-          - php:fixer
-          - php:md
-          - php:psalm
-          - php:sniff
+          - fixer
+          - md
+          - psalm
+          - sniff
         php-version:
           - 7.3
 
@@ -96,4 +96,4 @@ jobs:
         run: composer install --no-progress
 
       - name: Run Command
-        run: composer ci:${{ matrix.command }}
+        run: composer ci:php:${{ matrix.command }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   [#838](https://github.com/MyIntervals/emogrifier/pull/838),
   [#839](https://github.com/MyIntervals/emogrifier/pull/839),
   [#840](https://github.com/MyIntervals/emogrifier/pull/840),
-  [#841](https://github.com/MyIntervals/emogrifier/pull/841))
+  [#841](https://github.com/MyIntervals/emogrifier/pull/841).
+  [#843](https://github.com/MyIntervals/emogrifier/pull/843))
 - Upgrade to Symfony 5.0
   ([#822](https://github.com/MyIntervals/emogrifier/pull/820))
 - Clean up the folder structure and autoloading configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   [#838](https://github.com/MyIntervals/emogrifier/pull/838),
   [#839](https://github.com/MyIntervals/emogrifier/pull/839),
   [#840](https://github.com/MyIntervals/emogrifier/pull/840),
-  [#841](https://github.com/MyIntervals/emogrifier/pull/841).
+  [#841](https://github.com/MyIntervals/emogrifier/pull/841),
   [#843](https://github.com/MyIntervals/emogrifier/pull/843))
 - Upgrade to Symfony 5.0
   ([#822](https://github.com/MyIntervals/emogrifier/pull/820))


### PR DESCRIPTION
Now the matrix keys for the "static analysis" GitHub actions job
are short enough so that they do not get truncated in the GitHub
actions UI, making our CI more usable.