### PR TITLE
[TASK] Add a PHP-CS-Fixer rule to prefer single-quoted string literals

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -92,6 +92,7 @@ return (new \PhpCsFixer\Config())
             'strict_param' => true,
 
             // string notation
+            'single_quote' => true,
             'string_implicit_backslashes' => ['single_quoted' => 'escape'],
         ]
     );


### PR DESCRIPTION
As we already are doing this in our code, this added rule does not cause any changes to the code.