### PR TITLE
[CLEANUP] Remove a redundant CSS data cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 - Drop support for Symfony 5.1 (#972)
 - Drop support for PHP 7.1 (#967)
+- Remove a redundant CSS data cache (#1018)
 
 ### Fixed
 - Allow line feeds within `<html>` tag (#987)

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -21,7 +21,7 @@
       <code>$nodePath</code>
       <code>$path</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType occurrences="3">
       <code>int</code>
       <code>string</code>
       <code>string[]</code>
@@ -32,9 +32,8 @@
     <MixedPropertyTypeCoercion occurrences="1">
       <code>$this-&gt;styleAttributesForNodes</code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="4">
+    <MixedReturnStatement occurrences="3">
       <code>$this-&gt;caches[self::CACHE_KEY_COMBINED_STYLES][$cacheKey]</code>
-      <code>$this-&gt;caches[self::CACHE_KEY_CSS][$cssKey]</code>
       <code>$this-&gt;caches[self::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock]</code>
       <code>$this-&gt;caches[self::CACHE_KEY_SELECTOR][$selectorKey]</code>
     </MixedReturnStatement>

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -17,22 +17,17 @@ class CssInliner extends AbstractHtmlProcessor
     /**
      * @var int
      */
-    private const CACHE_KEY_CSS = 0;
+    private const CACHE_KEY_SELECTOR = 0;
 
     /**
      * @var int
      */
-    private const CACHE_KEY_SELECTOR = 1;
+    private const CACHE_KEY_CSS_DECLARATIONS_BLOCK = 1;
 
     /**
      * @var int
      */
-    private const CACHE_KEY_CSS_DECLARATIONS_BLOCK = 2;
-
-    /**
-     * @var int
-     */
-    private const CACHE_KEY_COMBINED_STYLES = 3;
+    private const CACHE_KEY_COMBINED_STYLES = 2;
 
     /**
      * This regular expression pattern will match any uninlinable at-rule with nested statements, along with any
@@ -86,7 +81,6 @@ class CssInliner extends AbstractHtmlProcessor
      * @var array<int, array<string, mixed>>
      */
     private $caches = [
-        self::CACHE_KEY_CSS => [],
         self::CACHE_KEY_SELECTOR => [],
         self::CACHE_KEY_CSS_DECLARATIONS_BLOCK => [],
         self::CACHE_KEY_COMBINED_STYLES => [],
@@ -361,7 +355,6 @@ class CssInliner extends AbstractHtmlProcessor
     private function clearAllCaches(): void
     {
         $this->caches = [
-            self::CACHE_KEY_CSS => [],
             self::CACHE_KEY_SELECTOR => [],
             self::CACHE_KEY_CSS_DECLARATIONS_BLOCK => [],
             self::CACHE_KEY_COMBINED_STYLES => [],
@@ -675,11 +668,6 @@ class CssInliner extends AbstractHtmlProcessor
      */
     private function parseCssRules(string $css): array
     {
-        $cssKey = \md5($css);
-        if (isset($this->caches[self::CACHE_KEY_CSS][$cssKey])) {
-            return $this->caches[self::CACHE_KEY_CSS][$cssKey];
-        }
-
         $matches = $this->getCssRuleMatches($css);
 
         $cssRules = [
@@ -721,8 +709,6 @@ class CssInliner extends AbstractHtmlProcessor
                 return $this->sortBySelectorPrecedence($a, $b);
             }
         );
-
-        $this->caches[self::CACHE_KEY_CSS][$cssKey] = $cssRules;
 
         return $cssRules;
     }


### PR DESCRIPTION
The cache with the key `CACHE_KEY_CSS` was storing all of the parsed CSS data
as a single entry, but would only ever be set once and never accessed.  It does
not make sense to call `inlineCss` again on the same document with the same CSS,
but in any case this method clears all caches as its first action.

This will reduce the memory footprint after `inlineCss` returns.