### PR TITLE
[FEATURE] Composer scripts for Psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "composer:normalize": "@php \"./.phive/composer-normalize\"",
         "php:fix": "@php \"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix config/ src/ tests/",
         "php:version": "@php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
-        "psalm:baseline": "@php \"./.phive/psalm\" --update-baseline",
+        "psalm:baseline": "@php \"./.phive/psalm\" --set-baseline=psalm.baseline.xml",
         "psalm:cc": "@php \"./.phive/psalm\" --clear-cache"
     },
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,9 @@
         "ci:tests:unit": "@php \"./vendor/bin/phpunit\"",
         "composer:normalize": "@php \"./.phive/composer-normalize\"",
         "php:fix": "@php \"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix config/ src/ tests/",
-        "php:version": "@php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'"
+        "php:version": "@php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
+        "psalm:baseline": "@php \"./.phive/psalm\" --update-baseline",
+        "psalm:cc": "@php \"./.phive/psalm\" --clear-cache"
     },
     "support": {
         "issues": "https://github.com/MyIntervals/emogrifier/issues",

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -9,7 +9,6 @@
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
       <code>$cssRule</code>
-      <code>$cssRule</code>
     </InvalidArgument>
     <InvalidOperand occurrences="1">
       <code>$matcher</code>


### PR DESCRIPTION
These save having to remember the command line arguments and/or type a more
intricate command:
- `composer psalm:baseline`: Update the `psalm.baseline.xml` to remove any issues
  that have been fixed;
- `composer psalm:cc`: Clear Psalm's cache for the project; sometimes this may
  be required to resolve spurious errors that might arise after switching
  between branches in the same directory.