### PR TITLE
[BUGFIX] Stop using a literal string as the rule value in a test

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,8 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.x-dev@">
-  <file src="tests/Unit/Css/StyleRuleTest.php">
-    <InvalidArgument occurrences="1">
-      <code>$declaration['value']</code>
-    </InvalidArgument>
-  </file>
-</files>
+<files psalm-version="4.x-dev@"/>

--- a/tests/Unit/Css/StyleRuleTest.php
+++ b/tests/Unit/Css/StyleRuleTest.php
@@ -8,6 +8,7 @@ use Pelago\Emogrifier\Css\StyleRule;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Rule\Rule;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
+use Sabberworm\CSS\Value\RuleValueList;
 
 /**
  * @covers \Pelago\Emogrifier\Css\StyleRule
@@ -93,7 +94,9 @@ final class StyleRuleTest extends TestCase
         $declarationBlock = new DeclarationBlock();
         foreach ($declarations as $declaration) {
             $rule = new Rule($declaration['property']);
-            $rule->setValue($declaration['value']);
+            $value = new RuleValueList();
+            $value->addListComponent($declaration['value']);
+            $rule->setValue($value);
             $declarationBlock->addRule($rule);
         }
         $styleRule = new StyleRule($declarationBlock, '');


### PR DESCRIPTION
Our previous usage violated the class contract.