### PR TITLE
[BUGFIX] Bump the minimum Symfony 4.4. version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.2 (#1111)
 
 ### Fixed
-- Bump the minimum Symfony 4.4. version (#1187)
+- Bump the minimum Symfony 4.4 version to avoid PHP deprecation warnings (#1187)
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.2 (#1111)
 
 ### Fixed
+- Bump the minimum Symfony 4.4. version (#1187)
 
 ## 6.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.4.0",
-        "symfony/css-selector": "^4.4 || ^5.4 || ^6.0"
+        "symfony/css-selector": "^4.4.23 || ^5.4.0 || ^6.0.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
For PHP 8.1 and 8.2, we need a bug fix that avoids a deprecation warning. (Symfony 5.4.0, 6.0.0 and 6.1.0 already have this fix.)