### PR TITLE
[TASK] Allow length unit to be lower-cased in tests

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1499,7 +1499,13 @@ final class CssInlinerTest extends TestCase
 
         $subject->inlineCss('html {mArGiN:0 2pX;}');
 
-        self::assertStringContainsString('style="margin: 0 2pX;"', $subject->render());
+        self::assertThat(
+            $subject->render(),
+            self::logicalOr(
+                self::stringContains('style="margin: 0 2pX;"'),
+                self::stringContains('style="margin: 0 2px;"')
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
When testing CSS property names are converted to lowercase, allowance can be
made for length units also being converted to lowercase, since they are not case
sensitive.  Some CSS parsers may re-render them as lowercase, which is fine.