### PR TITLE
[TASK] Automatically add a backslash for global functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   [#907](https://github.com/MyIntervals/emogrifier/pull/907))
 
 ### Changed
+- Automatically add a backslash for global functions
+  ([#909](https://github.com/MyIntervals/emogrifier/pull/909))
 - Update the development tools
   ([#898](https://github.com/MyIntervals/emogrifier/pull/898),
   [#895](https://github.com/MyIntervals/emogrifier/pull/895))

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -43,8 +43,7 @@ return \PhpCsFixer\Config::create()
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,
-            // not yet, but maybe later to improve performance
-            // 'native_function_invocation' => true,
+            'native_function_invocation' => true,
             'new_with_braces' => true,
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,


### PR DESCRIPTION
Using a leading backslash when calling a function in the global namespace
provides a (small) performance benefit.

Adjust the PHP CS Fixer configuration to add any missing backslashes.