### PR TITLE
[CLEANUP] Always use anonymous functions for callables

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -7,7 +7,8 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;matchingUninlinableCssRules === null</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="3">
+      <code>$cssRule</code>
       <code>$cssRule</code>
     </InvalidArgument>
     <InvalidOperand occurrences="1">
@@ -16,12 +17,8 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$excludedNodes</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="1">
-      <code>$m[0]</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$attributeName</code>
-      <code>\usort($cssRules['inlinable'], [$this, 'sortBySelectorPrecedence'])</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="4">
       <code>$this-&gt;caches[self::CACHE_KEY_COMBINED_STYLES][$cacheKey]</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@">
   <file src="src/CssInliner.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion occurrences="2">
       <code>$node</code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
@@ -17,7 +17,7 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>$excludedNodes</code>
     </LessSpecificReturnStatement>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$attributeName</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="4">

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -696,8 +696,8 @@ class CssInliner extends AbstractHtmlProcessor
         \usort(
             $cssRules['inlinable'],
             /**
-             * @param array<string, string> $a
-             * @param array<string, string> $b
+             * @param array{selector: string, line: int} $a
+             * @param array{selector: string, line: int} $b
              */
             function (array $a, array $b): int {
                 return $this->sortBySelectorPrecedence($a, $b);
@@ -757,8 +757,8 @@ class CssInliner extends AbstractHtmlProcessor
     }
 
     /**
-     * @param array<string, string> $a
-     * @param array<string, string> $b
+     * @param array{selector: string, line: int} $a
+     * @param array{selector: string, line: int} $b
      *
      * @return int
      */


### PR DESCRIPTION
This makes it possible to have type declarations and annotations,
both helping static code analysis as well as making the code easier
to understand.

Also make the type annotations of the methods called from the
anonymous functions more specific.