### PR TITLE
[CLEANUP] Remove unnecessary `md5()` call in `CssInliner::getCssSelectorPrecedence()`

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -742,7 +742,7 @@ class CssInliner extends AbstractHtmlProcessor
      */
     private function getCssSelectorPrecedence(string $selector): int
     {
-        $selectorKey = \md5($selector);
+        $selectorKey = $selector;
         if (isset($this->caches[self::CACHE_KEY_SELECTOR][$selectorKey])) {
             return $this->caches[self::CACHE_KEY_SELECTOR][$selectorKey];
         }


### PR DESCRIPTION
The input selector is guaranteed to be a string, so we can directly index the cache array with it. This avoids the overhead of calculating the cryptographic hash and the creation of a fresh string, makes the array more friendly for manual inspection using a debugger and avoids using a function that might be deprecated with PHP 8.4.