### PR TITLE
[TASK] Always run the unit tests in the same order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,8 @@
         "ci:tests": [
             "@ci:tests:unit"
         ],
-        "ci:tests:sof": "@php \"./vendor/bin/phpunit\" --stop-on-failure",
-        "ci:tests:unit": "@php \"./vendor/bin/phpunit\"",
+        "ci:tests:sof": "@php \"./vendor/bin/phpunit\" --stop-on-failure --do-not-cache-result",
+        "ci:tests:unit": "@php \"./vendor/bin/phpunit\" --do-not-cache-result",
         "composer:normalize": "@php \"./.phive/composer-normalize\"",
         "php:fix": "@php \"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix config/ src/ tests/",
         "php:version": "@php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,6 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         executionOrder="depends,defects"
          forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"


### PR DESCRIPTION
Also disable the PHPUnit result caching as this is only relevant
for running failing tests first.

Fixes #1136