### PR TITLE
[TASK] Add a fixer rule to ensure a PHP 8.4 compatibility

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -41,6 +41,10 @@ return (new \PhpCsFixer\Config())
 
             // function notation
             'native_function_invocation' => ['include' => ['@all']],
+            'nullable_type_declaration' => [
+                'syntax' => 'question_mark',
+            ],
+            'nullable_type_declaration_for_default_null_value' => true,
 
             // import
             'no_unused_imports' => true,

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -41,9 +41,6 @@ return (new \PhpCsFixer\Config())
 
             // function notation
             'native_function_invocation' => ['include' => ['@all']],
-            'nullable_type_declaration' => [
-                'syntax' => 'question_mark',
-            ],
             'nullable_type_declaration_for_default_null_value' => true,
 
             // import
@@ -54,6 +51,7 @@ return (new \PhpCsFixer\Config())
             'combine_consecutive_unsets' => true,
             'dir_constant' => true,
             'is_null' => true,
+            'nullable_type_declaration' => true,
 
             // namespace notation
             'no_leading_namespace_whitespace' => true,


### PR DESCRIPTION
Ensure that parameters that have a `null` default value also have `null` as part of their type declarations.

Also ensure a uniform notation for nullable types.

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Fixes #1269