### PR TITLE
[TASK] Allow single or double quotes in CSS

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -52,8 +52,13 @@ abstract class CssConstraint extends Constraint
             ([^\'"\\(\\)\\s]++)             #   quotes, parentheses or whitespace
             \\g{-2}                         #
             \\s*+\\)                        #
+        |(?<=[\\s:])                        # - singly or doubly quoted string, surrounded by whitespace or delimiters
+            ([\'"])                         #   of a property value (i.e. a colon is allowed before, and a semicolon or
+            ([^\'"]*+)                      #   closing curly brace is allowed after), with the quote captured in group
+            \\g{-2}                         #   13 and the string in group 14
+            (?=[\\s;\\}])                   #
         |(?<!\\w)0?+(\\.)(?=\\d)            # - start of decimal number less than 1 - optional `0` then decimal point
-                                            #   (captured in group 13), provided followed by a digit
+                                            #   (captured in group 15), provided followed by a digit
         |(?:                                # - Anything else is matched, though not captured.  This is required so that
             (?!                             #   any characters in the input string that happen to have a special meaning
                 \\s*+(?:                    #   in a regular expression can be escaped.  `.` would also work, but
@@ -79,6 +84,9 @@ abstract class CssConstraint extends Constraint
                 |\\burl\\(\\s*+([\'"]?+)    #
                     [^\'"\\(\\)\\s]++       #
                     \\g{-1}\\s*+\\)         #
+                |(?<=[\\s:])([\'"])         #
+                    [^\'"]++                #
+                    \\g{-1}(?=[\\s;\\}])    #
                 |(?<!\\w)0?+\\.(?=\\d)      #
             )                               #
             [^>]                            #
@@ -112,7 +120,8 @@ abstract class CssConstraint extends Constraint
         8 => self::AT_IMPORT_URL_REPLACEMENT_MATCHER,
         10 => self::AT_IMPORT_URL_REPLACEMENT_MATCHER,
         12 => 'url\\(\\s*+([\'"]?+)$12\\g{-1}\\s*+\\)',
-        13 => '0?+\\.',
+        13 => '([\'"])$14\\g{-1}',
+        15 => '0?+\\.',
     ];
 
     /**

--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -45,6 +45,14 @@ trait CssDataProviders
             'CSS with quoted URL in property value' => ['body { background-image: url("images/foo.jpeg"); }'],
         ]);
 
+        $datasetsWithQuotedPropertyValue = self::crossDatasetWithItself([
+            'CSS with single-quoted string in property value' => ['.new::before { content: \'New Entry! \'; }'],
+            'CSS with double-quoted string in property value' => ['.new::before { content: "New Entry! "; }'],
+            'CSS with quoted string in property value without trailing semicolon'
+                => ['.new::before { content: "New Entry! " }'],
+            'minified CSS with quoted string in property value' => ['.new::before{content:"New Entry! "}'],
+        ]);
+
         $datasetsWithAtImportRule = self::crossDatasetWithItself([
             '`@import` with unquoted string' => ['@import foo/bar.css;'],
             '`@import` with single-quoted string' => ['@import \'foo/bar.css\';'],
@@ -62,6 +70,7 @@ trait CssDataProviders
         return \array_merge(
             $datasetsWithAtMediaRuleSelectorListAndPropertyDeclaration,
             $datasetsWithUrlPropertyValue,
+            $datasetsWithQuotedPropertyValue,
             $datasetsWithAtImportRule
         );
     }
@@ -232,6 +241,17 @@ trait CssDataProviders
             'value does not match with only decimal point as number' => [
                 'width: .em;',
                 'width: 0.em;',
+            ],
+            'quoted value does not match unquoted' => ['content: "Test";', 'content: Test;'],
+            'quoted value does not match with leading space inside quotes' => ['content: "Test";', 'content: " Test";'],
+            'quoted value does not match with trailing space inside quotes' => [
+                'content: "Test";',
+                'content: "Test ";',
+            ],
+            'quoted empty string does not match string containing quotes' => ['content: ""', 'content: \'""\''],
+            'quoted string containing single quotes does not match quoted string containing double quotes' => [
+                'content: "\'\'";',
+                'content: \'""\';',
             ],
             '`attr` does not match quoted attribute name' => ['content: attr(title);', 'content: attr("title");'],
             '`url` does not match without explicit `url`' => ['background: url(foo.jpeg);', 'background: foo.jpeg;'],


### PR DESCRIPTION
This is primarily currently targeted at CSS property values, allowing single
quotes to be exchanged for double quotes or vice versa (but not removed or
added), provided there are no quotes within the string.