### PR TITLE
[BUGFIX] Also update the dependencies when running Composer update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
             DEPENDENCIES='';
           fi;
           composer install --no-progress
-          composer update --no-progress "${DEPENDENCIES}";
+          composer update --with-dependencies --no-progress "${DEPENDENCIES}";
           composer show;
 
       - name: Update PHIVE dependencies


### PR DESCRIPTION
This allows us to test compatibility with the lowest/highest versions
of all dependencies, not only the direct ones.