### PR TITLE
[TASK] Always run the CI jobs for all supported PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - 7.2
@@ -94,6 +95,7 @@ jobs:
     needs: [php-lint, composer-validate]
 
     strategy:
+      fail-fast: false
       matrix:
         command:
           - fixer
@@ -136,6 +138,7 @@ jobs:
     needs: [php-lint, composer-validate]
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - 7.2


### PR DESCRIPTION
This makes sure that we know exactly which PHP versions are affected
by change that has broken something.