### PR TITLE
Fix mapping width/height when decimal is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
+- Fix mapping width/height when decimal is used
+  ([#845](https://github.com/MyIntervals/emogrifier/pull/845))
 - Actually use the specified PHP version on GitHub actions
   ([#836](https://github.com/MyIntervals/emogrifier/pull/836))
 - Support `ci:php:lint` on Windows

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -239,7 +239,7 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
     private function mapWidthOrHeightProperty(\DOMElement $node, string $value, string $property)
     {
         // only parse values in px and %, but not values like "auto"
-        if (!\preg_match('/^(\\d+)(\.(\\d+))?(px|%)$/', $value)) {
+        if (!\preg_match('/^(\\d+)(\\.(\\d+))?(px|%)$/', $value)) {
             return;
         }
 

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -239,7 +239,7 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
     private function mapWidthOrHeightProperty(\DOMElement $node, string $value, string $property)
     {
         // only parse values in px and %, but not values like "auto"
-        if (!\preg_match('/^(\\d+)(px|%)$/', $value)) {
+        if (!\preg_match('/^(\\d+)(\.(\\d+))?(px|%)$/', $value)) {
             return;
         }
 

--- a/tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php
+++ b/tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php
@@ -103,8 +103,10 @@ class CssToAttributeConverterTest extends TestCase
             'background => bgcolor' => ['<p style="background: red top;">Bonjour</p>', 'bgcolor="red"'],
             'width with px' => ['<p style="width: 100px;">Hi</p>', 'width="100"'],
             'width with %' => ['<p style="width: 50%;">Hi</p>', 'width="50%"'],
+            'width with decimal %' => ['<p style="width: 50.5%;">Hi</p>', 'width="50.5%"'],
             'height with px' => ['<p style="height: 100px;">Hi</p>', 'height="100"'],
             'height with %' => ['<p style="height: 50%;">Hi</p>', 'height="50%"'],
+            'height with decimal %' => ['<p style="height: 50.5%;">Hi</p>', 'height="50.5%"'],
             'img.margin: 0 auto (horizontal centering) => align=center' => [
                 '<img style="margin: 0 auto;">',
                 'align="center"',


### PR DESCRIPTION
This fixes an issue where if you have a width like 33.33%, the mapWidthOrHeightProperty will not correctly detect it and the style cannot be converted into an attribute.