### PR TITLE
[TASK] Remove the Dependabot configuration for Composer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    milestone: 12
-
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "development"
-    versioning-strategy: "increase"
-    milestone: 12


### PR DESCRIPTION
We'll update our dependencies manually if and when the need arises
(as the Composer updates were the majority of the PRs by Dependabot).

Dependabot will still update the GitHub actions.

Dependabot will still create PRs for security-relevant updates, though.

Also drop the target milestone from the configuration in order to
reduce the work needed after we have released a new major version.

Fixes #1174