### PR TITLE
[TASK] Drop support for Symfony 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Support for PHP 7.3 will be removed in Emogrifier 8.0.
 
 ### Removed
-- Drop support for Symfony 3.x (#1120)
+- Drop support for Symfony 3.x and 5.3 (#1120, #1162)
 - Drop support for PHP 7.2 (#1111)
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.4.0",
-        "symfony/css-selector": "^4.4 || ^5.3 || ^6.0"
+        "symfony/css-selector": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
Symfony 5.3 has reached its end of life.