### PR TITLE
[BUGFIX] Allow line feeds within <html> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.1 (#967)
 
 ### Fixed
+- Allow line feeds within `<html>` tag (#987)
 
 ## 5.0.1
 

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -310,7 +310,7 @@ abstract class AbstractHtmlProcessor
             );
         } elseif ($hasHtmlTag) {
             $reworkedHtml = \preg_replace(
-                '/<html(.*?)>/i',
+                '/<html(.*?)>/is',
                 '<html$1><head>' . self::CONTENT_TYPE_META_TAG . '</head>',
                 $html
             );


### PR DESCRIPTION
Also add tests to confirm that the `<html>` tag's attributes are preserved, and
a duplicate `<html>` tag does not arise.

Resolves #981.