### PR TITLE
[TASK] Update the contribution workflow documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This is the workflow for contributing changes to this project::
    for your changes.
 9. Check that the CI build is green. (If it is not, fix the problems listed.)
    Please note that for first-time contributors, you will need to wait for a
-   maintainer to approve your pull request before the CI build will run.
+   maintainer to allow your CI build to run.
 10. Wait for a review by the maintainers.
 11. Polish your changes as needed until they are ready to be merged.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,22 +15,22 @@ project, you agree to abide by its terms.
 
 This is the workflow for contributing changes to this project::
 
-1. [Fork the git repository](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
+1. [Fork the Git repository](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
 2. Clone your forked repository locally and
    [install the development dependencies](#install-the-development-dependencies).
-3. Add a local remote "upstream" so you will be able to
-   [synchronize your fork with the original repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
-4. Create a local branch for your changes.
-5. [Add unit tests for your changes](#unit-test-your-changes).
+3. Create a local branch for your changes.
+4. [Add unit tests for your changes](#unit-test-your-changes).
    These tests should fail without your changes.
-6. Add your changes. Your added unit tests now should pass, and no other tests
+5. Add your changes. Your added unit tests now should pass, and no other tests
    should be broken. Check that your changes follow the same
    [coding style](#coding-style) as the rest of the project.
-7. Add a changelog entry.
-8. [Commit](#git-commits) and push your changes.
-9. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
-   for your changes. Check that the CI build is green. (If it is not, fix the
-   problems listed.)
+6. Add a changelog entry, newest on top.
+7. [Commit](#git-commits) and push your changes.
+8. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+   for your changes.
+9. Check that the CI build is green. (If it is not, fix the problems listed.)
+   Please note that for first-time contributors, you will need to wait for a
+   maintainer to approve your pull request before the CI build will run.
 10. Wait for a review by the maintainers.
 11. Polish your changes as needed until they are ready to be merged.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,13 +13,13 @@ project, you agree to abide by its terms.
 
 ## General workflow
 
-This is the workflow for contributing changes to Emogrifier:
+This is the workflow for contributing changes to this project::
 
-1. [Fork the Emogrifier Git repository](https://guides.github.com/activities/forking/).
-2. Clone your forked repository and
+1. [Fork the git repository](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
+2. Clone your forked repository locally and
    [install the development dependencies](#install-the-development-dependencies).
 3. Add a local remote "upstream" so you will be able to
-   [synchronize your fork with the original Emogrifier repository](https://help.github.com/articles/syncing-a-fork/).
+   [synchronize your fork with the original repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 4. Create a local branch for your changes.
 5. [Add unit tests for your changes](#unit-test-your-changes).
    These tests should fail without your changes.
@@ -28,12 +28,11 @@ This is the workflow for contributing changes to Emogrifier:
    [coding style](#coding-style) as the rest of the project.
 7. Add a changelog entry.
 8. [Commit](#git-commits) and push your changes.
-9. [Create a pull request](https://help.github.com/articles/about-pull-requests/)
-   for your changes. Check that the Travis build is green. (If it is not, fix
-   the problems listed by Travis.)
-10. [Request a review](https://help.github.com/articles/about-pull-request-reviews/)
-    from @oliverklee.
-11. Together with him, polish your changes until they are ready to be merged.
+9. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+   for your changes. Check that the CI build is green. (If it is not, fix the
+   problems listed.)
+10. Wait for a review by the maintainers.
+11. Polish your changes as needed until they are ready to be merged.
 
 ## About code reviews
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,23 +16,23 @@ project, you agree to abide by its terms.
 This is the workflow for contributing changes to this project::
 
 1. [Fork the Git repository](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
-2. Clone your forked repository locally and
+1. Clone your forked repository locally and
    [install the development dependencies](#install-the-development-dependencies).
-3. Create a local branch for your changes.
-4. [Add unit tests for your changes](#unit-test-your-changes).
+1. Create a local branch for your changes.
+1. [Add unit tests for your changes](#unit-test-your-changes).
    These tests should fail without your changes.
-5. Add your changes. Your added unit tests now should pass, and no other tests
+1. Add your changes. Your added unit tests now should pass, and no other tests
    should be broken. Check that your changes follow the same
    [coding style](#coding-style) as the rest of the project.
-6. Add a changelog entry, newest on top.
-7. [Commit](#git-commits) and push your changes.
-8. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+1. Add a changelog entry, newest on top.
+1. [Commit](#git-commits) and push your changes.
+1. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
    for your changes.
-9. Check that the CI build is green. (If it is not, fix the problems listed.)
+1. Check that the CI build is green. (If it is not, fix the problems listed.)
    Please note that for first-time contributors, you will need to wait for a
    maintainer to allow your CI build to run.
-10. Wait for a review by the maintainers.
-11. Polish your changes as needed until they are ready to be merged.
+1. Wait for a review by the maintainers.
+1. Polish your changes as needed until they are ready to be merged.
 
 ## About code reviews
 


### PR DESCRIPTION
We're not using Travis CI anymore. Also, there is no way external contributors to request reviews on pull requests.

Also update outdated URLs.

Also update the wording to be less Emogrifier-specific so we can copy'n'paste this documentation more easily to our sister project.