### PR TITLE
[TASK] Update our coding standard

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -2,154 +2,36 @@
 
 declare(strict_types=1);
 
-if (PHP_SAPI !== 'cli') {
-    die('This script supports command line usage only. Please check your command.');
-}
-
 return (new \PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules(
         [
-            // rule sets
-            '@DoctrineAnnotation' => true,
-            '@PHP56Migration:risky' => true,
-            '@PHP70Migration' => true,
-            '@PHP70Migration:risky' => true,
-            '@PHP71Migration' => true,
-            '@PHP71Migration:risky' => true,
+            '@PER-CS2.0' => true,
+            '@PER-CS2.0:risky' => true,
+
+            '@PHPUnit50Migration:risky' => true,
+            '@PHPUnit52Migration:risky' => true,
+            '@PHPUnit54Migration:risky' => true,
+            '@PHPUnit55Migration:risky' => true,
+            '@PHPUnit56Migration:risky' => true,
             '@PHPUnit57Migration:risky' => true,
             '@PHPUnit60Migration:risky' => true,
             '@PHPUnit75Migration:risky' => true,
             '@PHPUnit84Migration:risky' => true,
-            '@PER' => true,
 
-            // alias
-            'no_alias_functions' => true,
+            // needed for PHP 7.x
+            'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'match']],
 
-            // array notation
-            'array_syntax' => ['syntax' => 'short'],
-            'no_trailing_comma_in_singleline' => true,
-            'no_whitespace_before_comma_in_array' => true,
-            'whitespace_after_comma_in_array' => true,
-
-            // basic
-            'encoding' => true,
-            'psr_autoloading' => true,
-
-            // casing
-            'magic_constant_casing' => true,
-            'native_function_casing' => true,
-
-            // cast notation
-            'cast_spaces' => ['space' => 'none'],
-            'lowercase_cast' => true,
-            'modernize_types_casting' => true,
-            'no_short_bool_cast' => true,
-            'short_scalar_cast' => true,
-
-            // class notation
-            'class_attributes_separation' => true,
-            'no_blank_lines_after_class_opening' => true,
-            'no_php4_constructor' => true,
-
-            // class usage
-            // (no rules used from this section)
-
-            // comment
-            'no_empty_comment' => true,
-            'single_line_comment_style' => true,
-
-            // constant notation
-            // (no rules used from this section)
-
-            // control structure
-            'elseif' => true,
-            'no_superfluous_elseif' => true,
-            'no_unneeded_control_parentheses' => true,
-            'no_unneeded_curly_braces' => true,
-            'no_useless_else' => true,
-            'trailing_comma_in_multiline' => true,
-            'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
-
-            // function notation
-            'type_declaration_spaces' => ['elements' => ['function', 'property']],
-            'native_function_invocation' => ['include' => ['@all']],
-            'no_spaces_after_function_name' => true,
-            'return_type_declaration' => ['space_before' => 'none'],
-
-            // import
-            'no_leading_import_slash' => true,
-            'no_unused_imports' => true,
-            'ordered_imports' => true,
-
-            // language construct
-            'combine_consecutive_issets' => true,
-            'combine_consecutive_unsets' => true,
-            'declare_equal_normalize' => true,
-            'dir_constant' => true,
-            'is_null' => true,
-
-            // list notation
-            // (no rules used from this section)
-
-            // namespace notation
-            'no_leading_namespace_whitespace' => true,
-
-            // naming
-            // (no rules used from this section)
-
-            // operator
-            'concat_space' => ['spacing' => 'one'],
-            'new_with_braces' => true,
-            'standardize_not_equals' => true,
-            'ternary_operator_spaces' => true,
-            'ternary_to_null_coalescing' => true,
-            'unary_operator_spaces' => true,
-
-            // PHP tag
-            'blank_line_after_opening_tag' => true,
-            'echo_tag_syntax' => true,
-            'linebreak_after_opening_tag' => true,
-
-            // PHPUnit
             'php_unit_construct' => true,
+            'php_unit_dedicate_assert' => ['target' => 'newest'],
+            'php_unit_expectation' => ['target' => 'newest'],
             'php_unit_fqcn_annotation' => true,
+            'php_unit_method_casing' => true,
+            'php_unit_mock' => ['target' => 'newest'],
+            'php_unit_mock_short_will_return' => true,
+            'php_unit_namespaced' => ['target' => 'newest'],
             'php_unit_set_up_tear_down_visibility' => true,
+            'php_unit_test_annotation' => ['style' => 'annotation'],
             'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
-
-            // PHPDoc
-            'no_blank_lines_after_phpdoc' => true,
-            'no_empty_phpdoc' => true,
-            'phpdoc_add_missing_param_annotation' => true,
-            'phpdoc_indent' => true,
-            'phpdoc_no_package' => true,
-            'phpdoc_scalar' => true,
-            'phpdoc_separation' => true,
-            'phpdoc_trim' => true,
-            'phpdoc_types' => true,
-            'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
-
-            // return notation
-            'no_useless_return' => true,
-
-            // semicolon
-            'multiline_whitespace_before_semicolons' => true,
-            'no_empty_statement' => true,
-            'no_singleline_whitespace_before_semicolons' => true,
-            'semicolon_after_instruction' => true,
-            'space_after_semicolon' => true,
-
-            // strict
-            'declare_strict_types' => true,
-
-            // string notation
-            'escape_implicit_backslashes' => ['single_quoted' => true],
-            'single_quote' => true,
-
-            // whitespace
-            'compact_nullable_typehint' => true,
-            'no_extra_blank_lines' => true,
-            'spaces_inside_parentheses' => ['space' => 'none'],
-            'no_whitespace_in_blank_line' => true,
         ]
     );

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -37,7 +37,6 @@ return (new \PhpCsFixer\Config())
             'no_empty_comment' => true,
 
             // control structure
-            'no_superfluous_elseif' => true,
             'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
 
             // function notation

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -20,18 +20,78 @@ return (new \PhpCsFixer\Config())
             '@PHPUnit84Migration:risky' => true,
 
             // overwrite the PER2 defaults to restore compatibility with PHP 7.x
-            'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match']],
+            'trailing_comma_in_multiline' => ['elements' => ['arrays']],
 
+            // casing
+            'magic_constant_casing' => true,
+            'native_function_casing' => true,
+
+            // cast notation
+            'modernize_types_casting' => true,
+            'no_short_bool_cast' => true,
+
+            // class notation
+            'no_php4_constructor' => true,
+
+            // comment
+            'no_empty_comment' => true,
+
+            // control structure
+            'no_superfluous_elseif' => true,
+            'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+
+            // function notation
+            'native_function_invocation' => ['include' => ['@all']],
+
+            // import
+            'no_unused_imports' => true,
+
+            // language construct
+            'combine_consecutive_issets' => true,
+            'combine_consecutive_unsets' => true,
+            'dir_constant' => true,
+            'is_null' => true,
+
+            // namespace notation
+            'no_leading_namespace_whitespace' => true,
+
+            // operator
+            'standardize_not_equals' => true,
+            'ternary_to_null_coalescing' => true,
+
+            // PHP tag
+            'linebreak_after_opening_tag' => true,
+
+            // PHPUnit
             'php_unit_construct' => true,
             'php_unit_dedicate_assert' => ['target' => 'newest'],
             'php_unit_expectation' => ['target' => 'newest'],
             'php_unit_fqcn_annotation' => true,
-            'php_unit_method_casing' => true,
-            'php_unit_mock' => ['target' => 'newest'],
             'php_unit_mock_short_will_return' => true,
-            'php_unit_namespaced' => ['target' => 'newest'],
             'php_unit_set_up_tear_down_visibility' => true,
             'php_unit_test_annotation' => ['style' => 'annotation'],
             'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+
+            // PHPDoc
+            'no_blank_lines_after_phpdoc' => true,
+            'no_empty_phpdoc' => true,
+            'phpdoc_indent' => true,
+            'phpdoc_no_package' => true,
+            'phpdoc_trim' => true,
+            'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+
+            // return notation
+            'no_useless_return' => true,
+
+            // semicolon
+            'no_empty_statement' => true,
+            'no_singleline_whitespace_before_semicolons' => true,
+            'semicolon_after_instruction' => true,
+
+            // strict
+            'declare_strict_types' => true,
+
+            // string notation
+            'string_implicit_backslashes' => ['single_quoted' => 'escape'],
         ]
     );

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -20,7 +20,7 @@ return (new \PhpCsFixer\Config())
             '@PHPUnit84Migration:risky' => true,
 
             // needed for PHP 7.x
-            'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'match']],
+            'trailing_comma_in_multiline' => ['after_heredoc' => false, 'elements' => ['arrays', 'match']],
 
             'php_unit_construct' => true,
             'php_unit_dedicate_assert' => ['target' => 'newest'],

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -19,8 +19,8 @@ return (new \PhpCsFixer\Config())
             '@PHPUnit75Migration:risky' => true,
             '@PHPUnit84Migration:risky' => true,
 
-            // needed for PHP 7.x
-            'trailing_comma_in_multiline' => ['after_heredoc' => false, 'elements' => ['arrays', 'match']],
+            // overwrite the PER2 defaults to restore compatibility with PHP 7.x
+            'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match']],
 
             'php_unit_construct' => true,
             'php_unit_dedicate_assert' => ['target' => 'newest'],

--- a/src/Css/StyleRule.php
+++ b/src/Css/StyleRule.php
@@ -43,7 +43,7 @@ class StyleRule
         $selectors = $this->declarationBlock->getSelectors();
         return \array_map(
             static function (Selector $selector): string {
-                return (string)$selector;
+                return (string) $selector;
             },
             $selectors
         );

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -629,7 +629,7 @@ class CssInliner extends AbstractHtmlProcessor
             if (\count($this->excludedCssSelectors) > 0) {
                 // Normalize spaces, line breaks & tabs
                 $selectorsNormalized = \array_map(static function (string $selector): string {
-                    return (string)\preg_replace('@\\s++@u', ' ', $selector);
+                    return (string) \preg_replace('@\\s++@u', ' ', $selector);
                 }, $selectors);
 
                 $selectors = \array_filter($selectorsNormalized, function (string $selector): bool {
@@ -714,7 +714,7 @@ class CssInliner extends AbstractHtmlProcessor
             return false;
         }
 
-        return (bool)\preg_match('/:(?:' . self::OF_TYPE_PSEUDO_CLASS_MATCHER . ')/i', $selectorPart);
+        return (bool) \preg_match('/:(?:' . self::OF_TYPE_PSEUDO_CLASS_MATCHER . ')/i', $selectorPart);
     }
 
     /**
@@ -754,7 +754,7 @@ class CssInliner extends AbstractHtmlProcessor
             }
             $number = 0;
             $selector = \preg_replace('/' . $matcher . '\\w+/', '', $selector, -1, $number);
-            $precedence += ($value * (int)$number);
+            $precedence += ($value * (int) $number);
         }
         $this->caches[self::CACHE_KEY_SELECTOR][$selectorKey] = $precedence;
 
@@ -853,7 +853,7 @@ class CssInliner extends AbstractHtmlProcessor
      */
     private function attributeValueIsImportant(string $attributeValue): bool
     {
-        return (bool)\preg_match('/!\\s*+important$/i', $attributeValue);
+        return (bool) \preg_match('/!\\s*+important$/i', $attributeValue);
     }
 
     /**
@@ -1236,7 +1236,7 @@ class CssInliner extends AbstractHtmlProcessor
         ));
 
         $pregLastError = \preg_last_error();
-        $message = 'PCRE regex execution error `' . (string)($pcreErrorConstantNames[$pregLastError] ?? $pregLastError)
+        $message = 'PCRE regex execution error `' . (string) ($pcreErrorConstantNames[$pregLastError] ?? $pregLastError)
             . '`';
 
         if ($this->debug) {

--- a/src/Utilities/CssConcatenator.php
+++ b/src/Utilities/CssConcatenator.php
@@ -89,7 +89,7 @@ class CssConcatenator
                 $lastDeclarationsBlockWithoutSemicolon = \rtrim(\rtrim($lastRuleBlock->declarationsBlock), ';');
                 $lastRuleBlock->declarationsBlock = $lastDeclarationsBlockWithoutSemicolon . ';' . $declarationsBlock;
             } else {
-                $mediaRule->ruleBlocks[] = (object)\compact('selectorsAsKeys', 'declarationsBlock');
+                $mediaRule->ruleBlocks[] = (object) \compact('selectorsAsKeys', 'declarationsBlock');
             }
         }
     }
@@ -121,7 +121,7 @@ class CssConcatenator
             return $lastMediaRule;
         }
 
-        $newMediaRule = (object)[
+        $newMediaRule = (object) [
             'media' => $media,
             'ruleBlocks' => [],
         ];

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -186,7 +186,7 @@ abstract class CssConstraint extends Constraint
                 $regularExpressionEquivalent = \preg_replace_callback(
                     '/\\$(\\d++)/',
                     static function (array $referenceMatches) use ($matches): string {
-                        return \preg_quote($matches[(int)$referenceMatches[1]] ?? '', '/');
+                        return \preg_quote($matches[(int) $referenceMatches[1]] ?? '', '/');
                     },
                     $replacement
                 );

--- a/tests/Support/Constraint/StringContainsCssCount.php
+++ b/tests/Support/Constraint/StringContainsCssCount.php
@@ -45,7 +45,7 @@ final class StringContainsCssCount extends CssConstraint
      */
     public function toString(): string
     {
-        return 'contains exactly ' . (string)$this->count . ' occurrence(s) of CSS `' . $this->css . '`';
+        return 'contains exactly ' . (string) $this->count . ' occurrence(s) of CSS `' . $this->css . '`';
     }
 
     /**

--- a/tests/Support/Traits/TestStringConstraint.php
+++ b/tests/Support/Traits/TestStringConstraint.php
@@ -24,7 +24,7 @@ trait TestStringConstraint
             'int' => [0],
             'float' => [0.0],
             'array' => [[]],
-            'object' => [(object)[]],
+            'object' => [(object) []],
             'resource' => [\fopen('php://temp', 'r')],
             'callable' => [
                 static function (): void {},

--- a/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
+++ b/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
@@ -615,7 +615,7 @@ final class HtmlPrunerTest extends TestCase
         self::assertSame(
             $expectedCount,
             \substr_count($haystack, $needle),
-            'asserting \'' . $haystack . '\' contains ' . (string)$expectedCount . ' instance(s) of "' . $needle . '"'
+            'asserting \'' . $haystack . '\' contains ' . (string) $expectedCount . ' instance(s) of "' . $needle . '"'
         );
     }
 


### PR DESCRIPTION
Switch to the PER2 coding standard and reduce the number of custom rules.

This basically aligns our code style with that used by the PHP-CSS-Parser project, which is very close to the PER-2 coding standard.

Fixes #1262