### PR TITLE
[TASK] Allow chaining all configuration methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Configuration setting methods now all return `$this` to allow chaining
+  ([#824](https://github.com/MyIntervals/emogrifier/pull/824),
+  [#854](https://github.com/MyIntervals/emogrifier/pull/854))
 - Add support for PHP 7.4
   ([#821](https://github.com/MyIntervals/emogrifier/pull/821))
 - Disable php-cs-fixer Yoda conditions

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -211,21 +211,25 @@ class CssInliner extends AbstractHtmlProcessor
     /**
      * Disables the parsing of inline styles.
      *
-     * @return void
+     * @return self fluent interface
      */
     public function disableInlineStyleAttributesParsing()
     {
         $this->isInlineStyleAttributesParsingEnabled = false;
+
+        return $this;
     }
 
     /**
      * Disables the parsing of <style> blocks.
      *
-     * @return void
+     * @return self fluent interface
      */
     public function disableStyleBlocksParsing()
     {
         $this->isStyleBlocksParsingEnabled = false;
+
+        return $this;
     }
 
     /**
@@ -233,11 +237,13 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $mediaName the media type name, e.g., "braille"
      *
-     * @return void
+     * @return self fluent interface
      */
     public function addAllowedMediaType(string $mediaName)
     {
         $this->allowedMediaTypes[$mediaName] = true;
+
+        return $this;
     }
 
     /**
@@ -245,13 +251,15 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $mediaName the tag name, e.g., "braille"
      *
-     * @return void
+     * @return self fluent interface
      */
     public function removeAllowedMediaType(string $mediaName)
     {
         if (isset($this->allowedMediaTypes[$mediaName])) {
             unset($this->allowedMediaTypes[$mediaName]);
         }
+
+        return $this;
     }
 
     /**
@@ -261,11 +269,13 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $selector the selector to exclude, e.g., ".editor"
      *
-     * @return void
+     * @return self fluent interface
      */
     public function addExcludedSelector(string $selector)
     {
         $this->excludedSelectors[$selector] = true;
+
+        return $this;
     }
 
     /**
@@ -273,13 +283,15 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $selector the selector to no longer exclude, e.g., ".editor"
      *
-     * @return void
+     * @return self fluent interface
      */
     public function removeExcludedSelector(string $selector)
     {
         if (isset($this->excludedSelectors[$selector])) {
             unset($this->excludedSelectors[$selector]);
         }
+
+        return $this;
     }
 
     /**
@@ -287,11 +299,13 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param bool $debug set to true to enable debug mode
      *
-     * @return void
+     * @return self fluent interface
      */
     public function setDebug(bool $debug)
     {
         $this->debug = $debug;
+
+        return $this;
     }
 
     /**

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -90,6 +90,18 @@ class CssInlinerTest extends TestCase
     /**
      * @test
      */
+    public function setDebugProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->setDebug(false);
+
+        self::assertSame($subject, $result);
+    }
+
+    /**
+     * @test
+     */
     public function inlineCssProvidesFluentInterface()
     {
         $subject = CssInliner::fromHtml('<html><p>Hello world!</p></html>');
@@ -1690,6 +1702,18 @@ class CssInlinerTest extends TestCase
     /**
      * @test
      */
+    public function removeAllowedMediaTypeProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->removeAllowedMediaType('screen');
+
+        self::assertSame($subject, $result);
+    }
+
+    /**
+     * @test
+     */
     public function removeAllowedMediaTypeRemovesStylesForTheGivenMediaType()
     {
         $css = '@media screen { html { some-property: value; } }';
@@ -1699,6 +1723,18 @@ class CssInlinerTest extends TestCase
 
         $subject->inlineCss($css);
         self::assertNotContains('@media', $subject->render());
+    }
+
+    /**
+     * @test
+     */
+    public function addAllowedMediaTypeProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->addAllowedMediaType('braille');
+
+        self::assertSame($subject, $result);
     }
 
     /**
@@ -2337,6 +2373,18 @@ class CssInlinerTest extends TestCase
     /**
      * @test
      */
+    public function disableStyleBlocksParsingProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->disableStyleBlocksParsing();
+
+        self::assertSame($subject, $result);
+    }
+
+    /**
+     * @test
+     */
     public function inlineCssWhenDisabledNotAppliesCssFromStyleBlocks()
     {
         $styleAttributeValue = 'color: #ccc;';
@@ -2365,6 +2413,18 @@ class CssInlinerTest extends TestCase
         $subject->inlineCss();
 
         self::assertContains('<p style="' . $styleAttributeValue . '">', $subject->renderBodyContent());
+    }
+
+    /**
+     * @test
+     */
+    public function disableInlineStyleAttributesParsingProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->disableInlineStyleAttributesParsing();
+
+        self::assertSame($subject, $result);
     }
 
     /**
@@ -2643,6 +2703,18 @@ class CssInlinerTest extends TestCase
     /**
      * @test
      */
+    public function addExcludedSelectorProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->addExcludedSelector('p.x');
+
+        self::assertSame($subject, $result);
+    }
+
+    /**
+     * @test
+     */
     public function addExcludedSelectorIgnoresMatchingElementsFrom()
     {
         $subject = $this->buildDebugSubject('<html><body><p class="x"></p></body></html>');
@@ -2692,6 +2764,18 @@ class CssInlinerTest extends TestCase
         $subject->inlineCss('p { margin: 0; } em { font-style: italic; } strong { font-weight: bold; }');
 
         self::assertContains($htmlSubtree, $subject->renderBodyContent());
+    }
+
+    /**
+     * @test
+     */
+    public function removeExcludedSelectorProvidesFluentInterface()
+    {
+        $subject = CssInliner::fromHtml('<html></html>');
+
+        $result = $subject->removeExcludedSelector('p.x');
+
+        self::assertSame($subject, $result);
     }
 
     /**


### PR DESCRIPTION
The example given in the documentation using `disableStyleBlocksParsing()` will
now actually work.

Fixes #824