### PR TITLE
[TASK] Test more edge cases for Content-Type

### DIFF
--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -777,6 +777,10 @@ final class AbstractHtmlProcessorTest extends TestCase
             'HTML and HEAD element' => ['<html><head>', '</head></html>'],
             'HTML and HEAD element, HTML end tag omitted' => ['<html><head>', '</head>'],
             'HEAD element only' => ['<head>', '</head>'],
+            'HEAD element with space after start tag' => ['<head> ', '</head>'],
+            'HEAD element with line feed after start tag' => ["<head>\n", '</head>'],
+            'HEAD element with Windows line ending after start tag' => ["<head>\r\n", '</head>'],
+            'HEAD element with TAB after start tag' => ["<head>\t", '</head>'],
             'HEAD element with attribute' => ['<head lang="en">', '</head>'],
             'HTML, HEAD, and BODY with HEADER elements'
                 => ['<html><head>', '</head><body><header></header></body></html>'],
@@ -797,6 +801,10 @@ final class AbstractHtmlProcessorTest extends TestCase
             'HEAD element with uppercase TEMPLATE element'
                 => ['<head><TEMPLATE id="test"><p>Test</p></TEMPLATE></title>', '</head>'],
             'HEAD element with uppercase TITLE element' => ['<head><TITLE>Test</TITLE>', '</head>'],
+            'Second valid(ish) Content-Type in BODY' => [
+                '<head>',
+                '</head><body><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></body>',
+            ],
         ];
     }
 
@@ -822,9 +830,10 @@ final class AbstractHtmlProcessorTest extends TestCase
         $html = $htmlBefore . $contentTypeTag . $htmlAfter;
         $subject = TestingHtmlProcessor::fromHtml($html);
 
-        $result = $subject->render();
+        $domDocument = $subject->getDomDocument();
+        $resultHeadContent = $domDocument->saveHTML($domDocument->getElementsByTagName('head')->item(0));
 
-        $numberOfContentTypeMetaTags = \substr_count(\strtolower($result), 'content-type');
+        $numberOfContentTypeMetaTags = \substr_count(\strtolower($resultHeadContent), 'content-type');
         self::assertSame(1, $numberOfContentTypeMetaTags);
     }
 


### PR DESCRIPTION
During review for #961, a regex change to capture the HTML before the
`Content-Type` tag drew attention to a couple of edge cases that weren't
explicitly tested for and would fail if there was a mistake in the regex
pattern:
- A newline before the `Content-Type` tag (would fail without the
  `PCRE_DOTALL`/`s` modifier - while caught by another test,
  `getDomDocumentWithNormalizedHtmlRepresentsTheGivenHtml`, that test was not
  specifically intended for this purpose);
- A `Content-Type` tag in both the `<head>` and `<body>` (would fail without the
  lazy/`?` quantifier after `.*`).

Tests have now been added to cover these.