### PR TITLE
[BUGFIX] Make sure to use the Composer-installed development tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#773](https://github.com/MyIntervals/emogrifier/pull/773))
 
 ### Fixed
+- Make sure to use the Composer-installed development tools
+  ([#862](https://github.com/MyIntervals/emogrifier/pull/862))
 - Add missing `<head>` element when there's a `<header>` element
   ([#844](https://github.com/MyIntervals/emogrifier/pull/844),
   [#853](https://github.com/MyIntervals/emogrifier/pull/853))

--- a/composer.json
+++ b/composer.json
@@ -70,13 +70,13 @@
     "scripts": {
         "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
         "php:fix": "./tools/php-cs-fixer --config=config/php-cs-fixer.php fix config/ src/ tests/",
-        "ci:php:lint": "parallel-lint config src tests",
-        "ci:php:sniff": "phpcs config src tests",
+        "ci:php:lint": "vendor/bin/parallel-lint config src tests",
+        "ci:php:sniff": "vendor/bin/phpcs config src tests",
         "ci:php:fixer": "./tools/php-cs-fixer --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff config/ src/ tests/",
         "ci:php:md": "./tools/phpmd src text config/phpmd.xml",
-        "ci:php:psalm": "psalm --show-info=false",
-        "ci:tests:unit": "phpunit tests/",
-        "ci:tests:sof": "phpunit tests/ --stop-on-failure",
+        "ci:php:psalm": "vendor/bin/psalm --show-info=false",
+        "ci:tests:unit": "vendor/bin/phpunit tests/",
+        "ci:tests:sof": "vendor/bin/phpunit tests/ --stop-on-failure",
         "ci:tests": [
             "@ci:tests:unit"
         ],


### PR DESCRIPTION
We now provide the path for the development tools within `vendor/bin/`.
This avoids system-installed versions of the same tools (e.g., PHPUnit)
from getting called instead (which might be a different version and
also might not use our Composer autoloader).