### PR TITLE
[FEATURE] Set align attribute for <th> elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Set `align` attribute of `<th>` elements with `CssToAttributeConverter` (#1008)
 
 ### Changed
 - Also check the unit test code with Psalm (#1003)

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -28,7 +28,7 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
         ],
         'text-align' => [
             'attribute' => 'align',
-            'nodes' => ['p', 'div', 'td'],
+            'nodes' => ['p', 'div', 'td', 'th'],
             'values' => ['left', 'right', 'center', 'justify'],
         ],
         'float' => [

--- a/tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php
+++ b/tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php
@@ -84,6 +84,10 @@ final class CssToAttributeConverterTest extends TestCase
                 '<table><tr><td style="text-align: left;">hi</td></tr></table>',
                 'align="left',
             ],
+            'th.text-align => align' => [
+                '<table><tr><th style="text-align: left;">hi</th></tr></table>',
+                'align="left',
+            ],
             'text-align: left => align=left' => ['<p style="text-align: left;">hi</p>', 'align="left"'],
             'text-align: right => align=right' => ['<p style="text-align: right;">hi</p>', 'align="right"'],
             'text-align: center => align=center' => ['<p style="text-align: center;">hi</p>', 'align="center"'],


### PR DESCRIPTION
Since this is set for `<td>` elements, it makes sense to also set it for `<th>`
elements, as both represent table cells.  Although these attributes are
obsolete, there may still be some legacy email clients (e.g. older versions of
Outlook) that need it.