### PR TITLE
[TASK] Convert psalm-specific type annotations

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -804,9 +804,7 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $css CSS with comments removed
      *
-     * @psalm-return array<array-key, array<string, string>>
-     *
-     * @return string[][] Array of string sub-arrays with the keys
+     * @return array<array-key, array<string, string>> Array of string sub-arrays with the keys
      *         "media" (the media query string, e.g. "@media screen and (max-width: 480px)",
      *         or an empty string if not from an `@media` rule),
      *         "selectors" (the CSS selector(s), e.g., "*" or "h1, h2"),

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -524,9 +524,9 @@ class CssInliner extends AbstractHtmlProcessor
      * @param string $css CSS with comments removed
      *
      * @return string[] The first element is the CSS with the valid `@import` and `@charset` rules removed.  The second
-     * element contains a concatenation of the valid `@import` rules, each followed by whatever whitespace followed it
-     * in the original CSS (so that either unminified or minified formatting is preserved); if there were no `@import`
-     * rules, it will be an empty string.  The (valid) `@charset` rules are discarded.
+     *         element contains a concatenation of the valid `@import` rules, each followed by whatever whitespace
+     *         followed it in the original CSS (so that either unminified or minified formatting is preserved); if there
+     *         were no `@import` rules, it will be an empty string.  The (valid) `@charset` rules are discarded.
      */
     private function extractImportAndCharsetRules(string $css): array
     {
@@ -561,9 +561,9 @@ class CssInliner extends AbstractHtmlProcessor
      * @param string $css CSS with comments, import and charset removed
      *
      * @return string[] The first element is the CSS with the at-rules removed.  The second element contains a
-     * concatenation of the valid at-rules, each followed by whatever whitespace followed it in the original CSS (so
-     * that either unminified or minified formatting is preserved); if there were no at-rules, it will be an empty
-     * string.
+     *                  concatenation of the valid at-rules, each followed by whatever whitespace followed it in the
+     *                  original CSS (so that either unminified or minified formatting is preserved); if there were no
+     *                  at-rules, it will be an empty string.
      */
     private function extractUninlinableCssAtRules(string $css): array
     {
@@ -1201,7 +1201,7 @@ class CssInliner extends AbstractHtmlProcessor
      * @param string $selector
      *
      * @return string selector which will match the relevant DOM elements if the removed components are assumed to apply
-     * (or in the case of pseudo-elements will match their originating element)
+     *         (or in the case of pseudo-elements will match their originating element)
      */
     private function removeSelectorComponents(string $matcher, string $selector): string
     {
@@ -1219,7 +1219,7 @@ class CssInliner extends AbstractHtmlProcessor
      * @param string $selectorPart part of a selector which has been split up at combinators
      *
      * @return string selector part which will match the relevant DOM elements if the pseudo-classes are assumed to
-     * apply
+     *         apply
      */
     private function removeUnsupportedOfTypePseudoClasses(string $selectorPart): string
     {

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -282,9 +282,7 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      * Parses a shorthand CSS value and splits it into individual values
      *
      * @param string $value a string of CSS value with 1, 2, 3 or 4 sizes
-     *                      For example: padding: 0 auto;
-     *                      '0 auto' is split into top: 0, left: auto, bottom: 0,
-     *                      right: auto.
+     *        For example: padding: 0 auto; '0 auto' is split into top: 0, left: auto, bottom: 0, right: auto.
      *
      * @return string[] an array of values for top, right, bottom and left (using these as associative array keys)
      */

--- a/src/Utilities/CssConcatenator.php
+++ b/src/Utilities/CssConcatenator.php
@@ -61,7 +61,7 @@ class CssConcatenator
      * @param string[] $selectors Array of selectors for the rule, e.g. ["ul", "ol", "p:first-child"].
      * @param string $declarationsBlock The property declarations, e.g. "margin-top: 0.5em; padding: 0".
      * @param string $media The media query for the rule, e.g. "@media screen and (max-width:639px)",
-     *                      or an empty string if none.
+     *        or an empty string if none.
      */
     public function append(array $selectors, string $declarationsBlock, string $media = ''): void
     {
@@ -96,7 +96,7 @@ class CssConcatenator
 
     /**
      * @param string $media The media query for rules to be appended, e.g. "@media screen and (max-width:639px)",
-     *                      or an empty string if none.
+     *        or an empty string if none.
      *
      * @return \stdClass Object with properties as described for elements of `$mediaRules`.
      */
@@ -119,7 +119,7 @@ class CssConcatenator
      * Tests if two sets of selectors are equivalent (i.e. the same selectors, possibly in a different order).
      *
      * @param mixed[] $selectorsAsKeys1 Array in which the selectors are the keys, and the values are of no
-     *                                  significance.
+     *        significance.
      * @param mixed[] $selectorsAsKeys2 Another such array.
      *
      * @return bool
@@ -146,7 +146,7 @@ class CssConcatenator
 
     /**
      * @param \stdClass $ruleBlock Object with properties as described for elements of the `ruleBlocks` property of
-     *                            elements of `$mediaRules`.
+     *        elements of `$mediaRules`.
      *
      * @return string CSS for the rule block.
      */

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1129,16 +1129,12 @@ final class CssInlinerTest extends TestCase
      * Specificity ordering for selectors involving pseudo-classes, attributes and `:not` is covered through the
      * combination of these tests and the equal specificity tests and thus does not require explicit separate testing.
      *
-     * @return string[][]
-     *
-     * @psalm-return array<string, array<int, string>>
+     * @return array<string, array<int, string>>
      */
     public function differentCssSelectorSpecificityDataProvider(): array
     {
         /**
-         * @var string[] Selectors targeting `<span id="text">` with increasing specificity
-         *
-         * @psalm-var array<string, string>
+         * @var array<string, string> Selectors targeting `<span id="text">` with increasing specificity
          */
         $selectors = [
             'universal' => '*',
@@ -2185,15 +2181,11 @@ final class CssInlinerTest extends TestCase
     }
 
     /**
-     * @param string[] $precedingSelectorComponents Array of selectors to which each type of pseudo-component is
-     *                                              appended to create a selector for a CSS rule.
-     *                                              Keys are human-readable descriptions.
+     * @param array<string, string> $precedingSelectorComponents selectors to which each type of pseudo-component is
+     *                                                           appended to create a selector for a CSS rule.
+     *                                                           Keys are human-readable descriptions.
      *
-     * @psalm-param array<string, string> $precedingSelectorComponents
-     *
-     * @return string[][]
-     *
-     * @psalm-return array<string, array<int, string>>
+     * @return array<string, array<int, string>>
      */
     private function getCssRuleDatasetsWithSelectorPseudoComponents(array $precedingSelectorComponents): array
     {

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -2182,8 +2182,7 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @param array<string, string> $precedingSelectorComponents selectors to which each type of pseudo-component is
-     *                                                           appended to create a selector for a CSS rule.
-     *                                                           Keys are human-readable descriptions.
+     *        appended to create a selector for a CSS rule. Keys are human-readable descriptions.
      *
      * @return array<string, array<int, string>>
      */

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -572,9 +572,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return string[][]
-     *
-     * @psalm-return array<string, array<int, string>>
+     * @return array<string, array<int, string>>
      */
     public function documentTypeDataProvider(): array
     {
@@ -712,9 +710,8 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return string[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string}>
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint
+     * @array<string, array{0:string, 1:string}>
      */
     public function xmlSelfClosingTagDataProvider(): array
     {
@@ -739,17 +736,15 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return string[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string}>
+     * @return array<string, array{0:string, 1:string}>
      */
     public function nonXmlSelfClosingTagDataProvider(): array
     {
         return \array_map(
             /**
-             * @psalm-param array{0:string, 1:string} $dataset
+             * @param array{0:string, 1:string} $dataset
              *
-             * @psalm-return array{0:string, 1:string}
+             * @return array{0:string, 1:string}
              */
             static function (array $dataset) {
                 $dataset[0] = \str_replace('/>', '>', $dataset[0]);
@@ -760,25 +755,23 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return string[][] Each dataset has three elements in the following order:
+     * @return array<string, array{0:string, 1:string, 2:string}>
+     *         Each dataset has three elements in the following order:
      *         - HTML with non-XML self-closing tags (e.g. "...<br>...");
      *         - The equivalent HTML with XML self-closing tags (e.g. "...<br/>...");
      *         - The name of a self-closing tag contained in the HTML (e.g. "br").
-     *
-     * @psalm-return array<string, array{0:string, 1:string, 2:string}>
      */
     public function selfClosingTagDataProvider(): array
     {
         return \array_map(
             /**
-             * @psalm-param array{0:string, 1:string} $dataset
+             * @param array{0:string, 1:string} $dataset
              *
-             * @psalm-return array{0:string, 1:string, 2:string}
+             * @return array{0:string, 1:string, 2:string}
              */
             static function (array $dataset) {
                 \array_unshift($dataset, \str_replace('/>', '>', $dataset[0]));
 
-                /** @psalm-var array{0:string, 1:string, 2:string} */
                 return $dataset;
             },
             $this->xmlSelfClosingTagDataProvider()
@@ -789,11 +782,8 @@ final class AbstractHtmlProcessorTest extends TestCase
      * Concatenates pairs of datasets (in a similar way to SQL `JOIN`) such that each new dataset consists of a 'row'
      * from a left-hand-side dataset joined with a 'row' from a right-hand-side dataset.
      *
-     * @param string[][] $leftDatasets
-     * @param string[][] $rightDatasets
-     *
-     * @psalm-param array<string, array<int, string>> $leftDatasets
-     * @psalm-param array<string, array<int, string>> $rightDatasets
+     * @param array<string, array<int, string>> $leftDatasets
+     * @param array<string, array<int, string>> $rightDatasets
      *
      * @return string[][] The new datasets comprise the first dataset from the left-hand side with each of the datasets
      * from the right-hand side, and the each of the remaining datasets from the left-hand side with the first dataset

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -785,8 +785,8 @@ final class AbstractHtmlProcessorTest extends TestCase
      * @param array<string, array<int, string>> $rightDatasets
      *
      * @return string[][] The new datasets comprise the first dataset from the left-hand side with each of the datasets
-     * from the right-hand side, and the each of the remaining datasets from the left-hand side with the first dataset
-     * from the right-hand side.
+     *         from the right-hand side, and the each of the remaining datasets from the left-hand side with the first
+     *         dataset from the right-hand side.
      */
     public static function joinDatasets(array $leftDatasets, array $rightDatasets): array
     {

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -710,8 +710,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint
-     * @array<string, array{0:string, 1:string}>
+     * @return array<string, array{0:string, 1:string}>
      */
     public function xmlSelfClosingTagDataProvider(): array
     {

--- a/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
+++ b/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
@@ -166,13 +166,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string[]}>
+     * @return array<string, array{0:string, 1:string[]}>
      */
     public function provideHtmlAndNonMatchedClasses(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string[]}> */
         return [
             '1 attribute, 1 class, no classes to keep' => [
                 'HTML' => '<p class="foo">hello</p>',
@@ -233,13 +230,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string[], 2:string[]}>
+     * @return array<string, array{0:string, 1:string[], 2:string[]}>
      */
     public function provideHtmlAndSomeMatchedClasses(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string[], 2:string[]}> */
         return [
             '2 attributes, 1 different class each, 1st class to be kept' => [
                 'HTML' => '<p class="foo">hello</p><p class="bar">world</p>',
@@ -270,13 +264,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string[], 2:string[]}>
+     * @return array<string, array{0:string, 1:string[], 2:string[]}>
      */
     public function provideHtmlWithExtraWhitespaceAndSomeMatchedClasses(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string[], 2:string[]}> */
         return [
             '1 attribute, 2 classes with extra whitespace, 1 to be kept' => [
                 'HTML' => '<p class=" foo  bar ">hello</p>',
@@ -315,13 +306,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string[]}>
+     * @return array<string, array{0:string, 1:string[]}>
      */
     public function provideHtmlAndAllMatchedClasses(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string[]}> */
         return [
             '1 attribute, 1 class, that class to be kept' => [
                 'HTML' => '<p class="foo">hello</p>',
@@ -343,13 +331,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string[]}>
+     * @return array<string, array{0:string, 1:string[]}>
      */
     public function provideHtmlWithExtraWhitespaceAndAllMatchedClasses(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string[]}> */
         return [
             '1 attribute, 1 class with extra whitespace, that class to be kept' => [
                 'HTML' => '<p class=" foo ">hello</p>',
@@ -419,10 +404,7 @@ final class HtmlPrunerTest extends TestCase
      * @param string $html
      * @param string $css
      *
-     * @return (CssInliner|HtmlPruner)[] The `HtmlPruner` subject is the first element, and the `CssInliner` fixture is
-     *         the second element.
-     *
-     * @psalm-return array{0:HtmlPruner, 1:CssInliner}
+     * @return array{0:HtmlPruner, 1:CssInliner}
      */
     private function buildSubjectAndCssInlinerWithCssInlined(string $html, string $css): array
     {
@@ -460,13 +442,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string, 2:string[]}>
+     * @return array<string, array{0:string, 1:string, 2:string[]}>
      */
     public function provideClassesNotInUninlinableRules(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string, 2:string[]}> */
         return [
             'inlinable rule with different class' => [
                 'HTML' => '<p class="foo">hello</p>',
@@ -529,13 +508,10 @@ final class HtmlPrunerTest extends TestCase
     }
 
     /**
-     * @return (string|string[])[][]
-     *
-     * @psalm-return array<string, array{0:string, 1:string, 2:string[]}>
+     * @return array<string, array{0:string, 1:string, 2:string[]}>
      */
     public function provideClassesInUninlinableRules(): array
     {
-        /** @psalm-var array<string, array{0:string, 1:string, 2:string[]}> */
         return [
             'media rule' => [
                 'HTML' => '<p class="foo">hello</p>',

--- a/tests/Unit/Utilities/CssConcatenatorTest.php
+++ b/tests/Unit/Utilities/CssConcatenatorTest.php
@@ -64,9 +64,7 @@ final class CssConcatenatorTest extends TestCase
     }
 
     /**
-     * @return string[][]
-     *
-     * @psalm-return array<string, array<int, array<int, string>>>
+     * @return array<string, array<int, array<int, string>>>
      */
     public function equivalentSelectorsDataProvider(): array
     {
@@ -117,9 +115,7 @@ final class CssConcatenatorTest extends TestCase
     }
 
     /**
-     * @return string[][]
-     *
-     * @psalm-return array<string, array<int, array<int, string>>>
+     * @return array<string, array<int, array<int, string>>>
      */
     public function differentSelectorsDataProvider(): array
     {
@@ -280,9 +276,7 @@ final class CssConcatenatorTest extends TestCase
     }
 
     /**
-     * @return mixed[][]
-     *
-     * @psalm-return array<string, array{0:array<int, string>, 1:string, 2:array<int, string>, 3:string, 4:string}>
+     * @return array<string, array{0:array<int, string>, 1:string, 2:array<int, string>, 3:string, 4:string}>
      */
     public function combinableRulesDataProvider(): array
     {


### PR DESCRIPTION
`@param`/`@return`/`@varannotations` like `array<int, string>`
are now recognized by PhpStorm's code inspection.

This will make our type annotations more concise and allows us
to switch to another static type analysis tool (e.g., PHPStan) more easily.

Fixes #913