### PR TITLE
[TASK] Be less strict about the `@covers` annotation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-         beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          bootstrap="vendor/autoload.php"


### PR DESCRIPTION
We still want to require the `@covers` annotation to be used for testcase (`forceCoversAnnotation="true"`), but we also want to be able to indirectly execute code that is not referenced via an `@covers` annotation.