### PR TITLE
[CLEANUP] Assert invalid at-rule not found

### DIFF
--- a/tests/Unit/Utilities/CssDocumentTest.php
+++ b/tests/Unit/Utilities/CssDocumentTest.php
@@ -434,13 +434,9 @@ final class CssDocumentTest extends TestCase
 
         $result = $subject->renderNonConditionalAtRules();
 
-        self::assertThat(
-            \trim($result),
-            self::logicalOr(
-                self::identicalTo(''),
-                self::identicalTo(\trim($cssBefore))
-            )
-        );
+        \preg_match('/@[\\w\\-]++/', $atRuleCss, $atAndRuleNameMatches);
+        $atAndRuleName = $atAndRuleNameMatches[0];
+        self::assertStringNotContainsString($atAndRuleName, $result);
     }
 
     /**


### PR DESCRIPTION
Instead of asserting that the resultant CSS matches the valid CSS, assert that
it does not contain the invalid at-rule, by simply checking that `@` followed by
the rule name (of the invalid rule) is not found.  This avoids having to cater
for variations in the rendering of the valid CSS.