### PR TITLE
[TASK] Allow variable whitespace around `:` in CSS tests

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -27,16 +27,26 @@ abstract class CssConstraint extends Constraint
      * @var string
      */
     private const CSS_REGULAR_EXPRESSION_PATTERN = '/
-        (?<![\\s;}])                    # - `}` as end of declarations rule block, captured in group 1, with possible
-            (?:\\s*+;)?+                #   surrounding whitespace and optional preceding `;` (but not if preceded by
-            \\s*+(\\})\\s*+             #   another `}` or `;`)
-        |\\s*+([{};,])\\s*+             # - `{`, `}`, `;` or `,` captured in group 2, with possible whitespace around
-        |(^\\s++)                       # - whitespace at the very start, captured in group 3
-        |(>)\\s*+                       # - `>` (e.g. closing a `<style>` element opening tag) with optional whitespace
-                                        #   following, captured in group 4
-        |(?:(?!\\s*+[{};,]|^\\s)[^>])++ # - Anything else is matched, though not captured.  This is required so that any
-                                        #   characters in the input string that happen to have a special meaning in a
-                                        #   regular expression can be escaped.
+        (?<![\\s;}])                        # - `}` as end of declarations rule block, captured in group 1, with
+            (?:\\s*+;)?+                    #   possible surrounding whitespace and optional preceding `;` (but not if
+            \\s*+(\\})\\s*+                 #   preceded by another `}` or `;`)
+        |\\s*+(                             # - `{`, `}`, `;`, `,` or `:`, captured in group 2, with possible whitespace
+            [{};,]                          #   around - `:` is only matched if in a declarations block (i.e. not
+            |\\:(?![^\\{\\}]*+\\{)          #   followed later by `{` without a closing `}` first)
+        )\\s*+                              #
+        |(^\\s++)                           # - whitespace at the very start, captured in group 3
+        |(>)\\s*+                           # - `>` (e.g. closing a `<style>` element opening tag) with optional
+                                            #   whitespace following, captured in group 4
+        |(?:                                # - Anything else is matched, though not captured.  This is required so that
+            (?!                             #   any characters in the input string that happen to have a special meaning
+                \\s*+(?:                    #   in a regular expression can be escaped.  `.` would also work, but
+                    [{};,]                  #   matching a longer sequence is more optimal (and `.*` would not work).
+                    |\\:(?![^\\{\\}]*+\\{)  #
+                )                           #
+                |^\\s                       #
+            )                               #
+            [^>]                            #
+        )++                                 #
     /x';
 
     /**

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -26,10 +26,10 @@ final class AssertCssTest extends TestCase
     {
         $cssStrings = [
             'unminified CSS' => 'html, body { color: green; }',
-            'minified CSS' => 'html,body{color: green}',
-            'CSS with extra spaces' => '  html  ,  body  {  color: green  ;  }',
-            'CSS with linefeeds' => "\nhtml\n,\nbody\n{\ncolor: green\n;\n}",
-            'CSS with Windows line endings' => "\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor: green\r\n;\r\n}",
+            'minified CSS' => 'html,body{color:green}',
+            'CSS with extra spaces' => '  html  ,  body  {  color  :  green  ;  }  ',
+            'CSS with linefeeds' => "\nhtml\n,\nbody\n{\ncolor\n:\ngreen\n;\n}\n",
+            'CSS with Windows line endings' => "\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor\r\n:\r\ngreen\r\n;\r\n}\r\n",
         ];
 
         $datasets = [];
@@ -64,6 +64,18 @@ final class AssertCssTest extends TestCase
             'spurious `;` after rule in at-rule' => [
                 '@media print { body { color: green; } }',
                 '@media print { body { color: green; }; }',
+            ],
+            'invalid space after `:` for pseudo-class' => [
+                'p:first-child { color: green; }',
+                'p: first-child { color: green; }',
+            ],
+            'pseudo-class without descendant combinator does not match with' => [
+                'p:first-child { color: green; }',
+                'p :first-child { color: green; }',
+            ],
+            'pseudo-class with descendant combinator does not match without' => [
+                'p :first-child { color: green; }',
+                'p:first-child { color: green; }',
             ],
         ];
     }


### PR DESCRIPTION
(This is in property declarations only, not selectors.)

Would be needed to switch to an alternative CSS parser like
`sabberworm/php-css-parser` which may result in the addition or removal of such
whitespace - see #544.