### PR TITLE
[BUGFIX] Skip any style elements with null value, but still remove them

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
-  <file src="src/CssInliner.php">
-    <PossiblyNullOperand>
-      <code><![CDATA[$styleNode->nodeValue]]></code>
-    </PossiblyNullOperand>
-  </file>
   <file src="tests/Support/Constraint/CssConstraint.php">
     <DirectConstructorCall>
       <code>parent::__construct()</code>

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -492,7 +492,7 @@ class CssInliner extends AbstractHtmlProcessor
 
         $css = '';
         foreach ($styleNodes as $styleNode) {
-            if ($styleNode->nodeValue !== null) {
+            if (\is_string($styleNode->nodeValue)) {
                 $css .= "\n\n" . $styleNode->nodeValue;
             }
             $parentNode = $styleNode->parentNode;

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -492,7 +492,9 @@ class CssInliner extends AbstractHtmlProcessor
 
         $css = '';
         foreach ($styleNodes as $styleNode) {
-            $css .= "\n\n" . $styleNode->nodeValue;
+            if ($styleNode->nodeValue !== null) {
+                $css .= "\n\n" . $styleNode->nodeValue;
+            }
             $parentNode = $styleNode->parentNode;
             if ($parentNode instanceof \DOMNode) {
                 $parentNode->removeChild($styleNode);


### PR DESCRIPTION
Psalm indicates that `DOMNode::nodeValue` could be `null`, perhaps for entirely empty `<style>` elements.

If such are encountered during pre-processing, still remove them from the DOM, but don't append their contents to the CSS to be inlined with extra line-breaks.