### PR TITLE
[TASK] Drop support for obsolete Symfony versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Support for PHP 7.0 will be removed in Emogrifier 5.0.
 
 ### Removed
+- Drop support for Symfony versions that have reached their end of life
+  ([#847](https://github.com/MyIntervals/emogrifier/pull/847))
 - Drop the `Emogrifier` class
   ([#774](https://github.com/MyIntervals/emogrifier/pull/774))
 - Drop support for PHP 5.6

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "symfony/css-selector": "^2.8 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/css-selector": "^3.4 || ^4.3 || ^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15.3",


### PR DESCRIPTION
Now only Symfony versions are supported that are either actively
maintained or at least receive security fixes.

This reduces the risk of being impacted by bugs that are long fixed.

For a list of supported Symfony versions, see:
https://symfony.com/releases