### PR TITLE
[CLEANUP] Add newline in DocBlock before long descriptions

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -518,10 +518,11 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $css CSS with comments removed
      *
-     * @return string[] The first element is the CSS with the valid `@import` and `@charset` rules removed.  The second
-     *         element contains a concatenation of the valid `@import` rules, each followed by whatever whitespace
-     *         followed it in the original CSS (so that either unminified or minified formatting is preserved); if there
-     *         were no `@import` rules, it will be an empty string.  The (valid) `@charset` rules are discarded.
+     * @return string[]
+     *         The first element is the CSS with the valid `@import` and `@charset` rules removed.  The second element
+     *         contains a concatenation of the valid `@import` rules, each followed by whatever whitespace followed it
+     *         in the original CSS (so that either unminified or minified formatting is preserved); if there were no
+     *         `@import` rules, it will be an empty string.  The (valid) `@charset` rules are discarded.
      */
     private function extractImportAndCharsetRules(string $css): array
     {
@@ -555,10 +556,10 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $css CSS with comments, import and charset removed
      *
-     * @return string[] The first element is the CSS with the at-rules removed.  The second element contains a
-     *                  concatenation of the valid at-rules, each followed by whatever whitespace followed it in the
-     *                  original CSS (so that either unminified or minified formatting is preserved); if there were no
-     *                  at-rules, it will be an empty string.
+     * @return string[]
+     *         The first element is the CSS with the at-rules removed.  The second element contains a concatenation of
+     *         the valid at-rules, each followed by whatever whitespace followed it in the original CSS (so that either
+     *         unminified or minified formatting is preserved); if there were no at-rules, it will be an empty string.
      */
     private function extractUninlinableCssAtRules(string $css): array
     {
@@ -1161,8 +1162,9 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $selector
      *
-     * @return string Selector which will match the relevant DOM elements if the pseudo-classes are assumed to apply,
-     *                or in the case of pseudo-elements will match their originating element.
+     * @return string
+     *         selector which will match the relevant DOM elements if the pseudo-classes are assumed to apply, or in the
+     *         case of pseudo-elements will match their originating element
      */
     private function removeUnmatchablePseudoComponents(string $selector): string
     {
@@ -1209,8 +1211,9 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param array<int, string> $matches array of elements matched by the regular expression
      *
-     * @return string the full match if there were no unmatchable pseudo components within; otherwise, any preceding
-     *         combinator followed by "*", or an empty string if there was no preceding combinator
+     * @return string
+     *         the full match if there were no unmatchable pseudo components within; otherwise, any preceding combinator
+     *         followed by "*", or an empty string if there was no preceding combinator
      */
     private function replaceUnmatchableNotComponent(array $matches): string
     {
@@ -1228,8 +1231,9 @@ class CssInliner extends AbstractHtmlProcessor
      * @param string $matcher regular expression part to match the components to remove
      * @param string $selector
      *
-     * @return string selector which will match the relevant DOM elements if the removed components are assumed to apply
-     *         (or in the case of pseudo-elements will match their originating element)
+     * @return string
+     *         selector which will match the relevant DOM elements if the removed components are assumed to apply (or in
+     *         the case of pseudo-elements will match their originating element)
      */
     private function removeSelectorComponents(string $matcher, string $selector): string
     {
@@ -1246,8 +1250,8 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @param string $selectorPart part of a selector which has been split up at combinators
      *
-     * @return string selector part which will match the relevant DOM elements if the pseudo-classes are assumed to
-     *         apply
+     * @return string
+     *         selector part which will match the relevant DOM elements if the pseudo-classes are assumed to apply
      */
     private function removeUnsupportedOfTypePseudoClasses(string $selectorPart): string
     {
@@ -1265,10 +1269,11 @@ class CssInliner extends AbstractHtmlProcessor
      * Applies `$this->matchingUninlinableCssRules` to `$this->domDocument` by placing them as CSS in a `<style>`
      * element.
      *
-     * @param string $uninlinableCss This may contain any `@import` or `@font-face` rules that should precede the CSS
-     *        placed in the `<style>` element.  If there are no unlinlinable CSS rules to copy there, a `<style>`
-     *        element will be created containing just `$uninlinableCss`.  `$uninlinableCss` may be an empty string;
-     *        if it is, and there are no unlinlinable CSS rules, an empty `<style>` element will not be created.
+     * @param string $uninlinableCss
+     *        This may contain any `@import` or `@font-face` rules that should precede the CSS placed in the `<style>`
+     *        element.  If there are no unlinlinable CSS rules to copy there, a `<style>` element will be created
+     *        containing just `$uninlinableCss`.  `$uninlinableCss` may be an empty string; if it is, and there are no
+     *        unlinlinable CSS rules, an empty `<style>` element will not be created.
      */
     private function copyUninlinableCssToStyleNode(string $uninlinableCss): void
     {

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -279,13 +279,13 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
     }
 
     /**
-     * Parses a shorthand CSS value and splits it into individual values
+     * Parses a shorthand CSS value and splits it into individual values.  For example: `padding: 0 auto;` - `0 auto` is
+     * split into top: 0, left: auto, bottom: 0, right: auto.
      *
-     * @param string $value a string of CSS value with 1, 2, 3 or 4 sizes
-     *        For example: padding: 0 auto; '0 auto' is split into top: 0, left: auto, bottom: 0, right: auto.
+     * @param string $value a CSS property value with 1, 2, 3 or 4 sizes
      *
-     * @return array<string, string> an array of values for top, right, bottom and left
-     *         (using these as associative array keys)
+     * @return array<string, string>
+     *         an array of values for top, right, bottom and left (using these as associative array keys)
      */
     private function parseCssShorthandValue(string $value): array
     {

--- a/src/Utilities/CssConcatenator.php
+++ b/src/Utilities/CssConcatenator.php
@@ -62,10 +62,12 @@ class CssConcatenator
     /**
      * Appends a declaration block to the CSS.
      *
-     * @param array<array-key, string> $selectors Array of selectors for the rule, e.g. ["ul", "ol", "p:first-child"].
-     * @param string $declarationsBlock The property declarations, e.g. "margin-top: 0.5em; padding: 0".
-     * @param string $media The media query for the rule, e.g. "@media screen and (max-width:639px)",
-     *        or an empty string if none.
+     * @param array<array-key, string> $selectors
+     *        array of selectors for the rule, e.g. ["ul", "ol", "p:first-child"]
+     * @param string $declarationsBlock
+     *        the property declarations, e.g. "margin-top: 0.5em; padding: 0"
+     * @param string $media
+     *        the media query for the rule, e.g. "@media screen and (max-width:639px)", or an empty string if none
      */
     public function append(array $selectors, string $declarationsBlock, string $media = ''): void
     {
@@ -105,12 +107,12 @@ class CssConcatenator
      *        or an empty string if none.
      *
      * @return object{
-     *   media: string,
-     *   ruleBlocks: array<int, object{
-     *     selectorsAsKeys: array<string, array-key>,
-     *     declarationsBlock: string
-     *   }>
-     * }
+     *           media: string,
+     *           ruleBlocks: array<int, object{
+     *             selectorsAsKeys: array<string, array-key>,
+     *             declarationsBlock: string
+     *           }>
+     *         }
      */
     private function getOrCreateMediaRuleToAppendTo(string $media): object
     {
@@ -130,8 +132,8 @@ class CssConcatenator
     /**
      * Tests if two sets of selectors are equivalent (i.e. the same selectors, possibly in a different order).
      *
-     * @param array<string, array-key> $selectorsAsKeys1 array in which the selectors are the keys, and the values are
-     *        of no significance
+     * @param array<string, array-key> $selectorsAsKeys1
+     *        array in which the selectors are the keys, and the values are of no significance
      * @param array<string, array-key> $selectorsAsKeys2 another such array
      *
      * @return bool


### PR DESCRIPTION
This will allow for changing the parameter or return value type (or parameter
name) with a clean commit, without having to reformat the description for 120
character line-lengths.

Also
- Align multiline `@param` and `@return` bodies with the first line (i.e. so
  that each subsequent line of description (or in some cases, type) is at the
  position after the space following the at-tag;
- Remove 'sentence' capitalization and full stop from some descriptions which
  are not sentences;
- Move part of a parameter description for `parseCssShorthandValue` to the
  method description where it belongs;
- Use backticks around parts of descriptions which are clearly code.