### PR TITLE
[BUGFIX] Check existing Content-Type is in <head>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Ignore `http-equiv` `Content-Type` in `<body>`
+  ([#961](https://github.com/MyIntervals/emogrifier/pull/961))
 - Allow "Content-Type" in content
   ([#959](https://github.com/MyIntervals/emogrifier/pull/959))
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -82,6 +82,10 @@
     </UnnecessaryVarAnnotation>
   </file>
   <file src="src/HtmlProcessor/AbstractHtmlProcessor.php">
+    <MixedArgument occurrences="2">
+      <code>static::HTML_COMMENT_PATTERN</code>
+      <code>static::HTML_TEMPLATE_ELEMENT_PATTERN</code>
+    </MixedArgument>
     <MixedOperand occurrences="7">
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::CONTENT_TYPE_META_TAG</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -82,13 +82,14 @@
     </UnnecessaryVarAnnotation>
   </file>
   <file src="src/HtmlProcessor/AbstractHtmlProcessor.php">
-    <MixedOperand occurrences="6">
+    <MixedOperand occurrences="7">
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::DEFAULT_DOCUMENT_TYPE</code>
       <code>static::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER</code>
       <code>static::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER</code>
+      <code>static::TAGNAME_ALLOWED_BEFORE_BODY_MATCHER</code>
     </MixedOperand>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -82,18 +82,13 @@
     </UnnecessaryVarAnnotation>
   </file>
   <file src="src/HtmlProcessor/AbstractHtmlProcessor.php">
-    <MixedArgument occurrences="2">
-      <code>static::HTML_COMMENT_PATTERN</code>
-      <code>static::HTML_TEMPLATE_ELEMENT_PATTERN</code>
-    </MixedArgument>
-    <MixedOperand occurrences="7">
+    <MixedOperand occurrences="6">
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::CONTENT_TYPE_META_TAG</code>
       <code>static::DEFAULT_DOCUMENT_TYPE</code>
       <code>static::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER</code>
       <code>static::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER</code>
-      <code>static::TAGNAME_ALLOWED_BEFORE_BODY_MATCHER</code>
     </MixedOperand>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -365,7 +365,7 @@ abstract class AbstractHtmlProcessor
     private function hasEndOfHeadElement(string $html): bool
     {
         $headEndTagMatchCount
-            = \preg_match('%<(?!' . static::TAGNAME_ALLOWED_BEFORE_BODY_MATCHER . '[\\s/>])\\w|</head>%i', $html);
+            = \preg_match('%<(?!' . self::TAGNAME_ALLOWED_BEFORE_BODY_MATCHER . '[\\s/>])\\w|</head>%i', $html);
         if (\is_int($headEndTagMatchCount) && $headEndTagMatchCount > 0) {
             // An exception to the implicit end of the `<head>` is any content within a `<template>` element, as well in
             // comments.  As an optimization, this is only checked for if a potential `<head>` end tag is found.
@@ -391,7 +391,7 @@ abstract class AbstractHtmlProcessor
      */
     private function removeHtmlComments(string $html): string
     {
-        $result = \preg_replace(static::HTML_COMMENT_PATTERN, '', $html);
+        $result = \preg_replace(self::HTML_COMMENT_PATTERN, '', $html);
         if (!\is_string($result)) {
             throw new \RuntimeException('Internal PCRE error', 1616521475);
         }
@@ -411,7 +411,7 @@ abstract class AbstractHtmlProcessor
      */
     private function removeHtmlTemplateElements(string $html): string
     {
-        $result = \preg_replace(static::HTML_TEMPLATE_ELEMENT_PATTERN, '', $html);
+        $result = \preg_replace(self::HTML_TEMPLATE_ELEMENT_PATTERN, '', $html);
         if (!\is_string($result)) {
             throw new \RuntimeException('Internal PCRE error', 1616519652);
         }

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -435,12 +435,19 @@ final class AbstractHtmlProcessorTest extends TestCase
             'body content only' => ['<p>Hello</p>'],
             'BODY element' => ['<body></body>'],
             'HEADER element' => ['<header></header>'],
-            'META element (implicit HEAD)' => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'http-equiv META element (implicit HEAD)'
+                => ['<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'],
+            'viewport META element (implicit HEAD)'
+                => ['<meta name="viewport" content="width=device-width, initial-scale=1.0">'],
             'META element with Content-Type as a value' => ['<meta name="description" content="Content-Type">'],
             'BODY element with Content-Type in text' => ['<body>Content-Type</body>'],
             'body content only with Content-Type in text' => ['<p>Content-Type</p>'],
             // broken: BODY element containing Content-Type META tag
             // broken: body content only with Content-Type META tag
+            'http-equiv META element within P (not allowed)'
+                => ['<p><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></p>'],
+            'viewport META element within P (allowed)'
+                => ['<p><meta name="viewport" content="width=device-width, initial-scale=1.0"></p>'],
         ];
     }
 
@@ -451,7 +458,7 @@ final class AbstractHtmlProcessorTest extends TestCase
      *
      * @dataProvider provideContentWithoutHeadTag
      */
-    public function addsMissingHeadTagOnlyOnce(string $html): void
+    public function addsMissingHeadTagExactlyOnce(string $html): void
     {
         $subject = TestingHtmlProcessor::fromHtml($html);
 


### PR DESCRIPTION
If a valid `Content-Type` `<meta>` element is present, DOM conversion will
create a `<head>` element for it even without an explicit `<head>` tag in the
HTML.

However, to be valid, it must not be in the `<body>` element.  As well as with
an explicit `<body>` start tag, the `<body>` element also begins whenever a
start tag for an element which cannot be in the `<head>` is encountered.  This
is now checked.

Fixes #923.