### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
 
       - name: Show the Composer version
@@ -67,6 +68,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           tools: composer:v2
           coverage: none
 
@@ -97,6 +99,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           tools: composer:v2, phive
           coverage: none
 
@@ -137,6 +140,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           tools: composer:v2, phive
           coverage: none
 
@@ -192,7 +196,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          ini-values: xdebug.max_nesting_level=500, error_reporting=E_ALL
+          ini-file: development
           tools: composer:v2
           coverage: none
 


### PR DESCRIPTION
This allows us to see (and fail on) PHP warnings and notices.

Fixes #1257