### PR TITLE
[FEATURE] Add a Dependabot action for updating GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    milestone: 12


### PR DESCRIPTION
With this configuration, GitHub's Dependabot will create PR
to update the versions of the GitHub Actions we are using in
our CI pipeline.