### PR TITLE
[CLEANUP] Test only supported DOCTYPEs

### DIFF
--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -345,18 +345,19 @@ class AbstractHtmlProcessorTest extends TestCase
     {
         return [
             'HTML5' => ['<!DOCTYPE html>'],
-            'XHTML 1.0 strict' => [
-                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" ' .
-                '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
+            'HTML 4.01 strict' => [
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" ' .
+                '"http://www.w3.org/TR/html4/strict.dtd">',
             ],
-            'XHTML 1.0 transitional' => [
-                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" ' .
-                '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
+            'HTML 4.01 transitional' => [
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" ' .
+                '"http://www.w3.org/TR/html4/loose.dtd">',
             ],
             'HTML 4 transitional' => [
                 '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" ' .
                 '"http://www.w3.org/TR/REC-html40/loose.dtd">',
             ],
+            'HTML 3.2' => ['<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">'],
         ];
     }
 


### PR DESCRIPTION
Remove XHTML document types (which are not supported) from test datasets,
replacing with HTML 4.01 document types, and adding HTML 3.2 document type for
completeness.

Closes #859.