### PR TITLE
[BUGFIX] Remove speculative parent constructor calls in test code

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -225,23 +225,4 @@ abstract class CssConstraint extends Constraint
 
         return $matcher;
     }
-
-    /**
-     * Invokes the parent class's constructor if there is one.  Since PHPUnit 8.x, `Constraint` (the parent class) does
-     * not have a defined constructor.  But...
-     *
-     * In PHP, a class that may be extended should have a defined constructor, even if it does nothing.
-     *
-     * That way, a child class that needs a constructor can explicitly call its parent's constructor.  If it could not,
-     * and then a newer version of the parent class needed a constructor, the newly added constructor would not be
-     * invoked implicitly during instantiation of the child class.  In that eventuality, the child class would also need
-     * updating, so there would be a compatibility issue, and potential for uncaught bugs if the child class's
-     * constructor was not updated.
-     */
-    protected function __construct()
-    {
-        if (\is_callable('parent::__construct')) {
-            parent::__construct();
-        }
-    }
 }

--- a/tests/Support/Constraint/IsEquivalentCss.php
+++ b/tests/Support/Constraint/IsEquivalentCss.php
@@ -27,8 +27,6 @@ final class IsEquivalentCss extends CssConstraint
      */
     public function __construct(string $css)
     {
-        parent::__construct();
-
         $this->css = $css;
         $this->cssPattern = '/^\\s*+' . self::getCssRegularExpressionMatcher(\trim($css)) . '\\s*+$/';
     }

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -27,8 +27,6 @@ final class StringContainsCss extends CssConstraint
      */
     public function __construct(string $css)
     {
-        parent::__construct();
-
         $this->css = $css;
         $this->cssPattern = '/' . self::getCssRegularExpressionMatcher($css) . '/';
     }

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -33,8 +33,6 @@ final class StringContainsCssCount extends CssConstraint
      */
     public function __construct(int $count, string $css)
     {
-        parent::__construct();
-
         $this->count = $count;
         $this->css = $css;
         $this->cssPattern = '/' . self::getCssRegularExpressionMatcher($css) . '/';


### PR DESCRIPTION
This fixes a deprecation warning in PHP 8.2.