### PR TITLE
[TASK] Drop @return void annotations

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -333,8 +333,6 @@ class CssInliner extends AbstractHtmlProcessor
 
     /**
      * Clears all caches.
-     *
-     * @return void
      */
     private function clearAllCaches(): void
     {
@@ -348,8 +346,6 @@ class CssInliner extends AbstractHtmlProcessor
 
     /**
      * Purges the visited nodes.
-     *
-     * @return void
      */
     private function purgeVisitedNodes(): void
     {
@@ -362,8 +358,6 @@ class CssInliner extends AbstractHtmlProcessor
      * This changes 'DISPLAY: none' to 'display: none'.
      * We wouldn't have to do this if DOMXPath supported XPath 2.0.
      * Also stores a reference of nodes with existing inline styles so we don't overwrite them.
-     *
-     * @return void
      */
     private function normalizeStyleAttributesOfAllNodes(): void
     {
@@ -394,8 +388,6 @@ class CssInliner extends AbstractHtmlProcessor
      * Normalizes the value of the "style" attribute and saves it.
      *
      * @param \DOMElement $node
-     *
-     * @return void
      */
     private function normalizeStyleAttributes(\DOMElement $node): void
     {
@@ -831,8 +823,6 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param \DOMElement $node
      * @param string[][] $cssRule
-     *
-     * @return void
      */
     private function copyInlinableCssToStyleAttribute(\DOMElement $node, array $cssRule): void
     {
@@ -918,8 +908,6 @@ class CssInliner extends AbstractHtmlProcessor
 
     /**
      * Merges styles from styles attributes and style nodes and applies them to the attribute nodes
-     *
-     * @return void
      */
     private function fillStyleAttributesWithMergedStyles(): void
     {
@@ -939,8 +927,6 @@ class CssInliner extends AbstractHtmlProcessor
     /**
      * Searches for all nodes with a style attribute and removes the "!important" annotations out of
      * the inline style declarations, eventually by rearranging declarations.
-     *
-     * @return void
      */
     private function removeImportantAnnotationFromAllInlineStyles(): void
     {
@@ -958,8 +944,6 @@ class CssInliner extends AbstractHtmlProcessor
      * to "font-size: 13px; font: 12px serif;" in order to remain correct.
      *
      * @param \DOMElement $node
-     *
-     * @return void
      */
     private function removeImportantAnnotationFromNodeInlineStyle(\DOMElement $node): void
     {
@@ -1000,8 +984,6 @@ class CssInliner extends AbstractHtmlProcessor
      * `$this->matchingUninlinableCssRules`.
      *
      * @param string[][] $cssRules the "uninlinable" array of CSS rules returned by `parseCssRules`
-     *
-     * @return void
      */
     private function determineMatchingUninlinableCssRules(array $cssRules): void
     {
@@ -1114,8 +1096,6 @@ class CssInliner extends AbstractHtmlProcessor
      *        placed in the `<style>` element.  If there are no unlinlinable CSS rules to copy there, a `<style>`
      *        element will be created containing just `$uninlinableCss`.  `$uninlinableCss` may be an empty string;
      *        if it is, and there are no unlinlinable CSS rules, an empty `<style>` element will not be created.
-     *
-     * @return void
      */
     private function copyUninlinableCssToStyleNode(string $uninlinableCss): void
     {
@@ -1144,8 +1124,6 @@ class CssInliner extends AbstractHtmlProcessor
      * @see https://github.com/MyIntervals/emogrifier/issues/103
      *
      * @param string $css
-     *
-     * @return void
      */
     protected function addStyleElementToDocument(string $css): void
     {

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -91,8 +91,6 @@ abstract class AbstractHtmlProcessor
      * Sets the HTML to process.
      *
      * @param string $html the HTML to process, must be UTF-8-encoded
-     *
-     * @return void
      */
     private function setHtml(string $html): void
     {
@@ -124,8 +122,6 @@ abstract class AbstractHtmlProcessor
 
     /**
      * @param \DOMDocument $domDocument
-     *
-     * @return void
      */
     private function setDomDocument(\DOMDocument $domDocument): void
     {
@@ -188,8 +184,6 @@ abstract class AbstractHtmlProcessor
      * The DOM document will always have a BODY element and a document type.
      *
      * @param string $html
-     *
-     * @return void
      */
     private function createUnifiedDomDocument(string $html): void
     {
@@ -201,8 +195,6 @@ abstract class AbstractHtmlProcessor
      * Creates a DOMDocument instance from the given HTML and stores it in $this->domDocument.
      *
      * @param string $html
-     *
-     * @return void
      */
     private function createRawDomDocument(string $html): void
     {
@@ -327,8 +319,6 @@ abstract class AbstractHtmlProcessor
 
     /**
      * Checks that $this->domDocument has a BODY element and adds it if it is missing.
-     *
-     * @return void
      *
      * @throws \UnexpectedValueException
      */

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -124,8 +124,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      *
      * @param string[] $styles the new CSS styles taken from the global styles to be applied to this node
      * @param \DOMElement $node node to apply styles to
-     *
-     * @return void
      */
     private function mapCssToHtmlAttributes(array $styles, \DOMElement $node): void
     {
@@ -144,8 +142,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      * @param string $property the name of the CSS property to map
      * @param string $value the value of the style rule to map
      * @param \DOMElement $node node to apply styles to
-     *
-     * @return void
      */
     private function mapCssToHtmlAttribute(string $property, string $value, \DOMElement $node): void
     {
@@ -186,8 +182,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      * @param string $property the name of the CSS property to map
      * @param string $value the value of the style rule to map
      * @param \DOMElement $node node to apply styles to
-     *
-     * @return void
      */
     private function mapComplexCssProperty(string $property, string $value, \DOMElement $node): void
     {
@@ -213,8 +207,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
     /**
      * @param \DOMElement $node node to apply styles to
      * @param string $value the value of the style rule to map
-     *
-     * @return void
      */
     private function mapBackgroundProperty(\DOMElement $node, string $value): void
     {
@@ -233,8 +225,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      * @param \DOMElement $node node to apply styles to
      * @param string $value the value of the style rule to map
      * @param string $property the name of the CSS property to map
-     *
-     * @return void
      */
     private function mapWidthOrHeightProperty(\DOMElement $node, string $value, string $property): void
     {
@@ -250,8 +240,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
     /**
      * @param \DOMElement $node node to apply styles to
      * @param string $value the value of the style rule to map
-     *
-     * @return void
      */
     private function mapMarginProperty(\DOMElement $node, string $value): void
     {
@@ -268,8 +256,6 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
     /**
      * @param \DOMElement $node node to apply styles to
      * @param string $value the value of the style rule to map
-     *
-     * @return void
      */
     private function mapBorderProperty(\DOMElement $node, string $value): void
     {

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -83,8 +83,6 @@ class HtmlPruner extends AbstractHtmlProcessor
      *
      * @param \DOMNodeList $elements
      * @param string[] $classesToKeep
-     *
-     * @return void
      */
     private function removeClassesFromElements(\DOMNodeList $elements, array $classesToKeep): void
     {
@@ -106,8 +104,6 @@ class HtmlPruner extends AbstractHtmlProcessor
      * Removes the `class` attribute from each element in `$elements`.
      *
      * @param \DOMNodeList $elements
-     *
-     * @return void
      */
     private function removeClassAttributeFromElements(\DOMNodeList $elements): void
     {

--- a/tests/Unit/Utilities/CssConcatenatorTest.php
+++ b/tests/Unit/Utilities/CssConcatenatorTest.php
@@ -22,7 +22,7 @@ final class CssConcatenatorTest extends TestCase
     private $subject = null;
 
     /**
-     * @return void
+     * Setup.
      */
     protected function setUp(): void
     {


### PR DESCRIPTION
We now always have the `void` return type declaration, and the
annotation nevers adds any additional information that cannot be
expressed with a return type declaration.