### PR TITLE
[CLEANUP] Drop an unused naming rule from the PHPMD ruleset

### DIFF
--- a/config/phpmd.xml
+++ b/config/phpmd.xml
@@ -36,7 +36,6 @@
     <rule ref="rulesets/design.xml/DevelopmentCodeFragment"/>
 
     <!--<rule ref="rulesets/naming.xml/ShortVariable"/>-->
-    <!--<rule ref="rulesets/naming.xml/LongVariable"/>-->
     <rule ref="rulesets/naming.xml/ShortMethodName"/>
     <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
     <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>


### PR DESCRIPTION
We actually think that long variable names can be a good thing,
and we do not want PHPMD to stop us from using them.

In order to avoid the impression of "we need to fix our code before
we can enable the commented-out rule", the rule now has been
removed from our PHPMD ruleset altogether.
