### PR TITLE
[TASK] Include Dependabot configuration in the release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,16 +407,18 @@ They will, however, be preserved and copied to a `<style>` element in the HTML:
 
 1. In the [composer.json](composer.json), update the `branch-alias` entry to
    point to the release _after_ the upcoming release.
-1. In the [CHANGELOG.md](CHANGELOG.md), create a new section with subheadings
+2. In the [CHANGELOG.md](CHANGELOG.md), create a new section with subheadings
    for changes _after_ the upcoming release, set the version number for the
    upcoming release, and remove any empty sections.
-1. Create a pull request "Prepare release of version x.y.z" with those
+3. In the [Dependabot configuration](.github/dependabot.yml), update the
+   target milestone to the next upcoming milestone.
+4. Create a pull request "Prepare release of version x.y.z" with those
    changes.
-1. Have the pull request reviewed and merged.
-1. Tag the new release.
-1. In the [Releases tab](https://github.com/MyIntervals/emogrifier/releases),
+5. Have the pull request reviewed and merged.
+6. Tag the new release.
+7. In the [Releases tab](https://github.com/MyIntervals/emogrifier/releases),
    create a new release and copy the change log entries to the new release.
-1. Post about the new release on social media.
+8. Post about the new release on social media.
 
 ## Maintainers
 


### PR DESCRIPTION
Also use real numbers for the affected enumeration in the README
as PhpStorm now does this automatically, and working against PhpStorm
would be too much of a hassle.