### PR TITLE
[TASK] Run the tests on CI with all warnings enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          ini-values: xdebug.max_nesting_level=500
+          ini-values: xdebug.max_nesting_level=500, error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 


### PR DESCRIPTION
This allows us to catch things that will break in future PHP versions, but still kind-of-work, e.g., deprecation warnings or incorrect types.

Closes #1117