### PR TITLE
Format `renderPreservesOriginalHtmlFormatting` test

### DIFF
--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -114,15 +114,17 @@ final class AbstractHtmlProcessorTest extends TestCase
     public function renderPreservesOriginalHtmlFormatting(): void
     {
         $rawHtml = '<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Hello world</title>
-    </head>
-    <body>
-       <li><em>Hello</em> world</li>
-    </body>
-</html>';
+                    <html lang="en">
+                        <head>
+                            <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+                            <title>Hello world</title>
+                        </head>
+                        <body>
+                            <ul>
+                                <li><em>Hello</em> world</li>
+                            </ul>
+                        </body>
+                    </html>';
 
         $subject = TestingHtmlProcessor::fromHtml($rawHtml);
         $renderedHtml = $subject->render();

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -113,18 +113,15 @@ final class AbstractHtmlProcessorTest extends TestCase
      */
     public function renderPreservesOriginalHtmlFormatting(): void
     {
-        $rawHtml = '<!DOCTYPE html>
-                    <html lang="en">
-                        <head>
-                            <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-                            <title>Hello world</title>
-                        </head>
-                        <body>
-                            <ul>
-                                <li><em>Hello</em> world</li>
-                            </ul>
-                        </body>
-                    </html>';
+        $rawHtml = "<!DOCTYPE html>\n" .
+            "<html>\n" .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' .
+            "<body>\n" .
+            "<ul>\n" .
+            "<li><em>Hello</em> world</li>\n" .
+            "</ul>\n" .
+            "</body>\n" .
+            '</html>';
 
         $subject = TestingHtmlProcessor::fromHtml($rawHtml);
         $renderedHtml = $subject->render();


### PR DESCRIPTION
- Wrapped `<li>` element in `<ul>`
- Updated text indention of the HTML code snippet
(according to https://github.com/MyIntervals/emogrifier/pull/1214/files#r1156552170)