### PR TITLE
[CLEANUP] Use more specific type annotations in `CssDocument`

### DIFF
--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -69,7 +69,7 @@ class CssDocument
      *
      * @param array<array-key, string> $allowedMediaTypes
      *
-     * @return array<int, StyleRule>
+     * @return list<StyleRule>
      */
     public function getStyleRulesData(array $allowedMediaTypes): array
     {


### PR DESCRIPTION
`list` means `array with numeric continuous keys starting with 0`.