### PR TITLE
[BUGFIX] Always ensure there is a head element present

### DIFF
--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -194,6 +194,7 @@ abstract class AbstractHtmlProcessor
     private function createUnifiedDomDocument(string $html)
     {
         $this->createRawDomDocument($html);
+        $this->ensureExistenceOfHeadElement();
         $this->ensureExistenceOfBodyElement();
     }
 
@@ -301,6 +302,26 @@ abstract class AbstractHtmlProcessor
             '$0/',
             $html
         );
+    }
+
+    /**
+     * Checks that $this->domDocument has a HEAD element and adds it if it is missing.
+     *
+     * @return void
+     *
+     * @throws \UnexpectedValueException
+     */
+    private function ensureExistenceOfHeadElement()
+    {
+        if ($this->getDomDocument()->getElementsByTagName('head')->item(0) !== null) {
+            return;
+        }
+
+        $htmlElement = $this->getDomDocument()->getElementsByTagName('html')->item(0);
+        if ($htmlElement === null) {
+            throw new \UnexpectedValueException('There is no HTML element although there should be one.', 1569930853);
+        }
+        $htmlElement->appendChild($this->getDomDocument()->createElement('head'));
     }
 
     /**

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Unit\HtmlProcessor;
 
+use Pelago\Emogrifier\CssInliner;
 use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 use Pelago\Emogrifier\Tests\Unit\HtmlProcessor\Fixtures\TestingHtmlProcessor;
 use PHPUnit\Framework\TestCase;
@@ -656,5 +657,27 @@ class AbstractHtmlProcessorTest extends TestCase
         foreach ($voidElements as $element) {
             self::assertFalse($element->hasChildNodes());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function htmlWithoutHeadOrBodyElementsAndStylesCopiedToStyleBlocksIsProperlyInlined()
+    {
+        $testHTML = '    
+    <header>
+        Test
+    </header>
+    <h1 class="">
+        Newsletter Example
+    </h1>
+';
+
+        $subject = CssInliner::fromHtml($testHTML);
+        $subject->setDebug(false);
+        $css = 'h1 {color:red;} h1:hover {color:green;}';
+        $subject->inlineCss($css);
+
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
Always ensure there is a head element present because the CSSInliner Expects it to be there.