### PR TITLE
[CLEANUP] Require `slevomat/coding-standard` 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
-        "slevomat/coding-standard": "^6.4",
+        "slevomat/coding-standard": "^6.4.1",
         "squizlabs/php_codesniffer": "^3.5.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
-        "slevomat/coding-standard": "^4.0.0 || ^6.4",
+        "slevomat/coding-standard": "^6.4",
         "squizlabs/php_codesniffer": "^3.5.1"
     },
     "autoload": {


### PR DESCRIPTION
The changes in #927 are not compatible with version 4.x.