### PR TITLE
[CLEANUP] Ignore warnings about unset properties in the tests

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -8,10 +8,6 @@
     <PossiblyNullReference occurrences="1">
       <code>removeChild</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>CssInlinerTest</code>
-      <code>CssInlinerTest</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php">
     <LessSpecificReturnStatement occurrences="1">
@@ -24,25 +20,9 @@
     <MoreSpecificReturnType occurrences="1">
       <code>array{0:string, 1:string, 2:string}</code>
     </MoreSpecificReturnType>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>AbstractHtmlProcessorTest</code>
-      <code>AbstractHtmlProcessorTest</code>
-    </PropertyNotSetInConstructor>
     <UnnecessaryVarAnnotation occurrences="1">
       <code>\DOMElement</code>
     </UnnecessaryVarAnnotation>
-  </file>
-  <file src="tests/Unit/HtmlProcessor/CssToAttributeConverterTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>CssToAttributeConverterTest</code>
-      <code>CssToAttributeConverterTest</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/HtmlProcessor/HtmlNormalizerTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>HtmlNormalizerTest</code>
-      <code>HtmlNormalizerTest</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Unit/HtmlProcessor/HtmlPrunerTest.php">
     <InvalidReturnStatement occurrences="7"/>
@@ -55,51 +35,8 @@
       <code>array&lt;string, array{0:string, 1:string[]}&gt;</code>
       <code>array&lt;string, array{0:string, 1:string[]}&gt;</code>
     </InvalidReturnType>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>HtmlPrunerTest</code>
-      <code>HtmlPrunerTest</code>
-    </PropertyNotSetInConstructor>
     <UnnecessaryVarAnnotation occurrences="1">
       <code>string</code>
     </UnnecessaryVarAnnotation>
-  </file>
-  <file src="tests/Unit/Support/Constraint/CssConstraintTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>CssConstraintTest</code>
-      <code>CssConstraintTest</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/Support/Constraint/StringContainsCssCountTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>StringContainsCssCountTest</code>
-      <code>StringContainsCssCountTest</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/Support/Constraint/StringContainsCssTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>StringContainsCssTest</code>
-      <code>StringContainsCssTest</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/Support/Traits/AssertCssTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>AssertCssTest</code>
-      <code>AssertCssTest</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/Utilities/ArrayIntersectorTest.php">
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>ArrayIntersectorTest</code>
-      <code>ArrayIntersectorTest</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/Utilities/CssConcatenatorTest.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>CssConcatenatorTest</code>
-      <code>CssConcatenatorTest</code>
-    </PropertyNotSetInConstructor>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,7 +10,15 @@
     errorBaseline="psalm.baseline.xml"
 >
     <projectFiles>
-        <directory name="src" />
-        <directory name="tests" />
+        <directory name="src"/>
+        <directory name="tests"/>
     </projectFiles>
+
+    <issueHandlers>
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <directory name="tests"/>
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+    </issueHandlers>
 </psalm>

--- a/tests/Unit/Utilities/CssConcatenatorTest.php
+++ b/tests/Unit/Utilities/CssConcatenatorTest.php
@@ -15,7 +15,7 @@ final class CssConcatenatorTest extends TestCase
     /**
      * @var CssConcatenator
      */
-    private $subject = null;
+    private $subject;
 
     /**
      * Setup.


### PR DESCRIPTION
Psalm is not aware that `setUp` always is called before any
test method in the tests.