### PR TITLE
[TASK] Pass debug setting on to CSS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Throw exception with invalid CSS in debug mode (#1142)
 - Only support up to 69 atomic expressions in a selector (#1113)
 - Require `sabberworm/php-css-parser:^8.4.0` (#1134)
 - Upgrade to PHPUnit 9 (#1112)

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -13,6 +13,7 @@ use Sabberworm\CSS\Property\Import as CssImport;
 use Sabberworm\CSS\Renderable as CssRenderable;
 use Sabberworm\CSS\RuleSet\DeclarationBlock as CssDeclarationBlock;
 use Sabberworm\CSS\RuleSet\RuleSet as CssRuleSet;
+use Sabberworm\CSS\Settings as ParserSettings;
 
 /**
  * Parses and stores a CSS document from a string of CSS, and provides methods to obtain the CSS in parts or as data
@@ -36,7 +37,7 @@ class CssDocument
     private $isImportRuleAllowed = true;
 
     /**
-     * @param string $css
+     * @param string $css {@see https://github.com/squizlabs/PHP_CodeSniffer/issues/3521}
      * @param bool $debug
      *        If this is `true`, an exception will be thrown if invalid CSS is encountered.
      *        Otherwise the parser will try to do the best it can.
@@ -44,15 +45,23 @@ class CssDocument
     public function __construct(string $css, bool $debug)
     {
         // CSS Parser currently throws exception with nested at-rules (like `@media`) in strict parsing mode
-        // @see https://github.com/sabberworm/PHP-CSS-Parser/issues/127
-        $parserSettings = \Sabberworm\CSS\Settings::create()->withLenientParsing(
-            !$debug ||
-            \preg_match('/@(?:media|supports|(?:-webkit-|-moz-|-ms-|-o-)?+(keyframes|document))\\b/', $css) === 1
-        );
+        $parserSettings = ParserSettings::create()->withLenientParsing(!$debug || static::hasNestedAtRule($css));
 
         // CSS Parser currently throws exception with non-empty whitespace-only CSS in strict parsing mode, so `trim()`
         // @see https://github.com/sabberworm/PHP-CSS-Parser/issues/349
         $this->sabberwormCssDocument = (new CssParser(\trim($css), $parserSettings))->parse();
+    }
+
+    /**
+     * Tests if a string of CSS appears to contain an at-rule with nested rules
+     * (`@media`, `@supports`, `@keyframes`, `@document`,
+     * the latter two additionally with vendor prefixes that may commonly be used).
+     *
+     * @see https://github.com/sabberworm/PHP-CSS-Parser/issues/127
+     */
+    private static function hasNestedAtRule(string $css): bool
+    {
+        return \preg_match('/@(?:media|supports|(?:-webkit-|-moz-|-ms-|-o-)?+(keyframes|document))\\b/', $css) === 1;
     }
 
     /**

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -37,7 +37,7 @@ class CssDocument
     private $isImportRuleAllowed = true;
 
     /**
-     * @param string $css {@see https://github.com/squizlabs/PHP_CodeSniffer/issues/3521}
+     * @param string $css
      * @param bool $debug
      *        If this is `true`, an exception will be thrown if invalid CSS is encountered.
      *        Otherwise the parser will try to do the best it can.
@@ -45,7 +45,7 @@ class CssDocument
     public function __construct(string $css, bool $debug)
     {
         // CSS Parser currently throws exception with nested at-rules (like `@media`) in strict parsing mode
-        $parserSettings = ParserSettings::create()->withLenientParsing(!$debug || static::hasNestedAtRule($css));
+        $parserSettings = ParserSettings::create()->withLenientParsing(!$debug || $this->hasNestedAtRule($css));
 
         // CSS Parser currently throws exception with non-empty whitespace-only CSS in strict parsing mode, so `trim()`
         // @see https://github.com/sabberworm/PHP-CSS-Parser/issues/349
@@ -59,7 +59,7 @@ class CssDocument
      *
      * @see https://github.com/sabberworm/PHP-CSS-Parser/issues/127
      */
-    private static function hasNestedAtRule(string $css): bool
+    private function hasNestedAtRule(string $css): bool
     {
         return \preg_match('/@(?:media|supports|(?:-webkit-|-moz-|-ms-|-o-)?+(keyframes|document))\\b/', $css) === 1;
     }

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -37,10 +37,22 @@ class CssDocument
 
     /**
      * @param string $css
+     * @param bool $debug
+     *        If this is `true`, an exception will be thrown if invalid CSS is encountered.
+     *        Otherwise the parser will try to do the best it can.
      */
-    public function __construct(string $css)
+    public function __construct(string $css, bool $debug)
     {
-        $this->sabberwormCssDocument = (new CssParser($css))->parse();
+        // CSS Parser currently throws exception with nested at-rules (like `@media`) in strict parsing mode
+        // @see https://github.com/sabberworm/PHP-CSS-Parser/issues/127
+        $parserSettings = \Sabberworm\CSS\Settings::create()->withLenientParsing(
+            !$debug ||
+            \preg_match('/@(?:media|supports|(?:-webkit-|-moz-|-ms-|-o-)?+(keyframes|document))\\b/', $css) === 1
+        );
+
+        // CSS Parser currently throws exception with non-empty whitespace-only CSS in strict parsing mode, so `trim()`
+        // @see https://github.com/sabberworm/PHP-CSS-Parser/issues/349
+        $this->sabberwormCssDocument = (new CssParser(\trim($css), $parserSettings))->parse();
     }
 
     /**

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -179,7 +179,7 @@ class CssInliner extends AbstractHtmlProcessor
         if ($this->isStyleBlocksParsingEnabled) {
             $combinedCss .= $this->getCssFromAllStyleNodes();
         }
-        $parsedCss = new CssDocument($combinedCss);
+        $parsedCss = new CssDocument($combinedCss, $this->debug);
 
         $excludedNodes = $this->getNodesToExclude();
         $cssRules = $this->collateCssRules($parsedCss);

--- a/tests/Unit/Css/CssDocumentTest.php
+++ b/tests/Unit/Css/CssDocumentTest.php
@@ -24,6 +24,11 @@ final class CssDocumentTest extends TestCase
         . '  font-family: "Foo Sans";' . "\n"
         . '  src: url("/foo-sans.woff2") format("woff2");' . "\n}";
 
+    private static function createDebugSubject(string $css): CssDocument
+    {
+        return new CssDocument($css, true);
+    }
+
     /**
      * @test
      *
@@ -436,8 +441,6 @@ final class CssDocumentTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     *
      * @dataProvider provideValidAtCharsetRules
      * @dataProvider provideInvalidAtCharsetRules
      */
@@ -453,8 +456,6 @@ final class CssDocumentTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     *
      * @dataProvider provideValidAtCharsetRules
      */
     public function discardsValidAtCharsetRuleInDebugMode(string $css): void
@@ -468,8 +469,6 @@ final class CssDocumentTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider provideInvalidAtCharsetRules
      */
@@ -512,9 +511,6 @@ final class CssDocumentTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $atRuleCss
-     * @param string $cssBefore
      *
      * @dataProvider provideInvalidNonConditionalAtRule
      */
@@ -588,11 +584,6 @@ final class CssDocumentTest extends TestCase
         $result = $subject->renderNonConditionalAtRules();
 
         self::assertSame('', $result);
-    }
-
-    private static function createDebugSubject(string $css): CssDocument
-    {
-        return new CssDocument($css, true);
     }
 
     /**

--- a/tests/Unit/Css/CssDocumentTest.php
+++ b/tests/Unit/Css/CssDocumentTest.php
@@ -441,8 +441,9 @@ final class CssDocumentTest extends TestCase
     /**
      * @test
      *
-     * @dataProvider provideValidAtCharsetRules
-     * @dataProvider provideInvalidAtCharsetRules
+     * @dataProvider provideValidAtCharsetRule
+     * @dataProvider provideInvalidAtCharsetRuleWhichCausesException
+     * @dataProvider provideInvalidAtCharsetRuleWhichDoesNotCauseException
      */
     public function discardsValidOrInvalidAtCharsetRuleNotInDebugMode(string $css): void
     {
@@ -456,7 +457,7 @@ final class CssDocumentTest extends TestCase
     /**
      * @test
      *
-     * @dataProvider provideValidAtCharsetRules
+     * @dataProvider provideValidAtCharsetRule
      */
     public function discardsValidAtCharsetRuleInDebugMode(string $css): void
     {
@@ -470,7 +471,9 @@ final class CssDocumentTest extends TestCase
     /**
      * @test
      *
-     * @dataProvider provideInvalidAtCharsetRules
+     * @dataProvider provideInvalidAtCharsetRuleWhichCausesException
+     *
+     * Invalid `@charset` rules which do not currently cause an exception not yet tested.
      */
     public function throwsExceptionForInvalidAtCharsetRuleInDebugMode(string $css): void
     {
@@ -487,7 +490,7 @@ final class CssDocumentTest extends TestCase
     /**
      * @return array<string, array{0: string}>
      */
-    public function provideValidAtCharsetRules(): array
+    public function provideValidAtCharsetRule(): array
     {
         return [
             'UTF-8' => ['@charset "UTF-8";'],
@@ -498,19 +501,29 @@ final class CssDocumentTest extends TestCase
     /**
      * @return array<string, array{0: string}>
      */
-    public function provideInvalidAtCharsetRules(): array
+    public function provideInvalidAtCharsetRuleWhichCausesException(): array
+    {
+        return [
+            'with unquoted value' => ['@charset UTF-8;'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function provideInvalidAtCharsetRuleWhichDoesNotCauseException(): array
     {
         return [
             'with uppercase identifier' => ['@CHARSET "UTF-8";'],
             'with extra space' => ['@charset  "UTF-8";'],
-            'with unquoted value' => ['@charset UTF-8;'],
         ];
     }
 
     /**
      * @test
      *
-     * @dataProvider provideInvalidNonConditionalAtRule
+     * @dataProvider provideInvalidNonConditionalAtRuleWhichCausesException
+     * @dataProvider provideInvalidNonConditionalAtRuleWhichDoesNotCauseException
      */
     public function discardsInvalidNonConditionalAtRuleNotInDebugMode(string $atRuleCss, string $cssBefore = ''): void
     {
@@ -526,7 +539,9 @@ final class CssDocumentTest extends TestCase
     /**
      * @test
      *
-     * @dataProvider provideInvalidNonConditionalAtRule
+     * @dataProvider provideInvalidNonConditionalAtRuleWhichCausesException
+     *
+     * Invalid non-conditional at-rules which do not currently cause an exception not yet tested.
      */
     public function throwsExceptionForInvalidNonConditionalAtRuleInDebugMode(
         string $atRuleCss,
@@ -535,17 +550,23 @@ final class CssDocumentTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $this->createDebugSubject($cssBefore . $atRuleCss);
-
-        self::markTestSkipped(
-            'This test is disabled as currently the CSS parser does not throw an exception in all cases.'
-            . ' Discarding of invalid rules in non-debug mode is already covered by other tests.'
-        );
     }
 
     /**
      * @return array<string, array<int, string>>
      */
-    public function provideInvalidNonConditionalAtRule(): array
+    public function provideInvalidNonConditionalAtRuleWhichCausesException(): array
+    {
+        return [
+            '`@charset` after style rule' => ['@charset "UTF-8";', 'p { color: red; }'],
+            '`@charset` after `@import` rule' => ['@charset "UTF-8";', '@import "foo.css";'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function provideInvalidNonConditionalAtRuleWhichDoesNotCauseException(): array
     {
         return [
             '`@font-face` without `font-family`' => ['
@@ -558,8 +579,6 @@ final class CssDocumentTest extends TestCase
                   font-family: "Foo Sans";
                 }
             '],
-            '`@charset` after style rule' => ['@charset "UTF-8";', 'p { color: red; }'],
-            '`@charset` after `@import` rule' => ['@charset "UTF-8";', '@import "foo.css";'],
             '`@import` after style rule' => ['@import "foo.css";', 'p { color: red; }'],
             '`@import` after `@font-face` rule' => ['@import "foo.css";', self::VALID_AT_FONT_FACE_RULE],
         ];


### PR DESCRIPTION
This partially addresses both #1139 and #1140.

However, if the CSS contains nested at-rules, the debug setting won't currently
be passed on, due to https://github.com/sabberworm/PHP-CSS-Parser/issues/127.

Some tests have been adapted to cater for an exception in debug mode with only
some of the data.