### PR TITLE
[TASK] Pin PHPUnit to version 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
-        "phpunit/phpunit": "^8.5.15 || ^9.5.4",
+        "phpunit/phpunit": "^8.5.15",
         "rawr/cross-data-providers": "^2.3.0"
     },
     "config": {


### PR DESCRIPTION
This avoid warnings about using PHPUnit features that deprecated in
PHPUnit 9.