### PR TITLE
[TASK] Add pregReplaceCallback method to handle internal regex errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: src/CssInliner.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method DOMElement\\:\\:setAttribute\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/CssInliner.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: src/CssInliner.php
 
 		-
-			message: "#^Parameter \\#1 \\$cssDeclarationsBlock of method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:parseCssDeclarationsBlock\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function ltrim expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/CssInliner.php

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -452,7 +452,7 @@ class CssInliner extends AbstractHtmlProcessor
      */
     private function normalizeStyleAttributes(\DOMElement $node): void
     {
-        $normalizedOriginalStyle = \preg_replace_callback(
+        $normalizedOriginalStyle = $this->pregReplaceCallback(
             '/-?+[_a-zA-Z][\\w\\-]*+(?=:)/S',
             /** @param array<array-key, string> $propertyNameMatches */
             static function (array $propertyNameMatches): string {
@@ -1208,6 +1208,33 @@ class CssInliner extends AbstractHtmlProcessor
     private function pregReplace(string $pattern, string $replacement, string $subject): string
     {
         $result = \preg_replace($pattern, $replacement, $subject);
+
+        if (!\is_string($result)) {
+            $this->logOrThrowPregLastError();
+            $result = $subject;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Wraps `preg_replace_callback`.
+     * If an error occurs (which is highly unlikely), either it is logged and the original `$subject` is returned,
+     * or in debug mode an exception is thrown.
+     *
+     * This method only supports strings, not arrays of strings.
+     *
+     * @param non-empty-string $pattern
+     * @param callable $callback
+     * @param string $subject
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    private function pregReplaceCallback(string $pattern, callable $callback, string $subject): string
+    {
+        $result = \preg_replace_callback($pattern, $callback, $subject);
 
         if (!\is_string($result)) {
             $this->logOrThrowPregLastError();


### PR DESCRIPTION
If an internal PCRE error occurs,
an exception will be thrown or `trigger_error` will be called, depending on the 'debug' setting.
In the latter case,
the original string passed to `preg_replace_callback` will be returned.

Resolves one PHPStan issue.