### PR TITLE
[TASK] Require `sabberworm/php-css-parser:^8.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Require `sabberworm/php-css-parser:^8.4.0` (#1134)
 - Upgrade to PHPUnit 9 (#1112)
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "sabberworm/php-css-parser": "^8.3.1",
+        "sabberworm/php-css-parser": "^8.4.0",
         "symfony/css-selector": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.x-dev@"/>
+<files psalm-version="4.x-dev@">
+  <file src="src/Css/CssDocument.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$atRules</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="tests/Unit/Css/StyleRuleTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$declaration['value']</code>
+    </InvalidArgument>
+  </file>
+</files>

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -40,10 +40,7 @@ class CssDocument
      */
     public function __construct(string $css)
     {
-        $cssParser = new CssParser($css);
-        /** @var SabberwormCssDocument $sabberwormCssDocument */
-        $sabberwormCssDocument = $cssParser->parse();
-        $this->sabberwormCssDocument = $sabberwormCssDocument;
+        $this->sabberwormCssDocument = (new CssParser($css))->parse();
     }
 
     /**
@@ -97,9 +94,7 @@ class CssDocument
         $atRulesDocument = new SabberwormCssDocument();
         $atRulesDocument->setContents($atRules);
 
-        /** @var string $renderedRules */
-        $renderedRules = $atRulesDocument->render();
-        return $renderedRules;
+        return $atRulesDocument->render();
     }
 
     /**
@@ -115,7 +110,6 @@ class CssDocument
         $result = null;
 
         if ($rule->atRuleName() === 'media') {
-            /** @var string $mediaQueryList */
             $mediaQueryList = $rule->atRuleArgs();
             [$mediaType] = \explode('(', $mediaQueryList, 2);
             if (\trim($mediaType) !== '') {


### PR DESCRIPTION
Fixes #1127

Also fixes parts of #1130 by removing some redundant type annotations,
and log the other Psalm warnings into the Psalm baseline so we can
fix them later.