### PR TITLE
[BUGFIX] Enquote development tool paths for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Make sure to use the Composer-installed development tools
-  ([#862](https://github.com/MyIntervals/emogrifier/pull/862))
+  ([#862](https://github.com/MyIntervals/emogrifier/pull/862),
+  [#865](https://github.com/MyIntervals/emogrifier/pull/865))
 - Add missing `<head>` element when there's a `<header>` element
   ([#844](https://github.com/MyIntervals/emogrifier/pull/844),
   [#853](https://github.com/MyIntervals/emogrifier/pull/853))

--- a/composer.json
+++ b/composer.json
@@ -69,14 +69,14 @@
     },
     "scripts": {
         "php:version": "php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
-        "php:fix": "./tools/php-cs-fixer --config=config/php-cs-fixer.php fix config/ src/ tests/",
-        "ci:php:lint": "vendor/bin/parallel-lint config src tests",
-        "ci:php:sniff": "vendor/bin/phpcs config src tests",
-        "ci:php:fixer": "./tools/php-cs-fixer --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff config/ src/ tests/",
-        "ci:php:md": "./tools/phpmd src text config/phpmd.xml",
-        "ci:php:psalm": "vendor/bin/psalm --show-info=false",
-        "ci:tests:unit": "vendor/bin/phpunit tests/",
-        "ci:tests:sof": "vendor/bin/phpunit tests/ --stop-on-failure",
+        "php:fix": "\"./tools/php-cs-fixer\" --config=config/php-cs-fixer.php fix config/ src/ tests/",
+        "ci:php:lint": "\"vendor/bin/parallel-lint\" config src tests",
+        "ci:php:sniff": "\"vendor/bin/phpcs\" config src tests",
+        "ci:php:fixer": "\"./tools/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff config/ src/ tests/",
+        "ci:php:md": "\"./tools/phpmd\" src text config/phpmd.xml",
+        "ci:php:psalm": "\"vendor/bin/psalm\" --show-info=false",
+        "ci:tests:unit": "\"vendor/bin/phpunit\" tests/",
+        "ci:tests:sof": "\"vendor/bin/phpunit\" tests/ --stop-on-failure",
         "ci:tests": [
             "@ci:tests:unit"
         ],


### PR DESCRIPTION
If the path-to-executable part of a command contains Unix-style path separators
(which are supported on Windows), it must be enclosed in double quotation marks
to work on Windows.