### PR TITLE
[CLEANUP] Move AssertCss logic to Constraint classes

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Support\Constraint;
+
+/**
+ * Provides a method for use in constraints making assertions about CSS content where whitespace may vary.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+trait CssConstraint
+{
+    /**
+     * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
+     * element added to the document, due to the way that certain parts are `trim`med.  Notably, whitespace either side
+     * of "{", "}" and "," or at the beginning of the CSS may be removed.
+     *
+     * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
+     * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
+     * readable and can use inputs containing extra whitespace.
+     *
+     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
+     *
+     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
+     */
+    private static function getCssNeedleRegExp(string $needle): string
+    {
+        $needleMatcher = \preg_replace_callback(
+            '/\\s*+([{},])\\s*+|(^\\s++)|(>)\\s*+|(?:(?!\\s*+[{},]|^\\s)[^>])++/',
+            static function (array $matches): string {
+                if (isset($matches[1]) && $matches[1] !== '') {
+                    // matched possibly some whitespace, followed by "{", "}" or ",", then possibly more whitespace
+                    return '\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';
+                }
+                if (isset($matches[2]) && $matches[2] !== '') {
+                    // matched whitespace at start
+                    return '\\s*+';
+                }
+                if (isset($matches[3]) && $matches[3] !== '') {
+                    // matched ">" (e.g. end of <style> tag) followed by possibly some whitespace
+                    return \preg_quote($matches[3], '/') . '\\s*+';
+                }
+                // matched any other sequence which could not overlap with the above
+                return \preg_quote($matches[0], '/');
+            },
+            $needle
+        );
+        return '/' . $needleMatcher . '/';
+    }
+}

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -62,15 +62,16 @@ abstract class CssConstraint extends Constraint
      */
     private static function getCssNeedleRegularExpressionReplacement(array $matches): string
     {
-        switch (true) {
-            case isset($matches[1]) && $matches[1] !== '':
-                return '\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';
-            case isset($matches[2]) && $matches[2] !== '':
-                return '\\s*+';
-            case isset($matches[3]) && $matches[3] !== '':
-                return \preg_quote($matches[3], '/') . '\\s*+';
-            default:
-                return \preg_quote($matches[0], '/');
+        if (($matches[1] ?? '') !== '') {
+            $regularExpressionEquivalent = '\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';
+        } elseif (($matches[2] ?? '') !== '') {
+            $regularExpressionEquivalent = '\\s*+';
+        } elseif (($matches[3] ?? '') !== '') {
+            $regularExpressionEquivalent = \preg_quote($matches[3], '/') . '\\s*+';
+        } else {
+            $regularExpressionEquivalent = \preg_quote($matches[0], '/');
         }
+
+        return $regularExpressionEquivalent;
     }
 }

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -22,7 +22,7 @@ abstract class CssConstraint extends Constraint
      *
      * @var string
      */
-    private const CSS_REGEX_PATTERN = '/
+    private const CSS_REGULAR_EXPRESSIOM_PATTERN = '/
         \\s*+([{},])\\s*+               # `{`, `}` or `,` captured in group 1, with possible whitespace either side
         |(^\\s++)                       # whitespace at the very start, captured in group 2
         |(>)\\s*+                       # `>` (e.g. closing a `<style>` element opening tag) with optional whitespace
@@ -48,7 +48,7 @@ abstract class CssConstraint extends Constraint
     protected static function getCssNeedleRegularExpressionPattern(string $needle): string
     {
         $needleMatcher = \preg_replace_callback(
-            self::CSS_REGEX_PATTERN,
+            self::CSS_REGULAR_EXPRESSIOM_PATTERN,
             [self::class, 'getCssNeedleRegularExpressionReplacement'],
             $needle
         );

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -30,7 +30,7 @@ class StringContainsCss extends CssConstraint
     }
 
     /**
-     * @inheritdoc
+     * @return string a string representation of the constraint
      */
     public function toString(): string
     {
@@ -38,9 +38,11 @@ class StringContainsCss extends CssConstraint
     }
 
     /**
-     * @inheritdoc
+     * Evaluates the constraint for the parameter `$other`.
      *
-     * @param mixed $other
+     * @param mixed $other value or object to evaluate
+     *
+     * @return bool `true` if the constraint is met, `false` otherwise
      */
     protected function matches($other): bool
     {

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Support\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+/**
+ * This constraint asserts that the string it is evaluated for contains some specific CSS, allowing for cosmetic
+ * whitespace differences.
+ *
+ * The CSS string passed in the constructor.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+class StringContainsCss extends Constraint
+{
+    use CssConstraint;
+
+    /**
+     * @var string
+     */
+    private $css;
+
+    /**
+     * @param string $css
+     */
+    public function __construct(string $css)
+    {
+        parent::__construct();
+
+        $this->css = $css;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toString(): string
+    {
+        return 'contains CSS `' . $this->css . '`';
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        return \preg_match(self::getCssNeedleRegExp($this->css), $other) > 0;
+    }
+}

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -46,6 +46,10 @@ class StringContainsCss extends CssConstraint
      */
     protected function matches($other): bool
     {
+        if (!\is_string($other)) {
+            return false;
+        }
+
         return \preg_match(self::getCssNeedleRegularExpressionPattern($this->css), $other) > 0;
     }
 }

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Support\Constraint;
 
-use PHPUnit\Framework\Constraint\Constraint;
-
 /**
  * This constraint asserts that the string it is evaluated for contains some specific CSS, allowing for cosmetic
  * whitespace differences.
@@ -14,10 +12,8 @@ use PHPUnit\Framework\Constraint\Constraint;
  *
  * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
-class StringContainsCss extends Constraint
+class StringContainsCss extends CssConstraint
 {
-    use CssConstraint;
-
     /**
      * @var string
      */
@@ -48,6 +44,6 @@ class StringContainsCss extends Constraint
      */
     protected function matches($other): bool
     {
-        return \preg_match(self::getCssNeedleRegExp($this->css), $other) > 0;
+        return \preg_match(self::getCssNeedleRegularExpressionPattern($this->css), $other) > 0;
     }
 }

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -37,7 +37,7 @@ class StringContainsCssCount extends CssConstraint
     }
 
     /**
-     * @inheritdoc
+     * @return string a string representation of the constraint
      */
     public function toString(): string
     {
@@ -45,9 +45,11 @@ class StringContainsCssCount extends CssConstraint
     }
 
     /**
-     * @inheritdoc
+     * Evaluates the constraint for the parameter `$other`.
      *
-     * @param mixed $other
+     * @param mixed $other value or object to evaluate
+     *
+     * @return bool `true` if the constraint is met, `false` otherwise
      */
     protected function matches($other): bool
     {

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -53,6 +53,10 @@ class StringContainsCssCount extends CssConstraint
      */
     protected function matches($other): bool
     {
+        if (!\is_string($other)) {
+            return false;
+        }
+
         return \preg_match_all(self::getCssNeedleRegularExpressionPattern($this->css), $other) === $this->count;
     }
 }

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Support\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+/**
+ * This constraint asserts that the string it is evaluated for contains some specific CSS a specific number of times,
+ * allowing for cosmetic whitespace differences.
+ *
+ * The CSS string and expected number of occurrences are passed in the constructor.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+class StringContainsCssCount extends Constraint
+{
+    use CssConstraint;
+
+    /**
+     * @var int
+     */
+    private $count;
+
+    /**
+     * @var string
+     */
+    private $css;
+
+    /**
+     * @param int $count
+     * @param string $css
+     */
+    public function __construct(int $count, string $css)
+    {
+        parent::__construct();
+
+        $this->count = $count;
+        $this->css = $css;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toString(): string
+    {
+        return 'contains exactly ' . (string)$this->count . ' occurrence(s) of CSS `' . $this->css . '`';
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @param mixed $other
+     */
+    protected function matches($other): bool
+    {
+        return \preg_match_all(self::getCssNeedleRegExp($this->css), $other) === $this->count;
+    }
+}

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Support\Constraint;
 
-use PHPUnit\Framework\Constraint\Constraint;
-
 /**
  * This constraint asserts that the string it is evaluated for contains some specific CSS a specific number of times,
  * allowing for cosmetic whitespace differences.
@@ -14,10 +12,8 @@ use PHPUnit\Framework\Constraint\Constraint;
  *
  * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
-class StringContainsCssCount extends Constraint
+class StringContainsCssCount extends CssConstraint
 {
-    use CssConstraint;
-
     /**
      * @var int
      */
@@ -55,6 +51,6 @@ class StringContainsCssCount extends Constraint
      */
     protected function matches($other): bool
     {
-        return \preg_match_all(self::getCssNeedleRegExp($this->css), $other) === $this->count;
+        return \preg_match_all(self::getCssNeedleRegularExpressionPattern($this->css), $other) === $this->count;
     }
 }

--- a/tests/Support/Traits/AssertCss.php
+++ b/tests/Support/Traits/AssertCss.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Support\Traits;
 
+use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss;
+use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCssCount;
+
 /**
  * Provides assertion methods for use with CSS content where whitespace may vary.
  *
@@ -12,56 +15,17 @@ namespace Pelago\Emogrifier\Tests\Support\Traits;
 trait AssertCss
 {
     /**
-     * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
-     * element added to the document, due to the way that certain parts are `trim`med.  Notably, whitespace either side
-     * of "{", "}" and "," or at the beginning of the CSS may be removed.
-     *
-     * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
-     * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
-     * readable and can use inputs containing extra whitespace.
-     *
-     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
-     *
-     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
-     */
-    private static function getCssNeedleRegExp(string $needle): string
-    {
-        $needleMatcher = \preg_replace_callback(
-            '/\\s*+([{},])\\s*+|(^\\s++)|(>)\\s*+|(?:(?!\\s*+[{},]|^\\s)[^>])++/',
-            static function (array $matches): string {
-                if (isset($matches[1]) && $matches[1] !== '') {
-                    // matched possibly some whitespace, followed by "{", "}" or ",", then possibly more whitespace
-                    return '\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';
-                }
-                if (isset($matches[2]) && $matches[2] !== '') {
-                    // matched whitespace at start
-                    return '\\s*+';
-                }
-                if (isset($matches[3]) && $matches[3] !== '') {
-                    // matched ">" (e.g. end of <style> tag) followed by possibly some whitespace
-                    return \preg_quote($matches[3], '/') . '\\s*+';
-                }
-                // matched any other sequence which could not overlap with the above
-                return \preg_quote($matches[0], '/');
-            },
-            $needle
-        );
-        return '/' . $needleMatcher . '/';
-    }
-
-    /**
      * Like `assertContains` but allows for removal of some unnecessary whitespace from the CSS.
      *
      * @param string $needle
      * @param string $haystack
+     * @param string $message
      */
-    private static function assertContainsCss(string $needle, string $haystack): void
+    private static function assertContainsCss(string $needle, string $haystack, string $message = ''): void
     {
-        self::assertRegExp(
-            self::getCssNeedleRegExp($needle),
-            $haystack,
-            'Plain text needle: "' . $needle . '"'
-        );
+        $constraint = new StringContainsCss($needle);
+
+        self::assertThat($haystack, $constraint, $message);
     }
 
     /**
@@ -70,14 +34,13 @@ trait AssertCss
      *
      * @param string $needle
      * @param string $haystack
+     * @param string $message
      */
-    private static function assertNotContainsCss(string $needle, string $haystack): void
+    private static function assertNotContainsCss(string $needle, string $haystack, string $message = ''): void
     {
-        self::assertNotRegExp(
-            self::getCssNeedleRegExp($needle),
-            $haystack,
-            'Plain text needle: "' . $needle . '"'
-        );
+        $constraint = self::logicalNot(new StringContainsCss($needle));
+
+        static::assertThat($haystack, $constraint, $message);
     }
 
     /**
@@ -87,16 +50,16 @@ trait AssertCss
      * @param int $expectedCount
      * @param string $needle
      * @param string $haystack
+     * @param string $message
      */
     private static function assertContainsCssCount(
         int $expectedCount,
         string $needle,
-        string $haystack
+        string $haystack,
+        string $message = ''
     ): void {
-        self::assertSame(
-            $expectedCount,
-            \preg_match_all(self::getCssNeedleRegExp($needle), $haystack),
-            'Plain text needle: "' . $needle . "\"\nHaystack: \"" . $haystack . '"'
-        );
+        $constraint = new StringContainsCssCount($expectedCount, $needle);
+
+        self::assertThat($haystack, $constraint, $message);
     }
 }

--- a/tests/Support/Traits/TestStringConstraint.php
+++ b/tests/Support/Traits/TestStringConstraint.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Support\Traits;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+/**
+ * Adds common tests to a test case for a `Constraint` which is expected to only evaluate against strings.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+trait TestStringConstraint
+{
+    /**
+     * @return mixed[][]
+     */
+    public function provideNonString(): array
+    {
+        return [
+            'bool' => [false],
+            'int' => [0],
+            'float' => [0.0],
+            'array' => [[]],
+            'object' => [(object)[]],
+            'resource' => [\fopen('php://temp', 'r')],
+            'callable' => [
+                function (): void {
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param mixed $nonString
+     *
+     * @dataProvider provideNonString
+     */
+    public function evaluatesFalseForNonString($nonString): void
+    {
+        $constraint = $this->createSubject();
+
+        $result = $constraint->evaluate($nonString, '', true);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * This is a placeholder for a method that should be implemented by the class using this trait.
+     *
+     * @throws \Exception
+     */
+    protected function createSubject(): Constraint
+    {
+        throw new \Exception('`createSubject` method must be re-implemented');
+    }
+}

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint;
 
-use Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint;
+use Pelago\Emogrifier\Tests\Unit\Support\Constraint\Fixtures\TestingCssConstraint;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,16 +16,14 @@ use PHPUnit\Framework\TestCase;
  */
 final class CssConstraintTest extends TestCase
 {
-    use CssConstraint;
-
     /**
      * @test
      */
-    public function getCssNeedleRegExpEscapesAllSpecialCharacters(): void
+    public function getCssNeedleRegularExpressionPatternEscapesAllSpecialCharacters(): void
     {
         $needle = '.\\+*?[^]$(){}=!<>|:-/';
 
-        $result = self::getCssNeedleRegExp($needle);
+        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
 
         $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
 
@@ -38,12 +36,12 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      */
-    public function getCssNeedleRegExpNotEscapesNonSpecialCharacters(): void
+    public function getCssNeedleRegularExpressionPatternNotEscapesNonSpecialCharacters(): void
     {
         $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
             . "\r\n\t `¬\"£%&_;'@~,";
 
-        $result = self::getCssNeedleRegExp($needle);
+        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
 
         $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
 
@@ -78,11 +76,13 @@ final class CssConstraintTest extends TestCase
      *
      * @dataProvider contentWithOptionalWhitespaceDataProvider
      */
-    public function getCssNeedleRegExpInsertsOptionalWhitespace(
+    public function getCssNeedleRegularExpressionPatternInsertsOptionalWhitespace(
         string $contentToInsertAround,
         string $otherContent
     ): void {
-        $result = self::getCssNeedleRegExp($otherContent . $contentToInsertAround . $otherContent);
+        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting(
+            $otherContent . $contentToInsertAround . $otherContent
+        );
 
         $quotedOtherContent = \preg_quote($otherContent, '/');
         $expectedResult = '/' . $quotedOtherContent . '\\s*+' . \preg_quote($contentToInsertAround, '/') . '\\s*+'
@@ -94,9 +94,9 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      */
-    public function getCssNeedleRegExpReplacesWhitespaceAtStartWithOptionalWhitespace(): void
+    public function getCssNeedleRegularExpressionPatternReplacesWhitespaceAtStartWithOptionalWhitespace(): void
     {
-        $result = self::getCssNeedleRegExp(' a');
+        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting(' a');
 
         self::assertSame('/\\s*+a/', $result);
     }
@@ -122,9 +122,9 @@ final class CssConstraintTest extends TestCase
      *
      * @dataProvider styleTagDataProvider
      */
-    public function getCssNeedleRegExpInsertsOptionalWhitespaceAfterStyleTag(string $needle): void
+    public function getCssNeedleRegularExpressionPatternInsertsOptionalWhitespaceAfterStyleTag(string $needle): void
     {
-        $result = self::getCssNeedleRegExp($needle);
+        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
 
         self::assertSame('/\\<style\\>\\s*+a/', $result);
     }

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint;
+
+use Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case.
+ *
+ * @covers \Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+final class CssConstraintTest extends TestCase
+{
+    use CssConstraint;
+
+    /**
+     * @test
+     */
+    public function getCssNeedleRegExpEscapesAllSpecialCharacters(): void
+    {
+        $needle = '.\\+*?[^]$(){}=!<>|:-/';
+
+        $result = self::getCssNeedleRegExp($needle);
+
+        $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
+
+        self::assertSame(
+            '/' . \preg_quote($needle, '/') . '/',
+            $resultWithWhitespaceMatchersRemoved
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getCssNeedleRegExpNotEscapesNonSpecialCharacters(): void
+    {
+        $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
+            . "\r\n\t `¬\"£%&_;'@~,";
+
+        $result = self::getCssNeedleRegExp($needle);
+
+        $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
+
+        self::assertSame(
+            '/' . $needle . '/',
+            $resultWithWhitespaceMatchersRemoved
+        );
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function contentWithOptionalWhitespaceDataProvider(): array
+    {
+        return [
+            '"{" alone' => ['{', ''],
+            '"}" alone' => ['}', ''],
+            '"," alone' => [',', ''],
+            '"{" with non-special character' => ['{', 'a'],
+            '"{" with two non-special characters' => ['{', 'a0'],
+            '"{" with special character' => ['{', '.'],
+            '"{" with two special characters' => ['{', '.+'],
+            '"{" with special character and non-special character' => ['{', '.a'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $contentToInsertAround
+     * @param string $otherContent
+     *
+     * @dataProvider contentWithOptionalWhitespaceDataProvider
+     */
+    public function getCssNeedleRegExpInsertsOptionalWhitespace(
+        string $contentToInsertAround,
+        string $otherContent
+    ): void {
+        $result = self::getCssNeedleRegExp($otherContent . $contentToInsertAround . $otherContent);
+
+        $quotedOtherContent = \preg_quote($otherContent, '/');
+        $expectedResult = '/' . $quotedOtherContent . '\\s*+' . \preg_quote($contentToInsertAround, '/') . '\\s*+'
+            . $quotedOtherContent . '/';
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getCssNeedleRegExpReplacesWhitespaceAtStartWithOptionalWhitespace(): void
+    {
+        $result = self::getCssNeedleRegExp(' a');
+
+        self::assertSame('/\\s*+a/', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function styleTagDataProvider(): array
+    {
+        return [
+            'without space after' => ['<style>a'],
+            'one space after' => ['<style> a'],
+            'two spaces after' => ['<style>  a'],
+            'linefeed after' => ["<style>\na"],
+            'Windows line ending after' => ["<style>\r\na"],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     *
+     * @dataProvider styleTagDataProvider
+     */
+    public function getCssNeedleRegExpInsertsOptionalWhitespaceAfterStyleTag(string $needle): void
+    {
+        $result = self::getCssNeedleRegExp($needle);
+
+        self::assertSame('/\\<style\\>\\s*+a/', $result);
+    }
+}

--- a/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
+++ b/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint\Fixtures;
+
+use Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint;
+
+/**
+ * Extends the `CssConstraint` class to provide indirect access to protected method(s) for testing.
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+abstract class TestingCssConstraint extends CssConstraint
+{
+    /**
+     * Chains on to `getCssNeedleRegularExpressionPattern` for testing the protected method.
+     *
+     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
+     *
+     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
+     */
+    public static function getCssNeedleRegularExpressionPatternForTesting(string $needle): string
+    {
+        return self::getCssNeedleRegularExpressionPattern($needle);
+    }
+}

--- a/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint;
+
+use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCssCount;
+use Pelago\Emogrifier\Tests\Support\Traits\TestStringConstraint;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case.
+ *
+ * Note that the majority of the functionality is tested indirectly via
+ * {@see \Pelago\Emogrifier\Tests\Unit\Support\Traits\AssertCssTest}; those tests are not repeated here.
+ *
+ * @covers \Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+final class StringContainsCssCountTest extends TestCase
+{
+    use TestStringConstraint;
+
+    /**
+     * @return Constraint
+     */
+    protected function createSubject(): Constraint
+    {
+        return new StringContainsCssCount(0, '');
+    }
+}

--- a/tests/Unit/Support/Constraint/StringContainsCssTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint;
+
+use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss;
+use Pelago\Emogrifier\Tests\Support\Traits\TestStringConstraint;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case.
+ *
+ * Note that the majority of the functionality is tested indirectly via
+ * {@see \Pelago\Emogrifier\Tests\Unit\Support\Traits\AssertCssTest}; those tests are not repeated here.
+ *
+ * @covers \Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss
+ *
+ * @author Jake Hotson <jake.github@qzdesign.co.uk>
+ */
+final class StringContainsCssTest extends TestCase
+{
+    use TestStringConstraint;
+
+    /**
+     * @return Constraint
+     */
+    protected function createSubject(): Constraint
+    {
+        return new StringContainsCss('');
+    }
+}

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pelago\Tests\Unit\Support\Traits;
+namespace Pelago\Emogrifier\Tests\Unit\Support\Traits;
 
 use Pelago\Emogrifier\Tests\Support\Traits\AssertCss;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -18,117 +18,6 @@ use PHPUnit\Framework\TestCase;
 final class AssertCssTest extends TestCase
 {
     use AssertCss;
-
-    /**
-     * @test
-     */
-    public function getCssNeedleRegExpEscapesAllSpecialCharacters(): void
-    {
-        $needle = '.\\+*?[^]$(){}=!<>|:-/';
-
-        $result = self::getCssNeedleRegExp($needle);
-
-        $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
-
-        self::assertSame(
-            '/' . \preg_quote($needle, '/') . '/',
-            $resultWithWhitespaceMatchersRemoved
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getCssNeedleRegExpNotEscapesNonSpecialCharacters(): void
-    {
-        $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
-            . "\r\n\t `¬\"£%&_;'@~,";
-
-        $result = self::getCssNeedleRegExp($needle);
-
-        $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
-
-        self::assertSame(
-            '/' . $needle . '/',
-            $resultWithWhitespaceMatchersRemoved
-        );
-    }
-
-    /**
-     * @return string[][]
-     */
-    public function contentWithOptionalWhitespaceDataProvider(): array
-    {
-        return [
-            '"{" alone' => ['{', ''],
-            '"}" alone' => ['}', ''],
-            '"," alone' => [',', ''],
-            '"{" with non-special character' => ['{', 'a'],
-            '"{" with two non-special characters' => ['{', 'a0'],
-            '"{" with special character' => ['{', '.'],
-            '"{" with two special characters' => ['{', '.+'],
-            '"{" with special character and non-special character' => ['{', '.a'],
-        ];
-    }
-
-    /**
-     * @test
-     *
-     * @param string $contentToInsertAround
-     * @param string $otherContent
-     *
-     * @dataProvider contentWithOptionalWhitespaceDataProvider
-     */
-    public function getCssNeedleRegExpInsertsOptionalWhitespace(
-        string $contentToInsertAround,
-        string $otherContent
-    ): void {
-        $result = self::getCssNeedleRegExp($otherContent . $contentToInsertAround . $otherContent);
-
-        $quotedOtherContent = \preg_quote($otherContent, '/');
-        $expectedResult = '/' . $quotedOtherContent . '\\s*+' . \preg_quote($contentToInsertAround, '/') . '\\s*+'
-            . $quotedOtherContent . '/';
-
-        self::assertSame($expectedResult, $result);
-    }
-
-    /**
-     * @test
-     */
-    public function getCssNeedleRegExpReplacesWhitespaceAtStartWithOptionalWhitespace(): void
-    {
-        $result = self::getCssNeedleRegExp(' a');
-
-        self::assertSame('/\\s*+a/', $result);
-    }
-
-    /**
-     * @return string[][]
-     */
-    public function styleTagDataProvider(): array
-    {
-        return [
-            'without space after' => ['<style>a'],
-            'one space after' => ['<style> a'],
-            'two spaces after' => ['<style>  a'],
-            'linefeed after' => ["<style>\na"],
-            'Windows line ending after' => ["<style>\r\na"],
-        ];
-    }
-
-    /**
-     * @test
-     *
-     * @param string $needle
-     *
-     * @dataProvider styleTagDataProvider
-     */
-    public function getCssNeedleRegExpInsertsOptionalWhitespaceAfterStyleTag(string $needle): void
-    {
-        $result = self::getCssNeedleRegExp($needle);
-
-        self::assertSame('/\\<style\\>\\s*+a/', $result);
-    }
 
     /**
      * @return string[][]


### PR DESCRIPTION
This is the pattern used by PHPUnit, and provides a couple of benefits:
- Constraints can be combined with, e.g., LogicalOr (will be useful for #544);
- The message provided upon a test failure will be clearer.

Also corrected the namespace for `AssertCssTest` for consistency with other
`TestCase` classes.