### PR TITLE
[TASK] Allow addition/removal of optional `;` in CSS tests

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -27,19 +27,22 @@ abstract class CssConstraint extends Constraint
      * @var string
      */
     private const CSS_REGULAR_EXPRESSIOM_PATTERN = '/
-        \\s*+([{},])\\s*+               # `{`, `}` or `,` captured in group 1, with possible whitespace either side
-        |(^\\s++)                       # whitespace at the very start, captured in group 2
-        |(>)\\s*+                       # `>` (e.g. closing a `<style>` element opening tag) with optional whitespace
-                                        # following, captured in group 3
-        |(?:(?!\\s*+[{},]|^\\s)[^>])++  # Anything else is matched, though not captured.  This is required so that any
-                                        # characters in the input string that happen to have a special meaning in a
-                                        # regular expression can be escaped.
+        (?<![\\s;}])                    # - `}` as end of declarations rule block, captured in group 1, with possible
+            (?:\\s*+;)?+                #   surrounding whitespace and optional preceding `;` (but not if preceded by
+            \\s*+(\\})\\s*+             #   another `}` or `;`)
+        |\\s*+([{};,])\\s*+             # - `{`, `}`, `;` or `,` captured in group 2, with possible whitespace around
+        |(^\\s++)                       # - whitespace at the very start, captured in group 3
+        |(>)\\s*+                       # - `>` (e.g. closing a `<style>` element opening tag) with optional whitespace
+                                        #   following, captured in group 4
+        |(?:(?!\\s*+[{};,]|^\\s)[^>])++ # - Anything else is matched, though not captured.  This is required so that any
+                                        #   characters in the input string that happen to have a special meaning in a
+                                        #   regular expression can be escaped.
     /x';
 
     /**
      * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
      * element added to the document, due to the way that certain parts are `trim`med.  Notably, whitespace either side
-     * of "{", "}" and "," or at the beginning of the CSS may be removed.
+     * of "{", "}", ";" and ",", or at the beginning of the CSS may be removed.
      *
      * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
      * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
@@ -67,11 +70,13 @@ abstract class CssConstraint extends Constraint
     private static function getCssNeedleRegularExpressionReplacement(array $matches): string
     {
         if (($matches[1] ?? '') !== '') {
-            $regularExpressionEquivalent = '\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';
+            $regularExpressionEquivalent = '(?:\\s*+;)?+\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';
         } elseif (($matches[2] ?? '') !== '') {
-            $regularExpressionEquivalent = '\\s*+';
+            $regularExpressionEquivalent = '\\s*+' . \preg_quote($matches[2], '/') . '\\s*+';
         } elseif (($matches[3] ?? '') !== '') {
-            $regularExpressionEquivalent = \preg_quote($matches[3], '/') . '\\s*+';
+            $regularExpressionEquivalent = '\\s*+';
+        } elseif (($matches[4] ?? '') !== '') {
+            $regularExpressionEquivalent = \preg_quote($matches[4], '/') . '\\s*+';
         } else {
             $regularExpressionEquivalent = \preg_quote($matches[0], '/');
         }

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -25,11 +25,11 @@ final class CssConstraintTest extends TestCase
 
         $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
 
-        $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
+        $resultWithOtherMatchersRemoved = \str_replace(['(?:\\s*+;)?+', '\\s*+'], '', $result);
 
         self::assertSame(
             '/' . \preg_quote($needle, '/') . '/',
-            $resultWithWhitespaceMatchersRemoved
+            $resultWithOtherMatchersRemoved
         );
     }
 
@@ -59,6 +59,7 @@ final class CssConstraintTest extends TestCase
         return [
             '"{" alone' => ['{', ''],
             '"}" alone' => ['}', ''],
+            '";" alone' => [';', ''],
             '"," alone' => [',', ''],
             '"{" with non-special character' => ['{', 'a'],
             '"{" with two non-special characters' => ['{', 'a0'],
@@ -85,10 +86,10 @@ final class CssConstraintTest extends TestCase
         );
 
         $quotedOtherContent = \preg_quote($otherContent, '/');
-        $expectedResult = '/' . $quotedOtherContent . '\\s*+' . \preg_quote($contentToInsertAround, '/') . '\\s*+'
-            . $quotedOtherContent . '/';
+        $expectedResult = $quotedOtherContent . '\\s*+' . \preg_quote($contentToInsertAround, '/') . '\\s*+'
+            . $quotedOtherContent;
 
-        self::assertSame($expectedResult, $result);
+        self::assertStringContainsString($expectedResult, $result);
     }
 
     /**

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -26,10 +26,10 @@ final class AssertCssTest extends TestCase
     {
         $cssStrings = [
             'unminified CSS' => 'html, body { color: green; }',
-            'minified CSS' => 'html,body{color: green;}',
-            'CSS with extra spaces' => '  html  ,  body  {  color: green;  }',
-            'CSS with linefeeds' => "\nhtml\n,\nbody\n{\ncolor: green;\n}",
-            'CSS with Windows line endings' => "\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor: green;\r\n}",
+            'minified CSS' => 'html,body{color: green}',
+            'CSS with extra spaces' => '  html  ,  body  {  color: green  ;  }',
+            'CSS with linefeeds' => "\nhtml\n,\nbody\n{\ncolor: green\n;\n}",
+            'CSS with Windows line endings' => "\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor: green\r\n;\r\n}",
         ];
 
         $datasets = [];
@@ -43,6 +43,7 @@ final class AssertCssTest extends TestCase
                 ];
             }
         }
+
         return $datasets;
     }
 
@@ -55,6 +56,15 @@ final class AssertCssTest extends TestCase
             'CSS part with "{" not in CSS' => ['p {', 'body { color: green; }'],
             'CSS part with "}" not in CSS' => ['color: red; }', 'body { color: green; }'],
             'CSS part with "," not in CSS' => ['html, body', 'body { color: green; }'],
+            'missing `;` after declaration where not optional' => [
+                'body { color: green; font-size: 15px; }',
+                "body { color: green\nfont-size: 15px; }",
+            ],
+            'extra `;` after declaration' => ['body { color: green; }', 'body { color: green;; }'],
+            'spurious `;` after rule in at-rule' => [
+                '@media print { body { color: green; } }',
+                '@media print { body { color: green; }; }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Also allow variation in whitespace around `;`.

Would be needed to switch to an alternative CSS parser like
`sabberworm/php-css-parser` which may result in the addition or removal the
optional semicolon, or whitespace around semicolons, in CSS declarations -
see #544.