### PR TITLE
[BUGFIX] Support minified combinator with pseudo-component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#880](https://github.com/MyIntervals/emogrifier/pull/880))
 
 ### Fixed
+- Support combinator followed by dynamic pseudo-class in minified CSS
+  ([#903](https://github.com/MyIntervals/emogrifier/pull/903))
 - Preserve all uninlinable (or otherwise unprocessed) at-rules
   ([#899](https://github.com/MyIntervals/emogrifier/pull/899))
 - Allow Windows CLI to run development tools installed through Phive

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -1094,7 +1094,7 @@ class CssInliner extends AbstractHtmlProcessor
         // The regex allows nested brackets via `(?2)`.
         // A space is temporarily prepended because the callback can't determine if the match was at the very start.
         $selectorWithoutNots = \ltrim(\preg_replace_callback(
-            '/(\\s?+):not(\\([^()]*+(?:(?2)[^()]*+)*+\\))/i',
+            '/([\\s>+~]?+):not(\\([^()]*+(?:(?2)[^()]*+)*+\\))/i',
             [$this, 'replaceUnmatchableNotComponent'],
             ' ' . $selector
         ));
@@ -1112,16 +1112,16 @@ class CssInliner extends AbstractHtmlProcessor
      * @param string[] $matches array of elements matched by the regular expression
      *
      * @return string the full match if there were no unmatchable pseudo components within; otherwise, any preceding
-     *         whitespace followed by "*", or an empty string if there was no preceding whitespace
+     *         combinator followed by "*", or an empty string if there was no preceding combinator
      */
     private function replaceUnmatchableNotComponent(array $matches): string
     {
-        [$notComponentWithAnyPrecedingWhitespace, $anyPrecedingWhitespace, $notArgumentInBrackets] = $matches;
+        [$notComponentWithAnyPrecedingCombinator, $anyPrecedingCombinator, $notArgumentInBrackets] = $matches;
 
         if ($this->hasUnsupportedPseudoClass($notArgumentInBrackets)) {
-            return $anyPrecedingWhitespace !== '' ? $anyPrecedingWhitespace . '*' : '';
+            return $anyPrecedingCombinator !== '' ? $anyPrecedingCombinator . '*' : '';
         }
-        return $notComponentWithAnyPrecedingWhitespace;
+        return $notComponentWithAnyPrecedingCombinator;
     }
 
     /**
@@ -1136,7 +1136,7 @@ class CssInliner extends AbstractHtmlProcessor
     private function removeSelectorComponents(string $matcher, string $selector): string
     {
         return \preg_replace(
-            ['/(\\s|^)' . $matcher . '/i', '/' . $matcher . '/i'],
+            ['/([\\s>+~]|^)' . $matcher . '/i', '/' . $matcher . '/i'],
             ['$1*', ''],
             $selector
         );

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -2259,6 +2259,12 @@ final class CssInlinerTest extends TestCase
                 'static pseudo-class &' => 'a:first-child',
                 'ancestor &' => 'p ',
                 'ancestor & type &' => 'p a',
+                'parent &' => 'p > ',
+                'adjacent sibling &' => 'a + ',
+                'general sibling &' => 'a ~ ',
+                'minified parent &' => 'p>',
+                'minified adjacent sibling &' => 'a+',
+                'minified general sibling &' => 'a~',
             ]
         );
         $datasetsWithCombinedPseudoSelectors = [
@@ -2314,6 +2320,12 @@ final class CssInlinerTest extends TestCase
                 'static pseudo-class &' => 'a:not(.a)',
                 'ancestor &' => 'ul ',
                 'ancestor & type &' => 'p b',
+                'parent &' => 'ul > ',
+                'adjacent sibling &' => 'p + ',
+                'general sibling &' => 'p ~ ',
+                'minified parent &' => 'ul>',
+                'minified adjacent sibling &' => 'p+',
+                'minified general sibling &' => 'p~',
             ]
         );
         $datasetsWithCombinedPseudoSelectors = [


### PR DESCRIPTION
Minified selectors such as `ul>:hover` would cause an exception in debug mode,
and otherwise would always be copied to the `<style>` element even if they could
never match anything, whereas, e.g., `ul > :hover` would be treated as intended.