### PR TITLE
[TASK] Allow whitespace variations in CSS tests

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -37,13 +37,14 @@ abstract class CssConstraint extends Constraint
         |(^\\s++)                           # - whitespace at the very start, captured in group 3
         |(>)\\s*+                           # - `>` (e.g. closing a `<style>` element opening tag) with optional
                                             #   whitespace following, captured in group 4
+        |(\\s++)                            # - whitespace, captured in group 5
         |(?:                                # - Anything else is matched, though not captured.  This is required so that
             (?!                             #   any characters in the input string that happen to have a special meaning
                 \\s*+(?:                    #   in a regular expression can be escaped.  `.` would also work, but
                     [{};,]                  #   matching a longer sequence is more optimal (and `.*` would not work).
                     |\\:(?![^\\{\\}]*+\\{)  #
                 )                           #
-                |^\\s                       #
+                |\\s                        #
             )                               #
             [^>]                            #
         )++                                 #
@@ -52,7 +53,8 @@ abstract class CssConstraint extends Constraint
     /**
      * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
      * element added to the document, due to the way that certain parts are `trim`med.  Notably, whitespace either side
-     * of "{", "}", ";" and ",", or at the beginning of the CSS may be removed.
+     * of "{", "}", ";", "," and (within a declarations block) ":", or at the beginning of the CSS may be removed.
+     * Other whitespace may be varied where equivalent (though not added or removed).
      *
      * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
      * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
@@ -87,6 +89,8 @@ abstract class CssConstraint extends Constraint
             $regularExpressionEquivalent = '\\s*+';
         } elseif (($matches[4] ?? '') !== '') {
             $regularExpressionEquivalent = \preg_quote($matches[4], '/') . '\\s*+';
+        } elseif (($matches[5] ?? '') !== '') {
+            $regularExpressionEquivalent = '\\s++';
         } else {
             $regularExpressionEquivalent = \preg_quote($matches[0], '/');
         }

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -39,7 +39,7 @@ final class CssConstraintTest extends TestCase
     public function getCssNeedleRegularExpressionPatternNotEscapesNonSpecialCharacters(): void
     {
         $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
-            . "\r\n\t `¬\"£%&_;'@~,";
+            . '`¬"£%&_;\'@~,';
 
         $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
 
@@ -61,6 +61,7 @@ final class CssConstraintTest extends TestCase
             '"}" alone' => ['}', ''],
             '";" alone' => [';', ''],
             '"," alone' => [',', ''],
+            '":" alone' => [':', ''],
             '"{" with non-special character' => ['{', 'a'],
             '"{" with two non-special characters' => ['{', 'a0'],
             '"{" with special character' => ['{', '.'],
@@ -128,5 +129,33 @@ final class CssConstraintTest extends TestCase
         $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
 
         self::assertSame('/\\<style\\>\\s*+a/', $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideWhitespaceBetweenWords(): array
+    {
+        return [
+            'one space' => ['a b'],
+            'two spaces' => ['a  b'],
+            'linefeed' => ["a\nb"],
+            'Windows line ending' => ["a\r\nb"],
+            'tab' => ["a\tb"],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     *
+     * @dataProvider provideWhitespaceBetweenWords
+     */
+    public function getCssNeedleRegularExpressionPatternReplacesWhitespaceWithVariableWhitespace(string $needle): void
+    {
+        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
+
+        self::assertStringContainsString('a\\s++b', $result);
     }
 }

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -132,7 +132,7 @@ final class CssConstraintTest extends TestCase
     }
 
     /**
-     * @return string[][]
+     * @return array<string, array<string>>
      */
     public function provideWhitespaceBetweenWords(): array
     {

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -25,11 +25,12 @@ final class AssertCssTest extends TestCase
     public function needleFoundDataProvider(): array
     {
         $cssStrings = [
-            'unminified CSS' => 'html, body { color: green; }',
-            'minified CSS' => 'html,body{color:green}',
-            'CSS with extra spaces' => '  html  ,  body  {  color  :  green  ;  }  ',
-            'CSS with linefeeds' => "\nhtml\n,\nbody\n{\ncolor\n:\ngreen\n;\n}\n",
-            'CSS with Windows line endings' => "\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor\r\n:\r\ngreen\r\n;\r\n}\r\n",
+            'unminified CSS' => '@media screen { html, body { color: green; } }',
+            'minified CSS' => '@media screen{html,body{color:green}}',
+            'CSS with extra spaces' => '  @media  screen  {  html  ,  body  {  color  :  green  ;  }  }  ',
+            'CSS with linefeeds' => "\n@media\nscreen\n{\nhtml\n,\nbody\n{\ncolor\n:\ngreen\n;\n}\n}\n",
+            'CSS with Windows line endings'
+                => "\r\n@media\r\nscreen\r\n{\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor\r\n:\r\ngreen\r\n;\r\n}\r\n}\r\n",
         ];
 
         $datasets = [];
@@ -76,6 +77,19 @@ final class AssertCssTest extends TestCase
             'pseudo-class with descendant combinator does not match without' => [
                 'p :first-child { color: green; }',
                 'p:first-child { color: green; }',
+            ],
+            'missing required whitespace after at-rule identifier' => ['@media screen', '@mediascreen'],
+            'missing required whitespace in calc before addition operator' => [
+                'width: calc(1px + 50%);',
+                'width: calc(1px+ 50%);',
+            ],
+            'missing required whitespace in calc before subtraction operator' => [
+                'width: calc(50% - 1px);',
+                'width: calc(50%- 1px);',
+            ],
+            'missing required whitespace in calc after addition operator' => [
+                'width: calc(1px + 50%);',
+                'width: calc(1px +50%);',
             ],
         ];
     }


### PR DESCRIPTION
Would be needed to switch to an alternative CSS parser like
`sabberworm/php-css-parser` which may result in some whitespace variations -
see #544.

Also added a test missing from #953 and updated a DocBlock to reflect that
change.