### PR TITLE
[CLEANUP] Group the used PHP CS Fixer rules

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -58,6 +58,7 @@ return (new \PhpCsFixer\Config())
             'single_line_comment_style' => true,
 
             // constant notation
+            // (no rules used from this section)
 
             // control structure
             'elseif' => true,
@@ -87,6 +88,7 @@ return (new \PhpCsFixer\Config())
             'is_null' => true,
 
             // list notation
+            // (no rules used from this section)
 
             // namespace notation
             'no_leading_namespace_whitespace' => true,

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -52,6 +52,7 @@ return (new \PhpCsFixer\Config())
             'no_php4_constructor' => true,
 
             // class usage
+            // (no rules used from this section)
 
             // comment
             'no_empty_comment' => true,
@@ -94,6 +95,7 @@ return (new \PhpCsFixer\Config())
             'no_leading_namespace_whitespace' => true,
 
             // naming
+            // (no rules used from this section)
 
             // operator
             'concat_space' => ['spacing' => 'one'],

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -10,6 +10,7 @@ return (new \PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules(
         [
+            // rule sets
             '@DoctrineAnnotation' => true,
             '@PHP56Migration:risky' => true,
             '@PHP70Migration' => true,
@@ -20,59 +21,100 @@ return (new \PhpCsFixer\Config())
             '@PHPUnit60Migration:risky' => true,
             '@PHPUnit75Migration:risky' => true,
             '@PSR12' => true,
-            'array_syntax' => ['syntax' => 'short'],
-            'blank_line_after_opening_tag' => true,
-            'cast_spaces' => ['space' => 'none'],
-            'class_attributes_separation' => true,
-            'combine_consecutive_issets' => true,
-            'combine_consecutive_unsets' => true,
-            'compact_nullable_typehint' => true,
-            'concat_space' => ['spacing' => 'one'],
-            'declare_equal_normalize' => true,
-            'declare_strict_types' => true,
-            'dir_constant' => true,
-            'echo_tag_syntax' => true,
-            'elseif' => true,
-            'encoding' => true,
-            'escape_implicit_backslashes' => ['single_quoted' => true],
-            'function_typehint_space' => true,
-            'is_null' => true,
-            'linebreak_after_opening_tag' => true,
-            'lowercase_cast' => true,
-            'magic_constant_casing' => true,
-            'modernize_types_casting' => true,
-            'multiline_whitespace_before_semicolons' => true,
-            'native_function_casing' => true,
-            'native_function_invocation' => ['include' => ['@all']],
-            'new_with_braces' => true,
+
+            // alias
             'no_alias_functions' => true,
-            'no_blank_lines_after_class_opening' => true,
-            'no_blank_lines_after_phpdoc' => true,
-            'no_empty_comment' => true,
-            'no_empty_phpdoc' => true,
-            'no_empty_statement' => true,
-            'no_extra_blank_lines' => true,
-            'no_leading_import_slash' => true,
-            'no_leading_namespace_whitespace' => true,
-            'no_php4_constructor' => true,
-            'no_short_bool_cast' => true,
-            'no_singleline_whitespace_before_semicolons' => true,
-            'no_spaces_after_function_name' => true,
-            'no_spaces_inside_parenthesis' => true,
-            'no_superfluous_elseif' => true,
+
+            // array notation
+            'array_syntax' => ['syntax' => 'short'],
             'no_trailing_comma_in_singleline_array' => true,
+            'no_whitespace_before_comma_in_array' => true,
+            'whitespace_after_comma_in_array' => true,
+
+            // basic
+            'encoding' => true,
+            'psr_autoloading' => true,
+
+            // casing
+            'magic_constant_casing' => true,
+            'native_function_casing' => true,
+
+            // cast notation
+            'cast_spaces' => ['space' => 'none'],
+            'lowercase_cast' => true,
+            'modernize_types_casting' => true,
+            'no_short_bool_cast' => true,
+            'short_scalar_cast' => true,
+
+            // class notation
+            'class_attributes_separation' => true,
+            'no_blank_lines_after_class_opening' => true,
+            'no_php4_constructor' => true,
+
+            // class usage
+
+            // comment
+            'no_empty_comment' => true,
+            'single_line_comment_style' => true,
+
+            // constant notation
+
+            // control structure
+            'elseif' => true,
+            'no_superfluous_elseif' => true,
             'no_unneeded_control_parentheses' => true,
             'no_unneeded_curly_braces' => true,
-            'no_unused_imports' => true,
             'no_useless_else' => true,
-            'no_useless_return' => true,
-            'no_whitespace_before_comma_in_array' => true,
-            'no_whitespace_in_blank_line' => true,
+            'trailing_comma_in_multiline' => true,
+            'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+
+            // function notation
+            'function_typehint_space' => true,
+            'native_function_invocation' => ['include' => ['@all']],
+            'no_spaces_after_function_name' => true,
+            'return_type_declaration' => ['space_before' => 'none'],
+
+            // import
+            'no_leading_import_slash' => true,
+            'no_unused_imports' => true,
             'ordered_imports' => true,
+
+            // language construct
+            'combine_consecutive_issets' => true,
+            'combine_consecutive_unsets' => true,
+            'declare_equal_normalize' => true,
+            'dir_constant' => true,
+            'is_null' => true,
+
+            // list notation
+
+            // namespace notation
+            'no_leading_namespace_whitespace' => true,
+
+            // naming
+
+            // operator
+            'concat_space' => ['spacing' => 'one'],
+            'new_with_braces' => true,
+            'standardize_not_equals' => true,
+            'ternary_operator_spaces' => true,
+            'ternary_to_null_coalescing' => true,
+            'unary_operator_spaces' => true,
+
+            // PHP tag
+            'blank_line_after_opening_tag' => true,
+            'echo_tag_syntax' => true,
+            'linebreak_after_opening_tag' => true,
+
+            // PHPUnit
             'php_unit_construct' => true,
             'php_unit_fqcn_annotation' => true,
             'php_unit_set_up_tear_down_visibility' => true,
             'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+
+            // PHPDoc
+            'no_blank_lines_after_phpdoc' => true,
+            'no_empty_phpdoc' => true,
             'phpdoc_add_missing_param_annotation' => true,
             'phpdoc_indent' => true,
             'phpdoc_no_package' => true,
@@ -81,23 +123,28 @@ return (new \PhpCsFixer\Config())
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
             'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
-            'psr_autoloading' => true,
-            'return_type_declaration' => ['space_before' => 'none'],
+
+            // return notation
+            'no_useless_return' => true,
+
+            // semicolon
+            'multiline_whitespace_before_semicolons' => true,
+            'no_empty_statement' => true,
+            'no_singleline_whitespace_before_semicolons' => true,
             'semicolon_after_instruction' => true,
-            'short_scalar_cast' => true,
-            'single_line_comment_style' => true,
-            'single_quote' => true,
             'space_after_semicolon' => true,
-            'standardize_not_equals' => true,
-            'ternary_operator_spaces' => true,
-            'ternary_to_null_coalescing' => true,
-            'trailing_comma_in_multiline' => true,
-            'unary_operator_spaces' => true,
-            'whitespace_after_comma_in_array' => true,
-            'yoda_style' => [
-                'equal' => false,
-                'identical' => false,
-                'less_and_greater' => false,
-            ],
+
+            // strict
+            'declare_strict_types' => true,
+
+            // string notation
+            'escape_implicit_backslashes' => ['single_quoted' => true],
+            'single_quote' => true,
+
+            // whitespace
+            'compact_nullable_typehint' => true,
+            'no_extra_blank_lines' => true,
+            'no_spaces_inside_parenthesis' => true,
+            'no_whitespace_in_blank_line' => true,
         ]
     );


### PR DESCRIPTION
The grouping follows the list of sections in the documentation at
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/doc/rules/index.rst.

This should make the configuration file more manageable.

(This change neither removes any rules nor does it add any.)