### PR TITLE
[CLEANUP] Slim down redundant class comments

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -15,13 +15,6 @@ use Symfony\Component\CssSelector\Exception\ParseException;
  * For Emogrifier 3.0.0, this will be the successor to the \Pelago\Emogrifier class (which then will be deprecated).
  *
  * For more information, please see the README.md file.
- *
- * @author Cameron Brooks
- * @author Jaime Prado
- * @author Oliver Klee <github@oliverklee.de>
- * @author Roman Ožana <ozana@omdesign.cz>
- * @author Sander Kruger <s.kruger@invessel.com>
- * @author Zoli Szabó <zoli.szabo+github@gmail.com>
  */
 class CssInliner extends AbstractHtmlProcessor
 {

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -8,8 +8,6 @@ namespace Pelago\Emogrifier\HtmlProcessor;
  * Base class for HTML processor that e.g., can remove, add or modify nodes or attributes.
  *
  * The "vanilla" subclass is the HtmlNormalizer.
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 abstract class AbstractHtmlProcessor
 {

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -11,8 +11,6 @@ namespace Pelago\Emogrifier\HtmlProcessor;
  * It will only add attributes, but leaves the style attribute untouched.
  *
  * To trigger the conversion, call the convertCssToVisualAttributes method.
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 class CssToAttributeConverter extends AbstractHtmlProcessor
 {

--- a/src/HtmlProcessor/HtmlNormalizer.php
+++ b/src/HtmlProcessor/HtmlNormalizer.php
@@ -10,8 +10,6 @@ namespace Pelago\Emogrifier\HtmlProcessor;
  * - disentangle incorrectly nested tags
  * - add HEAD and BODY elements (if they are missing)
  * - reformat the HTML
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 class HtmlNormalizer extends AbstractHtmlProcessor
 {

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -9,9 +9,6 @@ use Pelago\Emogrifier\Utilities\ArrayIntersector;
 
 /**
  * This class can remove things from HTML.
- *
- * @author Oliver Klee <github@oliverklee.de>
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 class HtmlPruner extends AbstractHtmlProcessor
 {

--- a/src/Utilities/ArrayIntersector.php
+++ b/src/Utilities/ArrayIntersector.php
@@ -16,8 +16,6 @@ namespace Pelago\Emogrifier\Utilities;
  * This class takes care of the detail.
  *
  * @internal
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 class ArrayIntersector
 {

--- a/src/Utilities/CssConcatenator.php
+++ b/src/Utilities/CssConcatenator.php
@@ -36,8 +36,6 @@ namespace Pelago\Emogrifier\Utilities;
  * ` }
  *
  * @internal
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 class CssConcatenator
 {

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -15,8 +15,6 @@ use PHPUnit\Framework\Constraint\Constraint;
  * Since, then, this is a class, and PHPUnit's `Constraint` class may or may not have a constructor (it did prior to
  * 8.x, but does not since) which must be called if it exists, this class also provides an explicit constructor which
  * will invoke the parent's constructor if there is one.
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 abstract class CssConstraint extends Constraint
 {

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -9,8 +9,6 @@ namespace Pelago\Emogrifier\Tests\Support\Constraint;
  * whitespace differences.
  *
  * The CSS string passed in the constructor.
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 class StringContainsCss extends CssConstraint
 {

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -9,8 +9,6 @@ namespace Pelago\Emogrifier\Tests\Support\Constraint;
  * allowing for cosmetic whitespace differences.
  *
  * The CSS string and expected number of occurrences are passed in the constructor.
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 class StringContainsCssCount extends CssConstraint
 {

--- a/tests/Support/Traits/AssertCss.php
+++ b/tests/Support/Traits/AssertCss.php
@@ -9,8 +9,6 @@ use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCssCount;
 
 /**
  * Provides assertion methods for use with CSS content where whitespace may vary.
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 trait AssertCss
 {

--- a/tests/Support/Traits/TestStringConstraint.php
+++ b/tests/Support/Traits/TestStringConstraint.php
@@ -8,8 +8,6 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 /**
  * Adds common tests to a test case for a `Constraint` which is expected to only evaluate against strings.
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 trait TestStringConstraint
 {

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -12,12 +12,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\CssInliner
- *
- * @author Oliver Klee <github@oliverklee.de>
- * @author Zoli Szabó <zoli.szabo+github@gmail.com>
  */
 final class CssInlinerTest extends TestCase
 {

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -10,11 +10,7 @@ use PHPUnit\Framework\TestCase;
 use TRegx\DataProvider\DataProviders;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 final class AbstractHtmlProcessorTest extends TestCase
 {

--- a/tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php
+++ b/tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php
@@ -9,11 +9,7 @@ use Pelago\Emogrifier\HtmlProcessor\CssToAttributeConverter;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\HtmlProcessor\CssToAttributeConverter
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 final class CssToAttributeConverterTest extends TestCase
 {

--- a/tests/Unit/HtmlProcessor/Fixtures/TestingHtmlProcessor.php
+++ b/tests/Unit/HtmlProcessor/Fixtures/TestingHtmlProcessor.php
@@ -8,8 +8,6 @@ use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 
 /**
  * Fixture class for AbstractHtmlProcessor.
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 final class TestingHtmlProcessor extends AbstractHtmlProcessor
 {

--- a/tests/Unit/HtmlProcessor/HtmlNormalizerTest.php
+++ b/tests/Unit/HtmlProcessor/HtmlNormalizerTest.php
@@ -9,11 +9,7 @@ use Pelago\Emogrifier\HtmlProcessor\HtmlNormalizer;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\HtmlProcessor\HtmlNormalizer
- *
- * @author Oliver Klee <github@oliverklee.de>
  */
 final class HtmlNormalizerTest extends TestCase
 {

--- a/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
+++ b/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
@@ -11,12 +11,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\HtmlProcessor\HtmlPruner
- *
- * @author Oliver Klee <github@oliverklee.de>
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class HtmlPrunerTest extends TestCase
 {

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -8,11 +8,7 @@ use Pelago\Emogrifier\Tests\Unit\Support\Constraint\Fixtures\TestingCssConstrain
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class CssConstraintTest extends TestCase
 {

--- a/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
+++ b/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
@@ -8,8 +8,6 @@ use Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint;
 
 /**
  * Extends the `CssConstraint` class to provide indirect access to protected method(s) for testing.
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 abstract class TestingCssConstraint extends CssConstraint
 {

--- a/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
@@ -10,14 +10,10 @@ use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * Note that the majority of the functionality is tested indirectly via
  * {@see \Pelago\Emogrifier\Tests\Unit\Support\Traits\AssertCssTest}; those tests are not repeated here.
  *
  * @covers \Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class StringContainsCssCountTest extends TestCase
 {

--- a/tests/Unit/Support/Constraint/StringContainsCssTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssTest.php
@@ -10,14 +10,10 @@ use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * Note that the majority of the functionality is tested indirectly via
  * {@see \Pelago\Emogrifier\Tests\Unit\Support\Traits\AssertCssTest}; those tests are not repeated here.
  *
  * @covers \Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class StringContainsCssTest extends TestCase
 {

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -9,11 +9,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\Tests\Support\Traits\AssertCss
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class AssertCssTest extends TestCase
 {

--- a/tests/Unit/Utilities/ArrayIntersectorTest.php
+++ b/tests/Unit/Utilities/ArrayIntersectorTest.php
@@ -8,11 +8,7 @@ use Pelago\Emogrifier\Utilities\ArrayIntersector;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\Utilities\ArrayIntersector
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class ArrayIntersectorTest extends TestCase
 {

--- a/tests/Unit/Utilities/CssConcatenatorTest.php
+++ b/tests/Unit/Utilities/CssConcatenatorTest.php
@@ -8,11 +8,7 @@ use Pelago\Emogrifier\Utilities\CssConcatenator;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test case.
- *
  * @covers \Pelago\Emogrifier\Utilities\CssConcatenator
- *
- * @author Jake Hotson <jake.github@qzdesign.co.uk>
  */
 final class CssConcatenatorTest extends TestCase
 {


### PR DESCRIPTION
- Drop `@author` annotation as the Git history already has this
  information.
- Drop the `Test case.` comments from test cases as their purpose
  already is implicit by their namespace.