### PR TITLE
[CLEANUP] Add type hint for function instead of variable

### DIFF
--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -51,8 +51,12 @@ trait CssDataProviders
             \array_values($datasetsWithoutStyleTags)
         );
 
-        /** @var array<string, array{0: string, 1: string}> $datasets */
         $datasets = \array_map(
+            /**
+             * @param array{0: string, 1: string} $dataset
+             *
+             * @return array{0: string, 1: string}
+             */
             static function (array $dataset): array {
                 return \array_map(
                     static function (string $css): string {


### PR DESCRIPTION
This avoids overriding the static analysis - the type hint for a function forms
part of the 'contract'.