### PR TITLE
[TASK] Stop using Slevomat PHPCS rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "rawr/cross-data-providers": "^2.3.0",
-        "slevomat/coding-standard": "^6.4.1",
         "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -81,26 +81,6 @@
 
     <!-- Functions -->
     <rule ref="Generic.Functions.CallTimePassByReference"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-        <!-- Allow PHPDoc with no additional information -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
-    <!--
-        The following rule makes only sense if we require PHP >= 7.4.
-        Otherwise, running the code sniffer on PHP 7.4 would suggest changes
-        that are not viable while we still support PHP 7.3
-        (because this rule checks which PHP version it is running on).
-        <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
-    -->
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-        <!-- Allow PHPDoc with no additional information -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
     <rule ref="Squiz.Functions.GlobalFunction"/>
 


### PR DESCRIPTION
This allows us to use the PHAR version of PHP_CodeSniffer, getting us
one step further from dependency hell.