### PR TITLE
[BUGFIX] Add .0 version suffixes to PHP version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#880](https://github.com/MyIntervals/emogrifier/pull/880))
 
 ### Fixed
+- Add `.0` version suffixes to PHP version requirements
+  ([#881](https://github.com/MyIntervals/emogrifier/pull/881))
 
 ## 4.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "source": "https://github.com/MyIntervals/emogrifier"
     },
     "require": {
-        "php": "~7.1 || ~7.2 || ~7.3 || ~7.4",
+        "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "symfony/css-selector": "^3.4.32 || ^4.3.5 || ^5.0"


### PR DESCRIPTION
Allowing PHP `~7.4` would allow PHP 7.5 as well (even if that version
most probably will not exist), while `~7.4.0` will not due to the way
the `~` operator for Composer version requirements works.