### PR TITLE
[CLEANUP] Move CssConstraint DocBlock info re c'tor there

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -11,10 +11,6 @@ use PHPUnit\Framework\Constraint\Constraint;
  *
  * Due to {@link https://bugs.php.net/bug.php?id=75060 PHP 'bug' #75060}, traits cannot have constants, so, as a
  * workaround, this is currently implemented as a base class (but ideally would be a `trait`).
- *
- * Since, then, this is a class, and PHPUnit's `Constraint` class may or may not have a constructor (it did prior to
- * 8.x, but does not since) which must be called if it exists, this class also provides an explicit constructor which
- * will invoke the parent's constructor if there is one.
  */
 abstract class CssConstraint extends Constraint
 {
@@ -97,9 +93,18 @@ abstract class CssConstraint extends Constraint
     }
 
     /**
-     * Invokes the parent class's constructor if there is one.
+     * Invokes the parent class's constructor if there is one.  Since PHPUnit 8.x, `Constraint` (the parent class) does
+     * not have a defined constructor.  But...
+     *
+     * In PHP, a class that may be extended should have a defined constructor, even if it does nothing.
+     *
+     * That way, a child class that needs a constructor can explicitly call its parent's constructor.  If it could not,
+     * and then a newer version of the parent class needed a constructor, the newly added constructor would not be
+     * invoked implicitly during instantiation of the child class.  In that eventuality, the child class would also need
+     * updating, so there would be a compatibility issue, and potential for uncaught bugs if the child class's
+     * constructor was not updated.
      */
-    public function __construct()
+    protected function __construct()
     {
         if (\is_callable('parent::__construct')) {
             parent::__construct();


### PR DESCRIPTION
Remove the information about the constructor for `CssConstraint` from the
DocBlock for the class, and add it to that for the constructor where it belongs.

Also further explain why the constructor is retained (see #1002).

Also change constructor visibility to `protected` (for good measure) - the class
is not intended to be instantiated in itself (and is `abstract` anyway).