### PR TITLE
[TASK] Drop support for Symfony 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Support for PHP 7.3 will be removed in Emogrifier 8.0.
 
 ### Removed
+- Drop support for Symfony 3.x (#1120)
 - Drop support for PHP 7.2 (#1111)
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.3.1",
-        "symfony/css-selector": "^3.4.32 || ^4.4 || ^5.3 || ^6.0"
+        "symfony/css-selector": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3.0",


### PR DESCRIPTION
Symfony 3.x has reached its end of life, and hence we do not need
to support it anymore either:

https://symfony.com/releases