### PR TITLE
[TASK] Rein in Dependabot a bit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,8 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "development"
+    ignore:
+      - dependency-name: "phpunit/phpunit"
+        versions: [ ">= 10.0.0" ]
+      - dependency-name: "rawr/cross-data-providers"
     versioning-strategy: "increase"


### PR DESCRIPTION
We want to stay at PHPUnit 9.x to stay compatible with PHP 7.3.

Also, `rawr/cross-data-providers` has breaking changes in newer releases. As that package has been abandonded anyway, we won't bother with updating it and switch to the successor instead later.