### PR TITLE
[TASK] getCssRegularExpression without delimiters

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -49,35 +49,35 @@ abstract class CssConstraint extends Constraint
     /x';
 
     /**
-     * Processing of @media rules may involve removal of some unnecessary whitespace from the CSS placed in the <style>
-     * element added to the document, due to the way that certain parts are `trim`med.  Notably, whitespace either side
-     * of "{", "}", ";", "," and (within a declarations block) ":", or at the beginning of the CSS may be removed.
-     * Other whitespace may be varied where equivalent (though not added or removed).
+     * Emogrification may result in CSS or `style` property values that do not exactly match the input CSS but are
+     * nonetheless equivalent.
      *
-     * This method helps takes care of that, by converting a search needle for an exact match into a regular expression
-     * that allows for such whitespace removal, so that the tests themselves do not need to be written less humanly
-     * readable and can use inputs containing extra whitespace.
+     * Notably, whitespace either side of "{", "}", ";", "," and (within a declarations block) ":", or at the beginning
+     * of the CSS may be removed.  Other whitespace may be varied where equivalent (though not added or removed).
      *
-     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
+     * This method helps takes care of that, by converting a CSS string into a regular expression part that will match
+     * the equivalent CSS whilst allowing for such whitespace variation.  Thus, such nuances can be abstracted away from
+     * the main tests, also allowing their test data to be written more humanly-readable with additional whitespace.
      *
-     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
+     * @param string $css
+     *
+     * @return string Slashes (`/`) should be used as deliminters in the pattern composed using this.
      */
-    protected static function getCssNeedleRegularExpressionPattern(string $needle): string
+    protected static function getCssRegularExpressionMatcher(string $css): string
     {
-        $needleMatcher = \preg_replace_callback(
+        return \preg_replace_callback(
             self::CSS_REGULAR_EXPRESSION_PATTERN,
-            [self::class, 'getCssNeedleRegularExpressionReplacement'],
-            $needle
+            [self::class, 'getCssRegularExpressionReplacement'],
+            $css
         );
-        return '/' . $needleMatcher . '/';
     }
 
     /**
-     * @param string[] $matches array of matches for {@see CSS_REGEX_PATTERN}
+     * @param string[] $matches array of matches for {@see CSS_REGULAR_EXPRESSION_PATTERN}
      *
      * @return string replacement string, which may be `$matches[0]` if no alteration is needed
      */
-    private static function getCssNeedleRegularExpressionReplacement(array $matches): string
+    private static function getCssRegularExpressionReplacement(array $matches): string
     {
         if (($matches[1] ?? '') !== '') {
             $regularExpressionEquivalent = '(?:\\s*+;)?+\\s*+' . \preg_quote($matches[1], '/') . '\\s*+';

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -18,6 +18,11 @@ final class StringContainsCss extends CssConstraint
     private $css;
 
     /**
+     * @var string
+     */
+    private $cssPattern;
+
+    /**
      * @param string $css
      */
     public function __construct(string $css)
@@ -25,6 +30,7 @@ final class StringContainsCss extends CssConstraint
         parent::__construct();
 
         $this->css = $css;
+        $this->cssPattern = '/' . self::getCssRegularExpressionMatcher($css) . '/';
     }
 
     /**
@@ -48,6 +54,6 @@ final class StringContainsCss extends CssConstraint
             return false;
         }
 
-        return \preg_match(self::getCssNeedleRegularExpressionPattern($this->css), $other) > 0;
+        return \preg_match($this->cssPattern, $other) > 0;
     }
 }

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -23,6 +23,11 @@ final class StringContainsCssCount extends CssConstraint
     private $css;
 
     /**
+     * @var string
+     */
+    private $cssPattern;
+
+    /**
      * @param int $count
      * @param string $css
      */
@@ -32,6 +37,7 @@ final class StringContainsCssCount extends CssConstraint
 
         $this->count = $count;
         $this->css = $css;
+        $this->cssPattern = '/' . self::getCssRegularExpressionMatcher($css) . '/';
     }
 
     /**
@@ -55,6 +61,6 @@ final class StringContainsCssCount extends CssConstraint
             return false;
         }
 
-        return \preg_match_all(self::getCssNeedleRegularExpressionPattern($this->css), $other) === $this->count;
+        return \preg_match_all($this->cssPattern, $other) === $this->count;
     }
 }

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -15,16 +15,16 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      */
-    public function getCssNeedleRegularExpressionPatternEscapesAllSpecialCharacters(): void
+    public function getCssRegularExpressionMatcherEscapesAllSpecialCharacters(): void
     {
-        $needle = '.\\+*?[^]$(){}=!<>|:-/';
+        $css = '.\\+*?[^]$(){}=!<>|:-/';
 
-        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
+        $result = TestingCssConstraint::getCssRegularExpressionMatcherForTesting($css);
 
         $resultWithOtherMatchersRemoved = \str_replace(['(?:\\s*+;)?+', '\\s*+'], '', $result);
 
         self::assertSame(
-            '/' . \preg_quote($needle, '/') . '/',
+            \preg_quote($css, '/'),
             $resultWithOtherMatchersRemoved
         );
     }
@@ -32,19 +32,15 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      */
-    public function getCssNeedleRegularExpressionPatternNotEscapesNonSpecialCharacters(): void
+    public function getCssRegularExpressionMatcherNotEscapesNonSpecialCharacters(): void
     {
-        $needle = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 ')))
-            . '`¬"£%&_;\'@~,';
+        $css = \implode('', \array_merge(\range('a', 'z'), \range('A', 'Z'), \range('0 ', '9 '))) . '`¬"£%&_;\'@~,';
 
-        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
+        $result = TestingCssConstraint::getCssRegularExpressionMatcherForTesting($css);
 
         $resultWithWhitespaceMatchersRemoved = \str_replace('\\s*+', '', $result);
 
-        self::assertSame(
-            '/' . $needle . '/',
-            $resultWithWhitespaceMatchersRemoved
-        );
+        self::assertSame($css, $resultWithWhitespaceMatchersRemoved);
     }
 
     /**
@@ -74,11 +70,11 @@ final class CssConstraintTest extends TestCase
      *
      * @dataProvider contentWithOptionalWhitespaceDataProvider
      */
-    public function getCssNeedleRegularExpressionPatternInsertsOptionalWhitespace(
+    public function getCssRegularExpressionMatcherInsertsOptionalWhitespace(
         string $contentToInsertAround,
         string $otherContent
     ): void {
-        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting(
+        $result = TestingCssConstraint::getCssRegularExpressionMatcherForTesting(
             $otherContent . $contentToInsertAround . $otherContent
         );
 
@@ -92,11 +88,11 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      */
-    public function getCssNeedleRegularExpressionPatternReplacesWhitespaceAtStartWithOptionalWhitespace(): void
+    public function getCssRegularExpressionMatcherReplacesWhitespaceAtStartWithOptionalWhitespace(): void
     {
-        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting(' a');
+        $result = TestingCssConstraint::getCssRegularExpressionMatcherForTesting(' a');
 
-        self::assertSame('/\\s*+a/', $result);
+        self::assertSame('\\s*+a', $result);
     }
 
     /**
@@ -116,15 +112,15 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
+     * @param string $css
      *
      * @dataProvider styleTagDataProvider
      */
-    public function getCssNeedleRegularExpressionPatternInsertsOptionalWhitespaceAfterStyleTag(string $needle): void
+    public function getCssRegularExpressionMatcherInsertsOptionalWhitespaceAfterStyleTag(string $css): void
     {
-        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
+        $result = TestingCssConstraint::getCssRegularExpressionMatcherForTesting($css);
 
-        self::assertSame('/\\<style\\>\\s*+a/', $result);
+        self::assertSame('\\<style\\>\\s*+a', $result);
     }
 
     /**
@@ -144,14 +140,14 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
+     * @param string $css
      *
      * @dataProvider provideWhitespaceBetweenWords
      */
-    public function getCssNeedleRegularExpressionPatternReplacesWhitespaceWithVariableWhitespace(string $needle): void
+    public function getCssRegularExpressionMatcherReplacesWhitespaceWithVariableWhitespace(string $css): void
     {
-        $result = TestingCssConstraint::getCssNeedleRegularExpressionPatternForTesting($needle);
+        $result = TestingCssConstraint::getCssRegularExpressionMatcherForTesting($css);
 
-        self::assertStringContainsString('a\\s++b', $result);
+        self::assertSame('a\\s++b', $result);
     }
 }

--- a/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
+++ b/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
@@ -12,14 +12,14 @@ use Pelago\Emogrifier\Tests\Support\Constraint\CssConstraint;
 abstract class TestingCssConstraint extends CssConstraint
 {
     /**
-     * Chains on to `getCssNeedleRegularExpressionPattern` for testing the protected method.
+     * Chains on to {@see getCssRegularExpressionMatcher} for testing the protected method.
      *
-     * @param string $needle Needle that would be used with `assertContains` or `assertNotContains`.
+     * @param string $css
      *
-     * @return string Needle to use with `assertRegExp` or `assertNotRegExp` instead.
+     * @return string
      */
-    public static function getCssNeedleRegularExpressionPatternForTesting(string $needle): string
+    public static function getCssRegularExpressionMatcherForTesting(string $css): string
     {
-        return self::getCssNeedleRegularExpressionPattern($needle);
+        return self::getCssRegularExpressionMatcher($css);
     }
 }


### PR DESCRIPTION
This will allow the method, correspondingly renamed from
`getCssNeedleRegularExpressionPattern` to `getCssRegularExpressionMatcher`, to
be used more flexibly, not necessarily for finding needles in haystacks.  It
also allows slight simplifications and tightening-up of its tests.

Update the DocBlock for the method to reflect this change and previous changes.

Also now compute the regular expression version of the CSS in the `Constraint`
constructors - this will be more efficient if the `Constraint` is re-used.