### PR TITLE
[BUGFIX] Allow @import after invalid @charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.1 (#967)
 
 ### Fixed
+- Allow `@import` after ignored invalid `@charset` (@1081)
 - Allow line feeds within `<html>` tag (#987)
 
 ## 5.0.1

--- a/src/Utilities/CssDocument.php
+++ b/src/Utilities/CssDocument.php
@@ -15,7 +15,7 @@ class CssDocument
     /**
      * @var string
      */
-    private const AT_CHARSET_OR_IMPORT_RULE_PATTERN = '/^\\s*+(@((?i)import(?-i)|charset)\\s[^;]++;\\s*+)/';
+    private const AT_CHARSET_OR_IMPORT_RULE_PATTERN = '/^\\s*+(@(import|charset)\\s[^;]++;\\s*+)/i';
 
     /**
      * This regular expression pattern will match any nested at-rule apart from
@@ -129,7 +129,9 @@ class CssDocument
      * Extracts `@import` and `@charset` rules from the supplied CSS.  These rules must not be preceded by any other
      * rules, or they will be ignored.  (From the CSS 2.1 specification: "CSS 2.1 user agents must ignore any '@import'
      * rule that occurs inside a block or after any non-ignored statement other than an @charset or an @import rule."
-     * Note also that `@charset` is case sensitive whereas `@import` is not.)
+     * Note also that `@charset` is case sensitive whereas `@import` is not.
+     * However, an invalidly cased `@charset` rule would be an ignored statement, and not affect the validity of any
+     * `@import` rules following.)
      *
      * @param string $css CSS with comments removed
      *

--- a/tests/Unit/Utilities/CssDocumentTest.php
+++ b/tests/Unit/Utilities/CssDocumentTest.php
@@ -363,6 +363,9 @@ final class CssDocumentTest extends TestCase
             '`@import`' => ['@import "foo.css";'],
             '`@font-face`' => [self::VALID_AT_FONT_FACE_RULE],
             '`@import` after `@charset`' => ['@import "foo.css";', '@charset "UTF-8";'],
+            '`@import` after invalid `@charset` (uppercase identifier)' => ['@import "foo.css";', '@CHARSET "UTF-8";'],
+            '`@import` after invalid `@charset` (extra space)' => ['@import "foo.css";', '@charset  "UTF-8";'],
+            '`@import` after invalid `@charset` (unquoted value)' => ['@import "foo.css";', '@charset UTF-8;'],
             '`@import` after `@import`' => ['@import "foo.css";', '@import "bar.css";'],
             '`@import` after space' => ['@import "foo.css";', ' '],
             '`@import` after line feed' => ['@import "foo.css";', "\n"],
@@ -413,14 +416,42 @@ final class CssDocumentTest extends TestCase
 
     /**
      * @test
+     *
+     * @param string $css
+     *
+     * @dataProvider provideValidAtCharsetRules
+     * @dataProvider provideInvalidAtCharsetRules
      */
-    public function discardsAtCharsetRule(): void
+    public function discardsValidOrInvalidAtCharsetRule(string $css): void
     {
-        $subject = new CssDocument('@charset "UTF-8";');
+        $subject = new CssDocument($css);
 
         $result = $subject->renderNonConditionalAtRules();
 
         self::assertSame('', $result);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function provideValidAtCharsetRules(): array
+    {
+        return [
+            'UTF-8' => ['@charset "UTF-8";'],
+            'iso-8859-15' => ['@charset "iso-8859-15";'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function provideInvalidAtCharsetRules(): array
+    {
+        return [
+            'with uppercase identifier' => ['@CHARSET "UTF-8";'],
+            'with extra space' => ['@charset  "UTF-8";'],
+            'with unquoted value' => ['@charset UTF-8;'],
+        ];
     }
 
     /**


### PR DESCRIPTION
From the spec: "User agents must ignore any `@import` rule that occurs inside a
block or after any non-ignored statement other than an `@charset` or an
`@import` rule."

This implies that an invalid `@charset` rule would be an "ignored statment" and
thus not in itself mean that any following `@import` rules must be ignored.

Since valid `@charset` rules are currently simply discarded (only UTF-8 is
supported), the change is to also (similarly) dicard invalid `@charset` rules.