### PR TITLE
[TASK] Normalize the DOCTYPE declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#776](https://github.com/MyIntervals/emogrifier/pull/776))
 
 ### Changed
+- Normalize DOCTYPE declaration according to polyglot markup recommendation
+  ([#866](https://github.com/MyIntervals/emogrifier/pull/866))
 - Upgrade to V2 of the PHP setup GitHub action
   ([#861](https://github.com/MyIntervals/emogrifier/pull/861))
 - Move the development tools to Phive

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -234,7 +234,7 @@ abstract class AbstractHtmlProcessor
     }
 
     /**
-     * Makes sure that the passed HTML has a document type.
+     * Makes sure that the passed HTML has a document type, with lowercase "html".
      *
      * @param string $html
      *
@@ -244,10 +244,28 @@ abstract class AbstractHtmlProcessor
     {
         $hasDocumentType = \stripos($html, '<!DOCTYPE') !== false;
         if ($hasDocumentType) {
-            return $html;
+            return $this->normalizeDocumentType($html);
         }
 
         return static::DEFAULT_DOCUMENT_TYPE . $html;
+    }
+
+    /**
+     * Makes sure the document type in the passed HTML has lowercase "html".
+     *
+     * @param string $html
+     *
+     * @return string HTML with normalized document type
+     */
+    private function normalizeDocumentType(string $html): string
+    {
+        // Limit to replacing the first occurrence: as an optimization; and in case an example exists as unescaped text.
+        return \preg_replace(
+            '/<!DOCTYPE\\s++html(?=[\\s>])/i',
+            '<!DOCTYPE html',
+            $html,
+            1
+        );
     }
 
     /**

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -99,7 +99,7 @@ class AbstractHtmlProcessorTest extends TestCase
             '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' .
             '<body></body>' .
             '</html>';
-        $formattedHtml = "<!DOCTYPE HTML>\n" .
+        $formattedHtml = "<!DOCTYPE html>\n" .
             "<html>\n" .
             '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . "\n" .
             "<body></body>\n" .
@@ -375,6 +375,49 @@ class AbstractHtmlProcessorTest extends TestCase
         $result = $subject->render();
 
         self::assertContains($documentType, $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function normalizedDocumentTypeDataProvider(): array
+    {
+        return [
+            'HTML5, uppercase' => ['<!DOCTYPE HTML>', '<!DOCTYPE html>'],
+            'HTML5, lowercase' => ['<!doctype html>', '<!DOCTYPE html>'],
+            'HTML5, mixed case' => ['<!DocType Html>', '<!DOCTYPE html>'],
+            'HTML5, extra whitespace' => ['<!DOCTYPE  html  >', '<!DOCTYPE html>'],
+            'HTML 4 transitional, uppercase' => [
+                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" '
+                    . '"http://www.w3.org/TR/REC-html40/loose.dtd">',
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" '
+                    . '"http://www.w3.org/TR/REC-html40/loose.dtd">',
+            ],
+            'HTML 4 transitional, lowercase' => [
+                '<!doctype html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" '
+                    . '"http://www.w3.org/TR/REC-html40/loose.dtd">',
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" '
+                    . '"http://www.w3.org/TR/REC-html40/loose.dtd">',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $documentType
+     * @param string $normalizedDocumentType
+     *
+     * @dataProvider normalizedDocumentTypeDataProvider
+     */
+    public function normalizesDocumentType(string $documentType, string $normalizedDocumentType)
+    {
+        $html = $documentType . '<html></html>';
+        $subject = TestingHtmlProcessor::fromHtml($html);
+
+        $result = $subject->render();
+
+        self::assertContains($normalizedDocumentType, $result);
     }
 
     /**


### PR DESCRIPTION
Ensure that the DOCTYPE declaration consists of uppercase `DOCTYPE` and
lowercase root element name (`html`).

This is done when the `DOMDocument` is created from an HTML source.  Once the
`DOMDocument` has been created, the `DOMDocumentType` cannot be changed, so the
document type declaration must be manipulated (if necessary) in the HTML
beforehand.  (Since only HTML documents are supported, the declaration is only
normalized when the root element name is HTML, in whatever case - the precise
specification for any element name involves lists of various Unicode character
ranges which it would be superfluous to allow for and try to match.  PHP's
`DOMDocument`/`libxml` itself will output the `DOCTYPE` keyword in uppercase in
any case.)

This normalization is consistent with the relevant part of the
[polyglot markup specification](
  https://dev.w3.org/html5/html-polyglot/html-polyglot.html#doctype
).
 While polyglot markup is primarily intended for serialization of HTML as XML
(we don't actually support outputting as XHTML), is also recommended for maximum
interoperability and robustness when rendering HTML.

This also makes the output consistent with that of `Masterminds/html5-php` and
would eliminate the need to change associated tests specifically for #831.

Closes #858.