### PR TITLE
[BUGFIX] Allow "Content-Type" in content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow "Content-Type" in content
+  ([#959](https://github.com/MyIntervals/emogrifier/pull/959))
 
 ## 5.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
+        "rawr/cross-data-providers": "^2.3.0",
         "slevomat/coding-standard": "^6.4.1",
         "squizlabs/php_codesniffer": "^3.5.8"
     },

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -271,8 +271,9 @@ abstract class AbstractHtmlProcessor
      */
     private function addContentTypeMetaTag(string $html): string
     {
-        $hasContentTypeMetaTag
-            = \preg_match('%<meta(?=\\s)[^>]*\\shttp-equiv=(["\']?+)Content-Type\\g{-1}[\\s/>]%i', $html) === 1;
+        $contentTypeMetaTagMatchCount
+            = \preg_match('%<meta(?=\\s)[^>]*\\shttp-equiv=(["\']?+)Content-Type\\g{-1}[\\s/>]%i', $html);
+        $hasContentTypeMetaTag = \is_int($contentTypeMetaTagMatchCount) && $contentTypeMetaTagMatchCount > 0;
         if ($hasContentTypeMetaTag) {
             return $html;
         }

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -271,7 +271,8 @@ abstract class AbstractHtmlProcessor
      */
     private function addContentTypeMetaTag(string $html): string
     {
-        $hasContentTypeMetaTag = \stripos($html, 'Content-Type') !== false;
+        $hasContentTypeMetaTag
+            = \preg_match('%<meta(?=\\s)[^>]*\\shttp-equiv=(["\']?+)Content-Type\\g{-1}[\\s/>]%i', $html) === 1;
         if ($hasContentTypeMetaTag) {
             return $html;
         }

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -678,12 +678,32 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
+     * @return string[][]
+     */
+    public function provideMalformedContentTypeMetaTag(): array
+    {
+        return [
+            'extra character before META' => ['<xmeta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'extra character after META' => ['<metax http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'extra character before HTTP-EQUIV'
+                => ['<meta xhttp-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'extra character after HTTP-EQUIV'
+                => ['<meta http-equivx="Content-Type" content="text/html; charset=utf-8">'],
+            'extra character before CONTENT-TYPE'
+                => ['<meta http-equiv=xContent-Type content="text/html; charset=utf-8">'],
+            'extra character after CONTENT-TYPE'
+                => ['<meta http-equiv=Content-Typex content="text/html; charset=utf-8">'],
+        ];
+    }
+
+    /**
      * @test
      *
      * @param string $html
      *
      * @dataProvider provideContentWithoutHeadTag
      * @dataProvider provideContentWithHeadTag
+     * @dataProvider provideMalformedContentTypeMetaTag
      */
     public function addsMissingContentTypeMetaTagOnlyOnce(string $html): void
     {

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -7,6 +7,7 @@ namespace Pelago\Emogrifier\Tests\Unit\HtmlProcessor;
 use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 use Pelago\Emogrifier\Tests\Unit\HtmlProcessor\Fixtures\TestingHtmlProcessor;
 use PHPUnit\Framework\TestCase;
+use TRegx\DataProvider\DataProviders;
 
 /**
  * Test case.
@@ -388,7 +389,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function contentWithoutHtmlTagDataProvider(): array
+    public function provideContentWithoutHtmlTag(): array
     {
         return [
             'doctype only' => ['<!DOCTYPE html>'],
@@ -396,6 +397,14 @@ final class AbstractHtmlProcessorTest extends TestCase
             'HEAD element' => ['<head></head>'],
             'BODY element' => ['<body></body>'],
             'HEAD AND BODY element' => ['<head></head><body></body>'],
+            'META element with Content-Type as a value' => ['<meta name="description" content="Content-Type">'],
+            'HEAD element with Content-Type in comment' => ['<head><!-- Content-Type --></head>'],
+            'BODY element with Content-Type in text' => ['<body>Content-Type</body>'],
+            'body content only with Content-Type in text' => ['<p>Content-Type</p>'],
+            'BODY element containing Content-Type META tag'
+                => ['<body><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></body>'],
+            'body content only with Content-Type META tag'
+                => ['<p>hello</p><meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
         ];
     }
 
@@ -404,7 +413,7 @@ final class AbstractHtmlProcessorTest extends TestCase
      *
      * @param string $html
      *
-     * @dataProvider contentWithoutHtmlTagDataProvider
+     * @dataProvider provideContentWithoutHtmlTag
      */
     public function addsMissingHtmlTag(string $html): void
     {
@@ -418,14 +427,20 @@ final class AbstractHtmlProcessorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function contentWithoutHeadTagDataProvider(): array
+    public function provideContentWithoutHeadTag(): array
     {
         return [
             'doctype only' => ['<!DOCTYPE html>'],
+            'HTML element' => ['<html></html>'],
             'body content only' => ['<p>Hello</p>'],
             'BODY element' => ['<body></body>'],
             'HEADER element' => ['<header></header>'],
             'META element (implicit HEAD)' => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'META element with Content-Type as a value' => ['<meta name="description" content="Content-Type">'],
+            'BODY element with Content-Type in text' => ['<body>Content-Type</body>'],
+            'body content only with Content-Type in text' => ['<p>Content-Type</p>'],
+            // broken: BODY element containing Content-Type META tag
+            // broken: body content only with Content-Type META tag
         ];
     }
 
@@ -434,7 +449,7 @@ final class AbstractHtmlProcessorTest extends TestCase
      *
      * @param string $html
      *
-     * @dataProvider contentWithoutHeadTagDataProvider
+     * @dataProvider provideContentWithoutHeadTag
      */
     public function addsMissingHeadTagOnlyOnce(string $html): void
     {
@@ -449,7 +464,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function contentWithHeadTagDataProvider(): array
+    public function provideContentWithHeadTag(): array
     {
         return [
             'HEAD element' => ['<head></head>'],
@@ -457,6 +472,14 @@ final class AbstractHtmlProcessorTest extends TestCase
             '(invalid) void HEAD element' => ['<head/>'],
             'HEAD element with attribute' => ['<head lang="en"></head>'],
             'HEAD element and HEADER element' => ['<head></head><header></header>'],
+            'HEAD element with Content-Type in comment' => ['<head><!-- Content-Type --></head>'],
+            'HEAD element with Content-Type as META value' => ['<meta name="description" content="Content-Type">'],
+            'with BODY element with Content-Type in text' => ['<head></head><body>Content-Type</body>'],
+            'with implicit body content with Content-Type in text' => ['<head></head><p>Content-Type</p>'],
+            'with BODY element containing Content-Type META tag'
+                => ['<head></head><body><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></body>'],
+            'with implicit body content with Content-Type META tag'
+                => ['<head></head><p>hello</p><meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
         ];
     }
 
@@ -465,7 +488,7 @@ final class AbstractHtmlProcessorTest extends TestCase
      *
      * @param string $html
      *
-     * @dataProvider contentWithHeadTagDataProvider
+     * @dataProvider provideContentWithHeadTag
      */
     public function notAddsSecondHeadTag(string $html): void
     {
@@ -659,8 +682,8 @@ final class AbstractHtmlProcessorTest extends TestCase
      *
      * @param string $html
      *
-     * @dataProvider contentWithoutHeadTagDataProvider
-     * @dataProvider contentWithHeadTagDataProvider
+     * @dataProvider provideContentWithoutHeadTag
+     * @dataProvider provideContentWithHeadTag
      */
     public function addsMissingContentTypeMetaTagOnlyOnce(string $html): void
     {
@@ -678,7 +701,33 @@ final class AbstractHtmlProcessorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function htmlAroundContentTypeDataProvider(): array
+    public function provideContentTypeMetaTag(): array
+    {
+        return [
+            'double-quoted attribute values' => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'single-quoted attribute values'
+                => ['<meta http-equiv=\'Content-Type\' content=\'text/html; charset=utf-8\'>'],
+            'unquoted attribute values' => ['<meta http-equiv=Content-Type content=text/html;charset=utf-8>'],
+            'reverse order attributes' => ['<meta content="text/html; charset=utf-8" http-equiv="Content-Type">'],
+            'without charset' => ['<meta http-equiv="Content-Type" content="text/html">'],
+            'XHTML' => ['<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8">'],
+            'tag with self-closing slash' => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>'],
+            'tag with extra whitespace' => ['<meta  http-equiv="Content-Type"  content="text/html ;  charset=utf-8" >'],
+            'tag with newlines' => ["<meta\nhttp-equiv='Content-Type'\ncontent='text/html\n;\ncharset=utf-8'\n>"],
+            'uppercase tag name' => ['<META http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'uppercase attribute names' => ['<meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">'],
+            'uppercase `Content-Type`' => ['<meta http-equiv="CONTENT-TYPE" content="text/html; charset=utf-8">'],
+            'lowercase `Content-Type`' => ['<meta http-equiv="content-type" content="text/html; charset=utf-8">'],
+            'uppercase MIME type' => ['<meta http-equiv="Content-Type" content="TEXT/HTML; charset=utf-8">'],
+            'uppercase `charset`' => ['<meta http-equiv="Content-Type" content="text/html; CHARSET=utf-8">'],
+            'uppercase `charset` value' => ['<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'],
+        ];
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideHtmlAroundContentType(): array
     {
         return [
             'HTML and HEAD element' => ['<html><head>', '</head></html>'],
@@ -691,21 +740,30 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
+     * @return string[][]
+     */
+    public function provideContentTypeTagAndSurroundingHtml(): array
+    {
+        return DataProviders::cross($this->provideContentTypeMetaTag(), $this->provideHtmlAroundContentType());
+    }
+
+    /**
      * @test
      *
+     * @param string $contentTypeTag
      * @param string $htmlBefore
      * @param string $htmlAfter
      *
-     * @dataProvider htmlAroundContentTypeDataProvider
+     * @dataProvider provideContentTypeTagAndSurroundingHtml
      */
-    public function notAddsSecondContentTypeMetaTag(string $htmlBefore, string $htmlAfter): void
+    public function notAddsSecondContentTypeMetaTag(string $contentTypeTag, string $htmlBefore, string $htmlAfter): void
     {
-        $html = $htmlBefore . '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $htmlAfter;
+        $html = $htmlBefore . $contentTypeTag . $htmlAfter;
         $subject = TestingHtmlProcessor::fromHtml($html);
 
         $result = $subject->render();
 
-        $numberOfContentTypeMetaTags = \substr_count($result, 'Content-Type');
+        $numberOfContentTypeMetaTags = \substr_count(\strtolower($result), 'content-type');
         self::assertSame(1, $numberOfContentTypeMetaTags);
     }
 


### PR DESCRIPTION
Use a regular expression to determine whether the provided HTML contains a
`Content-Type` `meta` element instead of just testing for the string
"Content-Type".  Also allow for case insensitivity.

A valid `Content-Type` `meta` element which is invalidly placed (i.e. within the
`body`) will still be determined to be valid.  This will be addressed separately
for #923.

Add the package `rawr/cross-data-providers` to the development dependencies.
This is useful to generate a matrix of combinations for test data providers.
There are a few existing instances where this could be used to replace code
effectively doing that, but which are not addressed in this commit.

Rename affected data provider methods from `xyzDataProvider` to `provideXyx`,
which is more succinct and a more commonly used nomenclature on other projects.

Fixes #957.