### PR TITLE
[BUGFIX] Add `<head>` element despite `<header>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
+- Add missing `<head>` element when there's a `<header>` element
+  ([#844](https://github.com/MyIntervals/emogrifier/pull/844),
+  [#853](https://github.com/MyIntervals/emogrifier/pull/853))
 - Fix mapping width/height when decimal is used
   ([#845](https://github.com/MyIntervals/emogrifier/pull/845))
 - Actually use the specified PHP version on GitHub actions

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -268,11 +268,15 @@ abstract class AbstractHtmlProcessor
 
         // We are trying to insert the meta tag to the right spot in the DOM.
         // If we just prepended it to the HTML, we would lose attributes set to the HTML tag.
-        $hasHeadTag = \stripos($html, '<head') !== false;
+        $hasHeadTag = \preg_match('/<head[\\s>]/i', $html);
         $hasHtmlTag = \stripos($html, '<html') !== false;
 
         if ($hasHeadTag) {
-            $reworkedHtml = \preg_replace('/<head(.*?)>/i', '<head$1>' . static::CONTENT_TYPE_META_TAG, $html);
+            $reworkedHtml = \preg_replace(
+                '/<head(?=[\\s>])([^>]*+)>/i',
+                '<head$1>' . static::CONTENT_TYPE_META_TAG,
+                $html
+            );
         } elseif ($hasHtmlTag) {
             $reworkedHtml = \preg_replace(
                 '/<html(.*?)>/i',

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -2253,6 +2253,20 @@ class CssInlinerTest extends TestCase
     }
 
     /**
+     * #844
+     *
+     * @test
+     */
+    public function inlineCssKeepsRuleWithPseudoComponentInMatchingSelectorForHtmlWithHeader()
+    {
+        $subject = $this->buildDebugSubject('<html><header><a>foo</a></header></html>');
+
+        $subject->inlineCss('a:hover { color: green; }');
+
+        self::assertContainsCss('<style type="text/css">a:hover { color: green; }</style>', $subject->render());
+    }
+
+    /**
      * @return string[][]
      */
     public function mediaTypesDataProvider(): array

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -2253,8 +2253,6 @@ class CssInlinerTest extends TestCase
     }
 
     /**
-     * #844
-     *
      * @test
      */
     public function inlineCssKeepsRuleWithPseudoComponentInMatchingSelectorForHtmlWithHeader()

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -175,6 +175,9 @@ class AbstractHtmlProcessorTest extends TestCase
             'doctype only' => ['<!DOCTYPE html>'],
             'body content only' => ['<p>Hello</p>'],
             'BODY element' => ['<body></body>'],
+            // #844
+            'HEADER element' => ['<header></header>'],
+            'META element (implicit HEAD)' => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
         ];
     }
 
@@ -185,13 +188,57 @@ class AbstractHtmlProcessorTest extends TestCase
      *
      * @dataProvider contentWithoutHeadTagDataProvider
      */
-    public function addsMissingHeadTag(string $html)
+    public function addsMissingHeadTagOnlyOnce(string $html)
     {
         $subject = TestingHtmlProcessor::fromHtml($html);
 
         $result = $subject->render();
 
-        self::assertContains('<head>', $result);
+        $headTagCount = \substr_count($result, '<head>');
+        self::assertSame(1, $headTagCount);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function contentWithHeadTagDataProvider(): array
+    {
+        return [
+            'HEAD element' => ['<head></head>'],
+            'HEAD element, capitalized' => ['<HEAD></HEAD>'],
+            '(invalid) void HEAD element' => ['<head/>'],
+            'HEAD element with attribute' => ['<head lang="en"></head>'],
+            'HEAD element and HEADER element' => ['<head></head><header></header>'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $html
+     *
+     * @dataProvider contentWithHeadTagDataProvider
+     */
+    public function notAddsSecondHeadTag(string $html)
+    {
+        $subject = TestingHtmlProcessor::fromHtml($html);
+
+        $result = $subject->render();
+
+        $headTagCount = \preg_match_all('%<head[\\s/>]%', $result);
+        self::assertSame(1, $headTagCount);
+    }
+
+    /**
+     * @test
+     */
+    public function preservesHeadAttributes()
+    {
+        $subject = TestingHtmlProcessor::fromHtml('<head lang="en"></head>');
+
+        $result = $subject->render();
+
+        self::assertContains('<head lang="en">', $result);
     }
 
     /**
@@ -319,22 +366,51 @@ class AbstractHtmlProcessorTest extends TestCase
 
     /**
      * @test
+     *
+     * @param string $html
+     *
+     * @dataProvider contentWithoutHeadTagDataProvider
+     * @dataProvider contentWithHeadTagDataProvider
      */
-    public function addsMissingContentTypeMetaTag()
+    public function addsMissingContentTypeMetaTagOnlyOnce(string $html)
     {
-        $subject = TestingHtmlProcessor::fromHtml('<p>Hello</p>');
+        $subject = TestingHtmlProcessor::fromHtml($html);
 
         $result = $subject->render();
 
-        self::assertContains('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $result);
+        $numberOfContentTypeMetaTags = \substr_count(
+            $result,
+            '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'
+        );
+        self::assertSame(1, $numberOfContentTypeMetaTags);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function htmlAroundContentTypeDataProvider(): array
+    {
+        return [
+            'HTML and HEAD element' => ['<html><head>', '</head></html>'],
+            'HTML and HEAD element, HTML end tag omitted' => ['<html><head>', '</head>'],
+            'HEAD element only' => ['<head>', '</head>'],
+            'HEAD element with attribute' => ['<head lang="en">', '</head>'],
+            'HTML, HEAD, and BODY with HEADER elements'
+                => ['<html><head>', '</head><body><header></header></body></html>'],
+        ];
     }
 
     /**
      * @test
+     *
+     * @param string $htmlBefore
+     * @param string $htmlAfter
+     *
+     * @dataProvider htmlAroundContentTypeDataProvider
      */
-    public function notAddsSecondContentTypeMetaTag()
+    public function notAddsSecondContentTypeMetaTag(string $htmlBefore, string $htmlAfter)
     {
-        $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>';
+        $html = $htmlBefore . '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $htmlAfter;
         $subject = TestingHtmlProcessor::fromHtml($html);
 
         $result = $subject->render();

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -175,7 +175,6 @@ class AbstractHtmlProcessorTest extends TestCase
             'doctype only' => ['<!DOCTYPE html>'],
             'body content only' => ['<p>Hello</p>'],
             'BODY element' => ['<body></body>'],
-            // #844
             'HEADER element' => ['<header></header>'],
             'META element (implicit HEAD)' => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
         ];


### PR DESCRIPTION
Also test around the issue.

Resolves #844.