### PR TITLE
[CLEANUP] Move CSS Constraint tests to their TestCase

### DIFF
--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Support\Traits;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\DataProvider\DataProviders;
+
+/**
+ * Adds common data providers to a test case for a `Constraint` which matches CSS.
+ *
+ * @mixin TestCase
+ */
+trait CssDataProviders
+{
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function provideEquivalentCss(): array
+    {
+        $cssStrings = [
+            'unminified CSS' => ['@media screen { html, body { color: green; } }'],
+            'minified CSS' => ['@media screen{html,body{color:green}}'],
+            'CSS with extra spaces' => ['  @media  screen  {  html  ,  body  {  color  :  green  ;  }  }  '],
+            'CSS with linefeeds' => ["\n@media\nscreen\n{\nhtml\n,\nbody\n{\ncolor\n:\ngreen\n;\n}\n}\n"],
+            'CSS with Windows line endings'
+                => ["\r\n@media\r\nscreen\r\n{\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor\r\n:\r\ngreen\r\n;\r\n}\r\n}\r\n"],
+        ];
+
+        /** @var array<string, array{0: string, 1: string}> $datasets */
+        $datasets = DataProviders::cross($cssStrings, $cssStrings);
+
+        return $datasets;
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function provideEquivalentCssInStyleTags(): array
+    {
+        $datasetsWithoutStyleTags = $this->provideEquivalentCss();
+
+        $datasetsWithRenamedKeys = \array_combine(
+            \array_map(
+                static function (string $description): string {
+                    return $description . ' in <style> tag';
+                },
+                \array_keys($datasetsWithoutStyleTags)
+            ),
+            \array_values($datasetsWithoutStyleTags)
+        );
+
+        /** @var array<string, array{0: string, 1: string}> $datasets */
+        $datasets = \array_map(
+            static function (array $dataset): array {
+                return \array_map(
+                    static function (string $css): string {
+                        return '<style>' . $css . '</style>';
+                    },
+                    $dataset
+                );
+            },
+            $datasetsWithRenamedKeys
+        );
+
+        return $datasets;
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function provideCssNeedleFoundInLargerHaystack()
+    {
+        return [
+            'needle at start of haystack' => ['p { color: green; }', 'p { color: green; } a { color: blue; }'],
+            'needle at end of haystack' => ['p { color: green; }', 'body { font-size: 16px; } p { color: green; }'],
+            'needle in middle of haystack' => [
+                'p { color: green; }',
+                'body { font-size: 16px; } p { color: green; } a { color: blue; }',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function provideCssNeedleNotFoundInHaystack(): array
+    {
+        return [
+            'CSS part with "{" not in CSS' => ['p {', 'body { color: green; }'],
+            'CSS part with "}" not in CSS' => ['color: red; }', 'body { color: green; }'],
+            'CSS part with "," not in CSS' => ['html, body', 'body { color: green; }'],
+            'missing `;` after declaration where not optional' => [
+                'body { color: green; font-size: 15px; }',
+                "body { color: green\nfont-size: 15px; }",
+            ],
+            'extra `;` after declaration' => ['body { color: green; }', 'body { color: green;; }'],
+            'spurious `;` after rule in at-rule' => [
+                '@media print { body { color: green; } }',
+                '@media print { body { color: green; }; }',
+            ],
+            'invalid space after `:` for pseudo-class' => [
+                'p:first-child { color: green; }',
+                'p: first-child { color: green; }',
+            ],
+            'pseudo-class without descendant combinator does not match with' => [
+                'p:first-child { color: green; }',
+                'p :first-child { color: green; }',
+            ],
+            'pseudo-class with descendant combinator does not match without' => [
+                'p :first-child { color: green; }',
+                'p:first-child { color: green; }',
+            ],
+            'missing required whitespace after at-rule identifier' => ['@media screen', '@mediascreen'],
+            'missing required whitespace in calc before addition operator' => [
+                'width: calc(1px + 50%);',
+                'width: calc(1px+ 50%);',
+            ],
+            'missing required whitespace in calc before subtraction operator' => [
+                'width: calc(50% - 1px);',
+                'width: calc(50%- 1px);',
+            ],
+            'missing required whitespace in calc after addition operator' => [
+                'width: calc(1px + 50%);',
+                'width: calc(1px +50%);',
+            ],
+            'more CSS than haystack' => ['p { color: green; } h1 { color: red; }', 'p { color: green; }'],
+        ];
+    }
+}

--- a/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
@@ -5,19 +5,164 @@ declare(strict_types=1);
 namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint;
 
 use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCssCount;
+use Pelago\Emogrifier\Tests\Support\Traits\CssDataProviders;
 use Pelago\Emogrifier\Tests\Support\Traits\TestStringConstraint;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Note that the majority of the functionality is tested indirectly via
- * {@see \Pelago\Emogrifier\Tests\Unit\Support\Traits\AssertCssTest}; those tests are not repeated here.
- *
  * @covers \Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss
  */
 final class StringContainsCssCountTest extends TestCase
 {
+    use CssDataProviders;
     use TestStringConstraint;
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideCssNeedleNotFoundInHaystack
+     */
+    public function matchesHaystackNotContainingNeedleWithZeroCount(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(0, $needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideEquivalentCss
+     * @dataProvider provideEquivalentCssInStyleTags
+     * @dataProvider provideCssNeedleFoundInLargerHaystack
+     */
+    public function notMatchesHaystackContainingNeedleWithZeroCount(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(0, $needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideEquivalentCss
+     * @dataProvider provideEquivalentCssInStyleTags
+     * @dataProvider provideCssNeedleFoundInLargerHaystack
+     */
+    public function matchesHaystackContainingExactlyOneNeedleWithCountOfOne(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(1, $needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideCssNeedleNotFoundInHaystack
+     */
+    public function notMatchesHaystackNotContainingNeedleWithCountOfOne(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(1, $needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideEquivalentCss
+     * @dataProvider provideEquivalentCssInStyleTags
+     * @dataProvider provideCssNeedleFoundInLargerHaystack
+     */
+    public function notMatchesHaystackContainingNeedleTwiceWithCountOfOne(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(1, $needle);
+
+        $result = $subject->evaluate($haystack . $haystack, '', true);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideEquivalentCss
+     * @dataProvider provideEquivalentCssInStyleTags
+     * @dataProvider provideCssNeedleFoundInLargerHaystack
+     */
+    public function matchesHaystackContainingNeedleTwiceWithCountOfTwo(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(2, $needle);
+
+        $result = $subject->evaluate($haystack . $haystack, '', true);
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideCssNeedleNotFoundInHaystack
+     */
+    public function notMatchesHaystackNotContainingNeedleWithCountOfTwo(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(2, $needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideEquivalentCss
+     * @dataProvider provideEquivalentCssInStyleTags
+     * @dataProvider provideCssNeedleFoundInLargerHaystack
+     */
+    public function notMatchesHaystackContainingExactlyOneNeedleWithCountOfTwo(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCssCount(2, $needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertFalse($result);
+    }
 
     /**
      * @return Constraint

--- a/tests/Unit/Support/Constraint/StringContainsCssTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssTest.php
@@ -5,19 +5,54 @@ declare(strict_types=1);
 namespace Pelago\Emogrifier\Tests\Unit\Support\Constraint;
 
 use Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss;
+use Pelago\Emogrifier\Tests\Support\Traits\CssDataProviders;
 use Pelago\Emogrifier\Tests\Support\Traits\TestStringConstraint;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Note that the majority of the functionality is tested indirectly via
- * {@see \Pelago\Emogrifier\Tests\Unit\Support\Traits\AssertCssTest}; those tests are not repeated here.
- *
  * @covers \Pelago\Emogrifier\Tests\Support\Constraint\StringContainsCss
  */
 final class StringContainsCssTest extends TestCase
 {
+    use CssDataProviders;
     use TestStringConstraint;
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideEquivalentCss
+     * @dataProvider provideEquivalentCssInStyleTags
+     * @dataProvider provideCssNeedleFoundInLargerHaystack
+     */
+    public function matchesHaystackContainingNeedle(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCss($needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @dataProvider provideCssNeedleNotFoundInHaystack
+     */
+    public function notMatchesHaystackNotContainingNeedle(string $needle, string $haystack): void
+    {
+        $subject = new StringContainsCss($needle);
+
+        $result = $subject->evaluate($haystack, '', true);
+
+        self::assertFalse($result);
+    }
 
     /**
      * @return Constraint

--- a/tests/Unit/Support/Traits/AssertCssTest.php
+++ b/tests/Unit/Support/Traits/AssertCssTest.php
@@ -16,255 +16,112 @@ final class AssertCssTest extends TestCase
     use AssertCss;
 
     /**
-     * @return string[][]
+     * @test
      */
-    public function needleFoundDataProvider(): array
+    public function assertContainsCssPassesTestIfNeedleFound(): void
     {
-        $cssStrings = [
-            'unminified CSS' => '@media screen { html, body { color: green; } }',
-            'minified CSS' => '@media screen{html,body{color:green}}',
-            'CSS with extra spaces' => '  @media  screen  {  html  ,  body  {  color  :  green  ;  }  }  ',
-            'CSS with linefeeds' => "\n@media\nscreen\n{\nhtml\n,\nbody\n{\ncolor\n:\ngreen\n;\n}\n}\n",
-            'CSS with Windows line endings'
-                => "\r\n@media\r\nscreen\r\n{\r\nhtml\r\n,\r\nbody\r\n{\r\ncolor\r\n:\r\ngreen\r\n;\r\n}\r\n}\r\n",
-        ];
-
-        $datasets = [];
-        foreach ($cssStrings as $needleDescription => $needle) {
-            foreach ($cssStrings as $haystackDescription => $haystack) {
-                $description = $needleDescription . ' in ' . $haystackDescription;
-                $datasets[$description] = [$needle, $haystack];
-                $datasets[$description . ' in <style> tag'] = [
-                    '<style>' . $needle . '</style>',
-                    '<style>' . $haystack . '</style>',
-                ];
-            }
-        }
-
-        return $datasets;
-    }
-
-    /**
-     * @return string[][]
-     */
-    public function needleNotFoundDataProvider(): array
-    {
-        return [
-            'CSS part with "{" not in CSS' => ['p {', 'body { color: green; }'],
-            'CSS part with "}" not in CSS' => ['color: red; }', 'body { color: green; }'],
-            'CSS part with "," not in CSS' => ['html, body', 'body { color: green; }'],
-            'missing `;` after declaration where not optional' => [
-                'body { color: green; font-size: 15px; }',
-                "body { color: green\nfont-size: 15px; }",
-            ],
-            'extra `;` after declaration' => ['body { color: green; }', 'body { color: green;; }'],
-            'spurious `;` after rule in at-rule' => [
-                '@media print { body { color: green; } }',
-                '@media print { body { color: green; }; }',
-            ],
-            'invalid space after `:` for pseudo-class' => [
-                'p:first-child { color: green; }',
-                'p: first-child { color: green; }',
-            ],
-            'pseudo-class without descendant combinator does not match with' => [
-                'p:first-child { color: green; }',
-                'p :first-child { color: green; }',
-            ],
-            'pseudo-class with descendant combinator does not match without' => [
-                'p :first-child { color: green; }',
-                'p:first-child { color: green; }',
-            ],
-            'missing required whitespace after at-rule identifier' => ['@media screen', '@mediascreen'],
-            'missing required whitespace in calc before addition operator' => [
-                'width: calc(1px + 50%);',
-                'width: calc(1px+ 50%);',
-            ],
-            'missing required whitespace in calc before subtraction operator' => [
-                'width: calc(50% - 1px);',
-                'width: calc(50%- 1px);',
-            ],
-            'missing required whitespace in calc after addition operator' => [
-                'width: calc(1px + 50%);',
-                'width: calc(1px +50%);',
-            ],
-        ];
+        self::assertContainsCss('a', 'a');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
      */
-    public function assertContainsCssPassesTestIfNeedleFound(string $needle, string $haystack): void
-    {
-        self::assertContainsCss($needle, $haystack);
-    }
-
-    /**
-     * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleNotFoundDataProvider
-     */
-    public function assertContainsCssFailsTestIfNeedleNotFound(string $needle, string $haystack): void
+    public function assertContainsCssFailsTestIfNeedleNotFound(): void
     {
         $this->expectException(ExpectationFailedException::class);
 
-        self::assertContainsCss($needle, $haystack);
+        self::assertContainsCss('a', 'b');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleNotFoundDataProvider
      */
-    public function assertNotContainsCssPassesTestIfNeedleNotFound(string $needle, string $haystack): void
+    public function assertNotContainsCssPassesTestIfNeedleNotFound(): void
     {
-        self::assertNotContainsCss($needle, $haystack);
+        self::assertNotContainsCss('a', 'b');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
      */
-    public function assertNotContainsCssFailsTestIfNeedleFound(string $needle, string $haystack): void
+    public function assertNotContainsCssFailsTestIfNeedleFound(): void
     {
         $this->expectException(ExpectationFailedException::class);
 
-        self::assertNotContainsCss($needle, $haystack);
+        self::assertNotContainsCss('a', 'a');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleNotFoundDataProvider
      */
-    public function assertContainsCssCountPassesTestExpectingZeroIfNeedleNotFound(
-        string $needle,
-        string $haystack
-    ): void {
-        self::assertContainsCssCount(0, $needle, $haystack);
+    public function assertContainsCssCountPassesTestExpectingZeroIfNeedleNotFound(): void
+    {
+        self::assertContainsCssCount(0, 'a', 'b');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
      */
-    public function assertContainsCssCountFailsTestExpectingZeroIfNeedleFound(string $needle, string $haystack): void
+    public function assertContainsCssCountFailsTestExpectingZeroIfNeedleFound(): void
     {
         $this->expectException(ExpectationFailedException::class);
 
-        self::assertContainsCssCount(0, $needle, $haystack);
+        self::assertContainsCssCount(0, 'a', 'a');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
      */
-    public function assertContainsCssCountPassesTestExpectingOneIfNeedleFound(string $needle, string $haystack): void
+    public function assertContainsCssCountPassesTestExpectingOneIfNeedleFound(): void
     {
-        self::assertContainsCssCount(1, $needle, $haystack);
+        self::assertContainsCssCount(1, 'a', 'a');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleNotFoundDataProvider
      */
-    public function assertContainsCssCountFailsTestExpectingOneIfNeedleNotFound(string $needle, string $haystack): void
+    public function assertContainsCssCountFailsTestExpectingOneIfNeedleNotFound(): void
     {
         $this->expectException(ExpectationFailedException::class);
 
-        self::assertContainsCssCount(1, $needle, $haystack);
+        self::assertContainsCssCount(1, 'a', 'b');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
      */
-    public function assertContainsCssCountFailsTestExpectingOneIfNeedleFoundTwice(
-        string $needle,
-        string $haystack
-    ): void {
-        $this->expectException(ExpectationFailedException::class);
-
-        self::assertContainsCssCount(1, $needle, $haystack . $haystack);
-    }
-
-    /**
-     * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
-     */
-    public function assertContainsCssCountPassesTestExpectingTwoIfNeedleFoundTwice(
-        string $needle,
-        string $haystack
-    ): void {
-        self::assertContainsCssCount(2, $needle, $haystack . $haystack);
-    }
-
-    /**
-     * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleNotFoundDataProvider
-     */
-    public function assertContainsCssCountFailsTestExpectingTwoIfNeedleNotFound(string $needle, string $haystack): void
+    public function assertContainsCssCountFailsTestExpectingOneIfNeedleFoundTwice(): void
     {
         $this->expectException(ExpectationFailedException::class);
 
-        self::assertContainsCssCount(2, $needle, $haystack);
+        self::assertContainsCssCount(1, 'a', 'a a');
     }
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @dataProvider needleFoundDataProvider
      */
-    public function assertContainsCssCountFailsTestExpectingTwoIfNeedleFoundOnlyOnce(
-        string $needle,
-        string $haystack
-    ): void {
+    public function assertContainsCssCountPassesTestExpectingTwoIfNeedleFoundTwice(): void
+    {
+        self::assertContainsCssCount(2, 'a', 'a a');
+    }
+
+    /**
+     * @test
+     */
+    public function assertContainsCssCountFailsTestExpectingTwoIfNeedleNotFound(): void
+    {
         $this->expectException(ExpectationFailedException::class);
 
-        self::assertContainsCssCount(2, $needle, $haystack);
+        self::assertContainsCssCount(2, 'a', 'b');
+    }
+
+    /**
+     * @test
+     */
+    public function assertContainsCssCountFailsTestExpectingTwoIfNeedleFoundOnlyOnce(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        self::assertContainsCssCount(2, 'a', 'a');
     }
 }


### PR DESCRIPTION
This means these `TestCase`s now cover their corresponding classes (as declared
by `@covers`) and not also dependant classes, which have their own `TestCase`s
now fully covering their functionality.

Also added CSS datasets for a needle found in a larger haystack, and a needle
only partially found in a haystack.