### PR TITLE
[CLEANUP] Remove the PHPMD rule for unused private methods

### DIFF
--- a/config/phpmd.xml
+++ b/config/phpmd.xml
@@ -44,6 +44,5 @@
 
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
-    <!--<rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>-->
     <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
 </ruleset>


### PR DESCRIPTION
We are not using it anyway as it reports false positives.