### PR TITLE
[CLEANUP] Use more specific type annotations in `CssInliner`

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -463,7 +463,7 @@ class CssInliner extends AbstractHtmlProcessor
 
         $properties = [];
         foreach (\preg_split('/;(?!base64|charset)/', $cssDeclarationsBlock) as $declaration) {
-            /** @var array<int, string> $matches */
+            /** @var list<string> $matches */
             $matches = [];
             if (!\preg_match('/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s', \trim($declaration), $matches)) {
                 continue;
@@ -505,7 +505,7 @@ class CssInliner extends AbstractHtmlProcessor
     /**
      * Find the nodes that are not to be emogrified.
      *
-     * @return array<int, \DOMElement>
+     * @return list<\DOMElement>
      *
      * @throws ParseException
      * @throws \UnexpectedValueException


### PR DESCRIPTION
`list` means `array with numeric continuous keys starting with 0`.