### PR TITLE
[TASK] Use PHP 8.2 in CI without faking the version for Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,10 +163,6 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Fake PHP version for 8.2.
-        run: composer config platform.php 8.1.99
-        if: matrix.php-version == '8.2'
-
       - name: Cache dependencies installed with composer
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
All necessary packages now are available for PHP 8.2, and we
do not need to fake PHP 8.2 as 8.1 in the Composer configuration
in order to get the packages installed.