### PR TITLE
[BUGFIX] Replace a deprecated callable check

### DIFF
--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -240,7 +240,7 @@ abstract class CssConstraint extends Constraint
      */
     protected function __construct()
     {
-        if (\is_callable('parent::__construct')) {
+        if (\is_callable([parent::class, '__construct'])) {
             parent::__construct();
         }
     }


### PR DESCRIPTION
`\is_callable('parent::__construct')` is deprecated in PHP 8.2.