### PR TITLE
[BUGFIX] Stop caching the vendor/ directory on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
 
 cache:
   directories:
-  - vendor
   - $HOME/.composer/cache
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
+- Stop caching the `vendor/` directory on Travis CI
+  ([#848](https://github.com/MyIntervals/emogrifier/pull/848))
 - Fix mapping width/height when decimal is used
   ([#845](https://github.com/MyIntervals/emogrifier/pull/845))
 - Actually use the specified PHP version on GitHub actions


### PR DESCRIPTION
Having this directory cached between builds can result in incorrect
versions of dependencies getting installed.

For a good build performance, caching the Composer cache directory
should suffice.