### PR TITLE
[TASK] Drop support for Symfony 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 - Remove a redundant CSS data cache (#1018)
-- Drop support for Symfony 5.1 (#972)
+- Drop support for Symfony 5.1 and 5.2 (#972, #1104)
 - Drop support for PHP 7.1 (#967)
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.3.1",
-        "symfony/css-selector": "^3.4.32 || ^4.4 || ^5.2 || ^6.0"
+        "symfony/css-selector": "^3.4.32 || ^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3.0",


### PR DESCRIPTION
According to https://symfony.com/releases, Symfony 5.2 has
reached its end of life.