### PR TITLE
[BUGFIX] Accurate return type for AbstractHtmlProcessorTest data providers

### DIFF
--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -834,7 +834,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return string[][]
+     * @return array<array-key, array<int, string>>
      */
     public function provideContentTypeMetaTag(): array
     {
@@ -860,7 +860,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return string[][]
+     * @return array<array-key, array<int, string>>
      */
     public function provideHtmlAroundContentType(): array
     {

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -834,7 +834,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return array<array-key, array<int, string>>
+     * @return array<string, array{0: string}>
      */
     public function provideContentTypeMetaTag(): array
     {
@@ -860,7 +860,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     }
 
     /**
-     * @return array<array-key, array<int, string>>
+     * @return array<string, array{0: string, 1: string}>
      */
     public function provideHtmlAroundContentType(): array
     {


### PR DESCRIPTION
`TRegx\DataProvider\DataProviders::cross` now expects `array<int|string, array<int, mixed>>`, rather than whatever it was previously loosely specified to.

(This does raise the question of whether tightening up the code annotation for Psalm could be considered a breaking change.  Though it only breaks the CI, not the software itself, so I guess not.)