### PR TITLE
[BUGFIX] Add `composer install` to GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
           else
             DEPENDENCIES='';
           fi;
+          composer install --no-progress
           composer update --no-progress "${DEPENDENCIES}";
           composer show;
 


### PR DESCRIPTION
There may be a previous installation in the box on which the command is running,
but it's not guaranteed.