### PR TITLE
[TASK] Drop support for Symfony 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Support for PHP 7.2 will be removed in Emogrifier 7.0.
 
 ### Removed
+- Drop support for Symfony 5.1
+  ([#972](https://github.com/MyIntervals/emogrifier/pull/972))
 - Drop support for PHP 7.1
   ([#967](https://github.com/MyIntervals/emogrifier/pull/967))
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "symfony/css-selector": "^3.4.32 || ^4.4 || ^5.1"
+        "symfony/css-selector": "^3.4.32 || ^4.4 || ^5.2"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",


### PR DESCRIPTION
Symfony 5.1 has reached its end of life.

We still support all Symfony versions that still are maintained,
i.e., 3.4, 4.4 and 5.2.