### PR TITLE
[BUGFIX] Preserve all uninlinable CSS at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#880](https://github.com/MyIntervals/emogrifier/pull/880))
 
 ### Fixed
+- Preserve all uninlinable (or otherwise unprocessed) at-rules
+  ([#899](https://github.com/MyIntervals/emogrifier/pull/899))
 - Allow Windows CLI to run development tools installed through Phive
   ([#900](https://github.com/MyIntervals/emogrifier/pull/900))
 - Switch to a maintained package for parallel PHP linting

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -53,6 +53,100 @@ final class CssInlinerTest extends TestCase
     ';
 
     /**
+     * @var string[]
+     *
+     * selectoin of at-rules which have no special handling by `CssInliner` but should be passed through and placed in a
+     * `<style>` element unmodified, for testing that and testing around
+     */
+    private const BLACK_BOX_AT_RULES = [
+        '@font-face' => '
+            @font-face {
+              font-family: "Foo Sans";
+              src: url("/foo-sans.woff2") format("woff2");
+            }
+        ',
+        '@-webkit-keyframes' => '
+            @-webkit-keyframes bounceIn {
+              from, 20%, 40%, 60%, 80%, to {
+                -webkit-animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+                animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+              }
+              0% {
+                opacity: 0;
+                -webkit-transform: scale3d(.3, .3, .3);
+                transform: scale3d(.3, .3, .3);
+              }
+              20% {
+                -webkit-transform: scale3d(1.1, 1.1, 1.1);
+                transform: scale3d(1.1, 1.1, 1.1);
+              }
+              40% {
+                -webkit-transform: scale3d(.9, .9, .9);
+                transform: scale3d(.9, .9, .9);
+              }
+              60% {
+                opacity: 1;
+                -webkit-transform: scale3d(1.03, 1.03, 1.03);
+                transform: scale3d(1.03, 1.03, 1.03);
+              }
+              80% {
+                -webkit-transform: scale3d(.97, .97, .97);
+                transform: scale3d(.97, .97, .97);
+              }
+              to {
+                opacity: 1;
+                -webkit-transform: scale3d(1, 1, 1);
+                transform: scale3d(1, 1, 1);
+              }
+            }
+        ',
+        '@keyframes' => '
+            @keyframes bounceIn {
+              from, 20%, 40%, 60%, 80%, to {
+                animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+              }
+              0% {
+                opacity: 0;
+                transform: scale3d(.3, .3, .3);
+              }
+              20% {
+                transform: scale3d(1.1, 1.1, 1.1);
+              }
+              40% {
+                transform: scale3d(.9, .9, .9);
+              }
+              60% {
+                opacity: 1;
+                transform: scale3d(1.03, 1.03, 1.03);
+              }
+              80% {
+                transform: scale3d(.97, .97, .97);
+              }
+              to {
+                opacity: 1;
+                transform: scale3d(1, 1, 1);
+              }
+            }
+        ',
+        '@supports' => '
+            @supports (display: grid) {
+              .main {
+                display: grid;
+              }
+            }
+        ',
+        // This can be used for rules to specifically target the Gecko engine (i.e., for email, Thunderbird).
+        // The `@document` non-vendor-specific counterpart appears to have no value for emails, which do not have a URL.
+        '@-moz-document' => '
+            @-moz-document url-prefix() {
+              body {
+                font-size: 15px;
+              }
+            }
+        ',
+    ];
+
+    /**
      * Builds a subject with the given HTML and debug mode enabled.
      *
      * @param string $html
@@ -3355,64 +3449,71 @@ final class CssInlinerTest extends TestCase
     /**
      * @return string[][]
      */
-    public function provideValidFontFaceRules(): array
+    public function provideValidAtRulesWithSurroundingCss(): array
     {
-        return [
-            'single @font-face' => [
-                'before' => '',
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
-                'after' => '',
-            ],
+        $datasets = [];
+
+        foreach (self::BLACK_BOX_AT_RULES as $name => $rule) {
+            $datasets += [
+                'single ' . $name => [
+                    'before' => '',
+                    'at-rules' => $rule,
+                    'after' => '',
+                ],
+                $name . ' followed by matching inlinable rule' => [
+                    'before' => '',
+                    'at-rules' => $rule,
+                    'after' => "\n" . 'p { color: green; }',
+                ],
+                $name . ' followed by matching uninlinable rule' => [
+                    'before' => '',
+                    'at-rules' => $rule,
+                    'after' => "\n" . 'p:hover { color: green; }',
+                ],
+                $name . ' followed by matching @media rule' => [
+                    'before' => '',
+                    'at-rules' => $rule,
+                    'after' => "\n" . '@media (max-width: 640px) { p { color: green; } }',
+                ],
+                $name . ' preceded by matching inlinable rule' => [
+                    'before' => "p { color: green; }\n",
+                    'at-rules' => $rule,
+                    'after' => '',
+                ],
+                $name . ' preceded by matching uninlinable rule' => [
+                    'before' => "p:hover { color: green; }\n",
+                    'at-rules' => $rule,
+                    'after' => '',
+                ],
+                $name . ' preceded by matching @media rule' => [
+                    'before' => "@media (max-width: 640px) { p { color: green; } }\n",
+                    'at-rules' => $rule,
+                    'after' => '',
+                ],
+            ];
+        }
+
+        return $datasets + [
             'uppercase @FONT-FACE' => [
                 'before' => '',
-                '@font-face' => '@FONT-FACE { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
+                'at-rules' => '@FONT-FACE { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
                 'after' => '',
             ],
             'mixed case @FoNt-FaCe' => [
                 'before' => '',
-                '@font-face' => '@FoNt-FaCe { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
+                'at-rules' => '@FoNt-FaCe { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
                 'after' => '',
             ],
             '2 @font-faces' => [
                 'before' => '',
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }'
+                'at-rules' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }'
                     . "\n" . '@font-face { font-family: "Bar Sans"; src: url("/bar-sans.woff2") format("woff2"); }',
                 'after' => '',
             ],
             '2 @font-faces, minified' => [
                 'before' => '',
-                '@font-face' => '@font-face{font-family:"Foo Sans";src:url(/foo-sans.woff2) format("woff2")}'
+                'at-rules' => '@font-face{font-family:"Foo Sans";src:url(/foo-sans.woff2) format("woff2")}'
                     . '@font-face{font-family:"Bar Sans";src:url(/bar-sans.woff2) format("woff2")}',
-                'after' => '',
-            ],
-            '@font-face followed by matching inlinable rule' => [
-                'before' => '',
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
-                'after' => "\n" . 'p { color: green; }',
-            ],
-            '@font-face followed by matching uninlinable rule' => [
-                'before' => '',
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
-                'after' => "\n" . 'p:hover { color: green; }',
-            ],
-            '@font-face followed by matching @media rule' => [
-                'before' => '',
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
-                'after' => "\n" . '@media (max-width: 640px) { p { color: green; } }',
-            ],
-            '@font-face preceded by matching inlinable rule' => [
-                'before' => "p { color: green; }\n",
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
-                'after' => '',
-            ],
-            '@font-face preceded by matching uninlinable rule' => [
-                'before' => "p:hover { color: green; }\n",
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
-                'after' => '',
-            ],
-            '@font-face preceded by matching @media rule' => [
-                'before' => "@media (max-width: 640px) { p { color: green; } }\n",
-                '@font-face' => '@font-face { font-family: "Foo Sans"; src: url("/foo-sans.woff2") format("woff2"); }',
                 'after' => '',
             ],
         ];
@@ -3422,21 +3523,67 @@ final class CssInlinerTest extends TestCase
      * @test
      *
      * @param string $cssBefore
-     * @param string $cssFontFaces
+     * @param string $atRules
      * @param string $cssAfter
      *
-     * @dataProvider provideValidFontFaceRules
+     * @dataProvider provideValidAtRulesWithSurroundingCss
      */
-    public function inlineCssPreservesValidFontFaceRules(
+    public function inlineCssPreservesValidAtRules(
         string $cssBefore,
-        string $cssFontFaces,
+        string $atRules,
         string $cssAfter
     ): void {
         $subject = $this->buildDebugSubject('<html><p>foo</p></html>');
 
-        $subject->inlineCss($cssBefore . $cssFontFaces . $cssAfter);
+        $subject->inlineCss($cssBefore . $atRules . $cssAfter);
 
-        self::assertStringContainsString($cssFontFaces, $subject->render());
+        self::assertStringContainsString(\ltrim($atRules), $subject->render());
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideValidAtRules(): array
+    {
+        return \array_map(
+            function (string $rule): array {
+                return [$rule];
+            },
+            self::BLACK_BOX_AT_RULES
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @param string $atRule
+     *
+     * @dataProvider provideValidAtRules
+     */
+    public function inlineCssMatchesRuleAfterAtRule(string $atRule): void
+    {
+        $subject = $this->buildDebugSubject('<html><body></body></html>');
+
+        $subject->inlineCss($atRule . ' body { color: green; }');
+
+        self::assertStringContainsString('<body style="color: green;">', $subject->render());
+    }
+
+    /**
+     * @test
+     *
+     * @param string $atRule
+     *
+     * @dataProvider provideValidAtRules
+     */
+    public function inlineCssKeepsUninlinableRulePositionAfterAtRule(string $atRule): void
+    {
+        $subject = $this->buildDebugSubject('<html><p>Hello world!</p></html>');
+        $css = $atRule . ' p:hover { color: green; }';
+
+        $subject->inlineCss($css);
+
+        self::assertContainsCss($css, $subject->render());
     }
 
     /**

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -55,7 +55,7 @@ final class CssInlinerTest extends TestCase
     /**
      * @var string[]
      *
-     * selectoin of at-rules which have no special handling by `CssInliner` but should be passed through and placed in a
+     * selection of at-rules which have no special handling by `CssInliner` but should be passed through and placed in a
      * `<style>` element unmodified, for testing that and testing around
      */
     private const BLACK_BOX_AT_RULES = [


### PR DESCRIPTION
All at-rules that have no special handling by Emogrifier will now by copied to a
`<style>` element.  Previously, Emogrifier would attempt to process them as
regular CSS rules, causing an exception in `CssSelectorConverter::toXPath()`,
which in 'debug' mode would be propagated; in either case they would be
discarded.

The rationale is that if any such rules are in the supplied CSS, they are
desired in the resulting HTML.  Emogrifier can treat them as a black box it
knows nothing about, simply to be passed on.

For at-rules which are containers for regular CSS rules (e.g. `@supports`), the
ordering could be important.  For now, these rules will be placed at the start
of the `<style>` element, so it is possible that they will be overridden by
other uninlinable rules that are placed after them, but were originally placed
before.  However, there should be no regression because, by being placed first
(and in their own original order), they would still never override a rule in the
`<style>` element that they would not have in the original CSS.

The ordering improvement can be addressed separately, e.g. by handling container
at-rules, like `@supports`, more generally, in a similarly way to how `@media`
rules are currently processed.  (Addressing #544 first may also help.)

Fixes #886.