### PR TITLE
[BUGFIX] Add missing semicolon in CSS test data

### DIFF
--- a/tests/Unit/Utilities/CssDocumentTest.php
+++ b/tests/Unit/Utilities/CssDocumentTest.php
@@ -16,7 +16,7 @@ final class CssDocumentTest extends TestCase
      * @var string
      */
     private const VALID_AT_FONT_FACE_RULE = '@font-face {' . "\n"
-        . '  font-family: "Foo Sans"' . "\n"
+        . '  font-family: "Foo Sans";' . "\n"
         . '  src: url("/foo-sans.woff2") format("woff2");' . "\n}";
 
     /**


### PR DESCRIPTION
The `@font-face` rule used for testing CSS parsing was missing a semicolon
between its properties.

Emogrifier currently passes on most of these types of at-rules unmodified,
without checking their validity too much.  Other CSS parsers might not be so
generous.