### PR TITLE
[TASK] Remove irrelevant trailing zeros from test data

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -65,8 +65,8 @@ final class CssInlinerTest extends TestCase
         '@-webkit-keyframes' => '
             @-webkit-keyframes bounceIn {
               from, 20%, 40%, 60%, 80%, to {
-                -webkit-animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
-                animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+                -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+                animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
               }
               0% {
                 opacity: 0;
@@ -100,7 +100,7 @@ final class CssInlinerTest extends TestCase
         '@keyframes' => '
             @keyframes bounceIn {
               from, 20%, 40%, 60%, 80%, to {
-                animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+                animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
               }
               0% {
                 opacity: 0;


### PR DESCRIPTION
Remove trailing zeros from decimal numbers in CSS test data that are unrelated
to the specifics of whether numerical equivalence is maintained.  CSS parsing
may result in such numbers being re-rendered more efficiently (i.e. `1.30`
becomes `1.3` and `1.0` becomes `1`).  The changed test data is not concerned
with this; it is for confirming uninlineable at-rules as a whole are passed on
roughly equivalently.