### PR TITLE
[TASK] Drop support for Symfony 4.3 and 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Support for PHP 7.1 will be removed in Emogrifier 6.0.
 
 ### Removed
+- Drop support for Symfony 4.3 and 5.0
+  ([#918](https://github.com/MyIntervals/emogrifier/pull/918),
+  [#936](https://github.com/MyIntervals/emogrifier/pull/936))
 - Stop checking `tests/` with Psalm
   ([#885](https://github.com/MyIntervals/emogrifier/pull/885))
 - Drop support for PHP 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 - Drop support for Symfony 4.3 and 5.0
-  ([#918](https://github.com/MyIntervals/emogrifier/pull/918),
-  [#936](https://github.com/MyIntervals/emogrifier/pull/936))
+  ([#936](https://github.com/MyIntervals/emogrifier/pull/936))
 - Stop checking `tests/` with Psalm
   ([#885](https://github.com/MyIntervals/emogrifier/pull/885))
 - Drop support for PHP 7.0

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "symfony/css-selector": "^3.4.32 || ^4.3.5 || ^5.0"
+        "symfony/css-selector": "^3.4.32 || ^4.4 || ^5.1"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",


### PR DESCRIPTION
Symfony 4.3 and 5.0 are end-of-life now.

Emogrifier still supports the Symfony LTS releases 3.4 and 4.4 as well
as the currently supported non-LTS version 5.1 (and newer 5.x versions).

Fixes #918