### PR TITLE
[FEATURE] Add the ability to exclude CSS selectors from being inlined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add CSS selectors exclusion feature (#1236)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,21 @@ calling the `inlineCss` method:
   $cssInliner->addExcludedSelector('.message-preview');
   $cssInliner->addExcludedSelector('.message-preview *');
   ```
+* `->addExcludedCssSelector(string $selector)` - Contrary to `addExcludedSelector`
+  which excludes HTML nodes, this method excludes CSS selectors from
+  being inlined. This is for example useful if you don't want your CSS reset rules
+  to be inlined on each HTML node (e.g. `* { margin: 0; padding: 0; font-size: 100% }`).
+  Note that these selectors must precisely match the selectors you wish to exclude.
+  Meaning that excluding `.example` will not exclude `p .example`.
+  ```php
+  $cssInliner->addExcludedCssSelector('*');
+  $cssInliner->addExcludedCssSelector('form');
+  ```
+* `->removeExcludedCssSelector(string $selector)` - Removes previously added excluded
+  selectors, if any.
+  ```php
+  $cssInliner->removeExcludedCssSelector('form');
+  ```
 
 ### Migrating from the dropped `Emogrifier` class to the `CssInliner` class
 

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -629,7 +629,7 @@ class CssInliner extends AbstractHtmlProcessor
             if (\count($this->excludedCssSelectors) > 0) {
                 // Normalize spaces, line breaks & tabs
                 $selectorsNormalized = \array_map(static function (string $selector): string {
-                    return (string) \preg_replace('@\\s++@u', ' ', $selector);
+                    return (string)\preg_replace('@\\s++@u', ' ', $selector);
                 }, $selectors);
 
                 $selectors = \array_filter($selectorsNormalized, function (string $selector): bool {

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -62,6 +62,11 @@ class CssInliner extends AbstractHtmlProcessor
     private $excludedSelectors = [];
 
     /**
+     * @var array<non-empty-string, bool>
+     */
+    private $excludedCssSelectors = [];
+
+    /**
      * @var array<string, bool>
      */
     private $allowedMediaTypes = ['all' => true, 'screen' => true, 'print' => true];
@@ -296,6 +301,36 @@ class CssInliner extends AbstractHtmlProcessor
     {
         if (isset($this->excludedSelectors[$selector])) {
             unset($this->excludedSelectors[$selector]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds a selector to exclude CSS selector from emogrification.
+     *
+     * @param non-empty-string $selector the selector to exclude, e.g., `.editor`
+     *
+     * @return $this
+     */
+    public function addExcludedCssSelector(string $selector): self
+    {
+        $this->excludedCssSelectors[$selector] = true;
+
+        return $this;
+    }
+
+    /**
+     * No longer excludes the CSS selector from emogrification.
+     *
+     * @param non-empty-string $selector the selector to no longer exclude, e.g., `.editor`
+     *
+     * @return $this
+     */
+    public function removeExcludedCssSelector(string $selector): self
+    {
+        if (isset($this->excludedCssSelectors[$selector])) {
+            unset($this->excludedCssSelectors[$selector]);
         }
 
         return $this;
@@ -588,7 +623,21 @@ class CssInliner extends AbstractHtmlProcessor
 
             $mediaQuery = $cssRule->getContainingAtRule();
             $declarationsBlock = $cssRule->getDeclarationAsText();
-            foreach ($cssRule->getSelectors() as $selector) {
+            $selectors = $cssRule->getSelectors();
+
+            // Maybe exclude CSS selectors
+            if (\count($this->excludedCssSelectors) > 0) {
+                // Normalize spaces, line breaks & tabs
+                $selectorsNormalized = \array_map(static function (string $selector): string {
+                    return (string) \preg_replace('@\\s++@u', ' ', $selector);
+                }, $selectors);
+
+                $selectors = \array_filter($selectorsNormalized, function (string $selector): bool {
+                    return !isset($this->excludedCssSelectors[$selector]);
+                });
+            }
+
+            foreach ($selectors as $selector) {
                 // don't process pseudo-elements and behavioral (dynamic) pseudo-classes;
                 // only allow structural pseudo-classes
                 $hasPseudoElement = \strpos($selector, '::') !== false;


### PR DESCRIPTION
Exclude CSS selectors from the stylesheets being inlined. This might for example prevent global CSS rules with universal selector (*) to be inlined on each node.

- Add unit tests
- Normalize selectors spaces/line breaks
- Add CHANGELOG entry
- Add README documentation