### PR TITLE
[FEATURE] Configure Dependabot to also update dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "development"
+    versioning-strategy: "increase"


### PR DESCRIPTION
If we want to have fixed versions of our development dependencies, manually updating them will be quite a hassle. Let's automate this instead using Dependabot.