### PR TITLE
[BUGFIX] Only support up to 69 atomic expressions in a selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Only support up to 69 atomic expressions in a selector (#1113)
 - Require `sabberworm/php-css-parser:^8.4.0` (#1134)
 - Upgrade to PHPUnit 9 (#1112)
 

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -1122,7 +1122,7 @@ final class CssInlinerTest extends TestCase
      *     < 2# < 2#+t < 2#+2t < 2#+. < 2#+.+t < 2#+.+2t < 2#+2. < 2#+2.+t < 2#+2.+2t
      * where '*' is the universal selector, 't' is a type selector, '.' is a class selector, and '#' is an ID selector.
      *
-     * Also confirm up to 99 class selectors are supported (much beyond this would require a more complex comparator).
+     * Also confirm up to 69 class selectors are supported (much beyond this would require a more complex comparator).
      *
      * Specificity ordering for selectors involving pseudo-classes, attributes and `:not` is covered through the
      * combination of these tests and the equal specificity tests and thus does not require explicit separate testing.
@@ -1179,10 +1179,10 @@ final class CssInlinerTest extends TestCase
             $previousDescription = $description;
         }
 
-        // broken: class more specific than 99 types (requires support for chaining `:not(h1):not(h1)...`)
-        $datasets['ID more specific than 99 classes'] = [
+        // broken: class more specific than 69 types (requires support for chaining `:not(h1):not(h1)...`)
+        $datasets['ID more specific than 69 classes'] = [
             '<p class="p-4" id="p4"',
-            \str_repeat('.p-4', 99),
+            \str_repeat('.p-4', 69),
             '#p4',
         ];
 


### PR DESCRIPTION
Starting from 70 atomic expressions, PHP will run into the nesting level
limit that was recently added to libxml:

https://gitlab.gnome.org/GNOME/libxml2/-/commit/6f1470a5d6e3e369fe93f52d5760ba7c947f0cd1