### PR TITLE
Temporarily disable the `Squiz.WhiteSpace.OperatorSpacing` sniff

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -139,7 +139,8 @@
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.CastSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <!-- disabled until https://github.com/squizlabs/PHP_CodeSniffer/issues/3377 is fixed -->
+    <!-- <rule ref="Squiz.WhiteSpace.OperatorSpacing"/> -->
     <rule ref="Squiz.WhiteSpace.PropertyLabelSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 </ruleset>


### PR DESCRIPTION
This sniff has a bug that gets in the way of an upcoming refactoring
of our code. Disable the sniff for the time being until the bug
has been fixed.