### PR TITLE
[TASK] Allow case insensitivity in CSS RGB values

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -32,6 +32,8 @@ abstract class CssConstraint extends Constraint
         |(>)\\s*+                           # - `>` (e.g. closing a `<style>` element opening tag) with optional
                                             #   whitespace following, captured in group 4
         |(\\s++)                            # - whitespace, captured in group 5
+        |(\\#[0-9A-Fa-f]++\\b)              # - RGB colour property value, captured in group 6, if in a declarations
+            (?![^\\{\\}]*+\\{)              #   block (i.e. not followed later by `{` without a closing `}` first)
         |(?:                                # - Anything else is matched, though not captured.  This is required so that
             (?!                             #   any characters in the input string that happen to have a special meaning
                 \\s*+(?:                    #   in a regular expression can be escaped.  `.` would also work, but
@@ -39,6 +41,8 @@ abstract class CssConstraint extends Constraint
                     |\\:(?![^\\{\\}]*+\\{)  #
                 )                           #
                 |\\s                        #
+                |(\\#[0-9A-Fa-f]++\\b)      #
+                    (?![^\\{\\}]*+\\{)      #
             )                               #
             [^>]                            #
         )++                                 #
@@ -136,6 +140,8 @@ abstract class CssConstraint extends Constraint
             $regularExpressionEquivalent = \preg_quote($matches[4], '/') . '\\s*+';
         } elseif (($matches[5] ?? '') !== '') {
             $regularExpressionEquivalent = '\\s++';
+        } elseif (($matches[6] ?? '') !== '') {
+            $regularExpressionEquivalent = '(?i:' . \preg_quote($matches[6], '/') . ')';
         } else {
             $regularExpressionEquivalent = \preg_quote($matches[0], '/');
         }

--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -91,7 +91,18 @@ trait CssDataProviders
             $equivalentCssPropertyDeclarations
         );
 
-        return $datasetsWithPropertyDelcaration;
+        $equivalentPropertyDeclarationsWithRgbValue = [
+            'property declaration with lowercase RGB value' => ['color: #0f0;'],
+            'property declaration with uppercase RGB value' => ['color: #0F0;'],
+        ];
+
+        /** @var array<string, array{0: string, 1: string}> $datasetsWithPropertyDelcarationWithRgbValue */
+        $datasetsWithPropertyDelcarationWithRgbValue = DataProviders::cross(
+            $equivalentPropertyDeclarationsWithRgbValue,
+            $equivalentPropertyDeclarationsWithRgbValue
+        );
+
+        return $datasetsWithPropertyDelcaration + $datasetsWithPropertyDelcarationWithRgbValue;
     }
 
     /**
@@ -181,6 +192,9 @@ trait CssDataProviders
                 'p :first-child { color: green; }',
                 'p:first-child { color: green; }',
             ],
+            'class does not match if uppercase' => ['.a { color: red; }', '.A { color: red; }'],
+            'ID does not match if uppercase' => ['#a { color: red; }', '#A { color: red; }'],
+            '`font-family` does not match if uppercase' => ['font-family: a;', 'font-family: A;'],
             'missing required whitespace after at-rule identifier' => ['@media screen', '@mediascreen'],
             'missing required whitespace in calc before addition operator' => [
                 'width: calc(1px + 50%);',

--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -102,7 +102,22 @@ trait CssDataProviders
             $equivalentPropertyDeclarationsWithRgbValue
         );
 
-        return $datasetsWithPropertyDelcaration + $datasetsWithPropertyDelcarationWithRgbValue;
+        $equivalentPropertyDeclarationsWithSixDigitRgbValue = [
+            'property declaration with lowercase 6-digit RGB value' => ['color: #abcdef;'],
+            'property declaration with uppercase 6-digit RGB value' => ['color: #ABCDEF;'],
+        ];
+
+        /** @var array<string, array{0: string, 1: string}> $datasetsWithPropertyDelcarationWithSixDigitRgbValue */
+        $datasetsWithPropertyDelcarationWithSixDigitRgbValue = DataProviders::cross(
+            $equivalentPropertyDeclarationsWithSixDigitRgbValue,
+            $equivalentPropertyDeclarationsWithSixDigitRgbValue
+        );
+
+        return \array_merge(
+            $datasetsWithPropertyDelcaration,
+            $datasetsWithPropertyDelcarationWithRgbValue,
+            $datasetsWithPropertyDelcarationWithSixDigitRgbValue
+        );
     }
 
     /**


### PR DESCRIPTION
When testing for matching CSS, allow RGB values in CSS property declarations to
be upper or lower case.