### PR TITLE
[TASK] Annotate regex patterns as non-empty-string

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -1146,7 +1146,7 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * This method only supports strings, not arrays of strings.
      *
-     * @param string $pattern
+     * @param non-empty-string $pattern
      * @param string $replacement
      * @param string $subject
      *

--- a/tests/Support/Constraint/IsEquivalentCss.php
+++ b/tests/Support/Constraint/IsEquivalentCss.php
@@ -18,7 +18,7 @@ final class IsEquivalentCss extends CssConstraint
     private $css;
 
     /**
-     * @var string
+     * @var non-empty-string
      */
     private $cssPattern;
 

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -18,7 +18,7 @@ final class StringContainsCss extends CssConstraint
     private $css;
 
     /**
-     * @var string
+     * @var non-empty-string
      */
     private $cssPattern;
 

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -23,7 +23,7 @@ final class StringContainsCssCount extends CssConstraint
     private $css;
 
     /**
-     * @var string
+     * @var non-empty-string
      */
     private $cssPattern;
 


### PR DESCRIPTION
A mere `string` type annotation will generate errors with Psalm 5.15 (the latest version at time of writing).