### PR TITLE
[TASK] Rework the `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,34 +1,21 @@
 # top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
+# Unix-style newlines with a newline ending every file, and with same defaults
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-# PHP files
-[*.php]
 indent_style = space
 indent_size = 4
+max_line_length = 120
 
-# MD files
 [*.md]
-indent_style = space
-indent_size = 4
+max_line_length = 80
 
-# XML files
-[*.xml]
-indent_style = space
-indent_size = 4
-
-# YAML files
 [*.{yml,yaml}]
-indent_style = space
 indent_size = 2
 
-# JSON files
-[*.json]
-indent_style = space
-indent_size = 4
+[*.xml]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file, and with same defaults
+# Unix-style newlines with a newline ending every file, and with sane defaults
 [*]
 charset = utf-8
 end_of_line = lf


### PR DESCRIPTION
- use sane defaults instead of redundant settings for each file type
- add a default line length limit for all types to avoid
  overeager line breaking by IDEs
- use shorter lines for Markdown to match what many projects use
- use a 2-space indent for XML files to match what PHIVE uses
  when it updates its configuration file
- drop redundant comments