### PR TITLE
[BUGFIX] Switch to a maintained package for parallel PHP linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#880](https://github.com/MyIntervals/emogrifier/pull/880))
 
 ### Fixed
+- Switch to a maintained package for parallel PHP linting
+  ([#884](https://github.com/MyIntervals/emogrifier/pull/884))
 - Add `.0` version suffixes to PHP version requirements
   ([#881](https://github.com/MyIntervals/emogrifier/pull/881))
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/css-selector": "^3.4.32 || ^4.3.5 || ^5.0"
     },
     "require-dev": {
-        "grogy/php-parallel-lint": "^1.1.0",
+        "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "phpunit/phpunit": "^6.5.14",
         "psalm/plugin-phpunit": "^0.5.8",
         "slevomat/coding-standard": "^4.0.0",


### PR DESCRIPTION
`grogy/php-parallel-lint` is no longer maintained.

Fixes #883