### PR TITLE
[CLEANUP] Allow array subtype parameters

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
   <file src="src/CssInliner.php">
-    <InvalidArgument>
-      <code><![CDATA[\usort(
-            $cssRules['inlinable'],
-            /**
-             * @param array{selector: string, line: int} $first
-             * @param array{selector: string, line: int} $second
-             */
-            function (array $first, array $second): int {
-                return $this->sortBySelectorPrecedence($first, $second);
-            }
-        )]]></code>
-    </InvalidArgument>
     <PossiblyNullOperand>
       <code><![CDATA[$styleNode->nodeValue]]></code>
     </PossiblyNullOperand>

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -608,8 +608,8 @@ class CssInliner extends AbstractHtmlProcessor
         \usort(
             $cssRules['inlinable'],
             /**
-             * @param array{selector: string, line: int} $first
-             * @param array{selector: string, line: int} $second
+             * @param array{selector: string, line: int, ...} $first
+             * @param array{selector: string, line: int, ...} $second
              */
             function (array $first, array $second): int {
                 return $this->sortBySelectorPrecedence($first, $second);
@@ -667,8 +667,8 @@ class CssInliner extends AbstractHtmlProcessor
     }
 
     /**
-     * @param array{selector: string, line: int} $first
-     * @param array{selector: string, line: int} $second
+     * @param array{selector: string, line: int, ...} $first
+     * @param array{selector: string, line: int, ...} $second
      *
      * @return int
      */


### PR DESCRIPTION
The type specification of `array{selector: string, line: int}` is exact. To allow arrays with other various random elements, we need `array{selector: string, line: int, ...}`

Kudos to @weirdan for help with this
(https://github.com/vimeo/psalm/issues/10188).