### PR TITLE
[CLEANUP] Remove workaround for PHPUnit 7

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -95,14 +95,4 @@ abstract class CssConstraint extends Constraint
 
         return $regularExpressionEquivalent;
     }
-
-    /**
-     * Invokes the parent class's constructor if there is one.
-     */
-    public function __construct()
-    {
-        if (\is_callable('parent::__construct')) {
-            parent::__construct();
-        }
-    }
 }

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -22,8 +22,6 @@ final class StringContainsCss extends CssConstraint
      */
     public function __construct(string $css)
     {
-        parent::__construct();
-
         $this->css = $css;
     }
 

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -28,8 +28,6 @@ final class StringContainsCssCount extends CssConstraint
      */
     public function __construct(int $count, string $css)
     {
-        parent::__construct();
-
         $this->count = $count;
         $this->css = $css;
     }


### PR DESCRIPTION
PHPUnit's `Constraint` class now does not have a constructor anymore,
and hence we do not need to call it anymore in the constructors of
classes inheriting from `Constraint`.