### PR TITLE
[TASK] Run the static analysis tools with PHP 7.4, not 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
+          - 7.4
 
     steps:
       - name: Checkout
@@ -72,7 +72,7 @@ jobs:
           - psalm
           - sniff
         php-version:
-          - 7.3
+          - 7.4
 
     steps:
       - name: Checkout

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -88,7 +88,13 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <!--
+        The following rule makes only sense if we require PHP >= 7.4.
+        Otherwise, running the code sniffer on PHP 7.4 would suggest changes
+        that are not viable while we still support PHP 7.3
+        (because this rule checks which PHP version it is running on).
+        <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    -->
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
         <!-- Allow PHPDoc with no additional information -->


### PR DESCRIPTION
All the tools which we are using should properly support PHP 7.4 by
now, and we can benefit from the improved performance.