### PR TITLE
[CLEANUP] Add class for `preg_ function` error handling

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/CssInliner.php
 
 		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:removeSelectorComponents\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 3
 			path: src/CssInliner.php
@@ -31,59 +26,9 @@ parameters:
 			path: src/CssInliner.php
 
 		-
-			message: "#^Parameter \\#1 \\$cssDeclarationsBlock of method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:parseCssDeclarationsBlock\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function ltrim expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function trim expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
 			message: "#^Parameter \\#2 \\$array of function array_map expects array, array\\<int, string\\>\\|false given\\.$#"
 			count: 1
 			path: src/CssInliner.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method DOMElement\\:\\:setAttribute\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\AbstractHtmlProcessor\\:\\:addContentTypeMetaTag\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
-
-		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\AbstractHtmlProcessor\\:\\:ensurePhpUnrecognizedSelfClosingTagsAreXml\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
-
-		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\AbstractHtmlProcessor\\:\\:normalizeDocumentType\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
-
-		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\AbstractHtmlProcessor\\:\\:removeSelfClosingTagsClosingTags\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
-
-		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\AbstractHtmlProcessor\\:\\:renderBodyContent\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
@@ -118,11 +63,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 2
-			path: src/HtmlProcessor/CssToAttributeConverter.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method DOMElement\\:\\:setAttribute\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
 			path: src/HtmlProcessor/CssToAttributeConverter.php
 
 		-
@@ -176,39 +116,14 @@ parameters:
 			path: src/Utilities/CssConcatenator.php
 
 		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\Tests\\\\Support\\\\Constraint\\\\CssConstraint\\:\\:getCssMatcherAllowingOptionalTrailingSemicolon\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: tests/Support/Constraint/CssConstraint.php
-
-		-
-			message: "#^Parameter \\#1 \\$matcher of static method Pelago\\\\Emogrifier\\\\Tests\\\\Support\\\\Constraint\\\\CssConstraint\\:\\:getCssMatcherAllowingOptionalTrailingSemicolon\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: tests/Support/Constraint/CssConstraint.php
-
-		-
 			message: "#^Offset 0 does not exist on array\\{0\\?\\: string\\}\\.$#"
 			count: 1
 			path: tests/Unit/Css/CssDocumentTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$css of method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:inlineCss\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: tests/Unit/CssInlinerTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function trim expects string, string\\|false given\\.$#"
 			count: 1
 			path: tests/Unit/CssInlinerTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 2
-			path: tests/Unit/CssInlinerTest.php
-
-		-
-			message: "#^Method Pelago\\\\Emogrifier\\\\Tests\\\\Unit\\\\HtmlProcessor\\\\AbstractHtmlProcessorTest\\:\\:normalizeHtmlElement\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function strtolower expects string, string\\|false given\\.$#"

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\HtmlProcessor;
 
+use Pelago\Emogrifier\Utilities\Preg;
+
 /**
  * Base class for HTML processor that e.g., can remove, add or modify nodes or attributes.
  *
@@ -180,7 +182,7 @@ abstract class AbstractHtmlProcessor
         $htmlWithPossibleErroneousClosingTags = $this->getDomDocument()->saveHTML($this->getBodyElement());
         $bodyNodeHtml = $this->removeSelfClosingTagsClosingTags($htmlWithPossibleErroneousClosingTags);
 
-        return \preg_replace('%</?+body(?:\\s[^>]*+)?+>%', '', $bodyNodeHtml);
+        return (new Preg())->replace('%</?+body(?:\\s[^>]*+)?+>%', '', $bodyNodeHtml);
     }
 
     /**
@@ -192,7 +194,7 @@ abstract class AbstractHtmlProcessor
      */
     private function removeSelfClosingTagsClosingTags(string $html): string
     {
-        return \preg_replace('%</' . self::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER . '>%', '', $html);
+        return (new Preg())->replace('%</' . self::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER . '>%', '', $html);
     }
 
     /**
@@ -288,7 +290,7 @@ abstract class AbstractHtmlProcessor
     private function normalizeDocumentType(string $html): string
     {
         // Limit to replacing the first occurrence: as an optimization; and in case an example exists as unescaped text.
-        return \preg_replace(
+        return (new Preg())->replace(
             '/<!DOCTYPE\\s++html(?=[\\s>])/i',
             '<!DOCTYPE html',
             $html,
@@ -317,13 +319,13 @@ abstract class AbstractHtmlProcessor
         $hasHtmlTag = \stripos($html, '<html') !== false;
 
         if ($hasHeadTag) {
-            $reworkedHtml = \preg_replace(
+            $reworkedHtml = (new Preg())->replace(
                 '/<head(?=[\\s>])([^>]*+)>/i',
                 '<head$1>' . self::CONTENT_TYPE_META_TAG,
                 $html
             );
         } elseif ($hasHtmlTag) {
-            $reworkedHtml = \preg_replace(
+            $reworkedHtml = (new Preg())->replace(
                 '/<html(.*?)>/is',
                 '<html$1><head>' . self::CONTENT_TYPE_META_TAG . '</head>',
                 $html
@@ -403,12 +405,7 @@ abstract class AbstractHtmlProcessor
      */
     private function removeHtmlComments(string $html): string
     {
-        $result = \preg_replace(self::HTML_COMMENT_PATTERN, '', $html);
-        if (!\is_string($result)) {
-            throw new \RuntimeException('Internal PCRE error', 1616521475);
-        }
-
-        return $result;
+        return (new Preg())->throwExceptions(true)->replace(self::HTML_COMMENT_PATTERN, '', $html);
     }
 
     /**
@@ -423,12 +420,7 @@ abstract class AbstractHtmlProcessor
      */
     private function removeHtmlTemplateElements(string $html): string
     {
-        $result = \preg_replace(self::HTML_TEMPLATE_ELEMENT_PATTERN, '', $html);
-        if (!\is_string($result)) {
-            throw new \RuntimeException('Internal PCRE error', 1616519652);
-        }
-
-        return $result;
+        return (new Preg())->throwExceptions(true)->replace(self::HTML_TEMPLATE_ELEMENT_PATTERN, '', $html);
     }
 
     /**
@@ -441,7 +433,7 @@ abstract class AbstractHtmlProcessor
      */
     private function ensurePhpUnrecognizedSelfClosingTagsAreXml(string $html): string
     {
-        return \preg_replace(
+        return (new Preg())->replace(
             '%<' . self::PHP_UNRECOGNIZED_VOID_TAGNAME_MATCHER . '\\b[^>]*+(?<!/)(?=>)%',
             '$0/',
             $html

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\HtmlProcessor;
 
+use Pelago\Emogrifier\Utilities\Preg;
+
 /**
  * This HtmlProcessor can convert style HTML attributes to the corresponding other visual HTML attributes,
  * e.g. it converts style="width: 100px" to width="100".
@@ -233,7 +235,7 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
             return;
         }
 
-        $number = \preg_replace('/[^0-9.%]/', '', $value);
+        $number = (new Preg())->replace('/[^0-9.%]/', '', $value);
         $node->setAttribute($property, $number);
     }
 

--- a/src/Utilities/Preg.php
+++ b/src/Utilities/Preg.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Utilities;
+
+/**
+ * PHP's `preg_*` functions can return `false` on failure.
+ * Failure is rare but may occur with a complex pattern applied to a long subject.
+ * Catastrophic backtracking may occur ({@see https://www.regular-expressions.info/catastrophic.html}).
+ * Failure may also occur due to programmer error, if an invalid pattern is provided.
+ *
+ * Catering for failure in each case clutters up the code with error handling.
+ * This class provides wrappers for some `preg_*` functions, with errors handled either
+ * - by throwing an exception, or
+ * - by triggering a user error and providing fallback logic (e.g. returning the subject string unmodified).
+ *
+ * @internal
+ */
+final class Preg
+{
+    /**
+     * whether to throw exceptions on errors (or call `trigger_error` and implement fallback)
+     *
+     * @var bool
+     */
+    private $throwExceptions = false;
+
+    /**
+     * Sets whether exceptions should be thrown if an error occurs.
+     */
+    public function throwExceptions(bool $throw): self
+    {
+        $this->throwExceptions = $throw;
+
+        return $this;
+    }
+
+    /**
+     * Wraps `preg_replace`, though does not support `$subject` being an array.
+     * If an error occurs, and exceptions are not being thrown, the original `$subject` is returned.
+     *
+     * @param non-empty-string|non-empty-array<non-empty-string> $pattern
+     * @param string|non-empty-array<string> $replacement
+     *
+     * @throws \RuntimeException
+     */
+    public function replace($pattern, $replacement, string $subject, int $limit = -1, ?int &$count = null): string
+    {
+        $result = \preg_replace($pattern, $replacement, $subject, $limit, $count);
+
+        if ($result === null) {
+            $this->logOrThrowPregLastError();
+            $result = $subject;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Wraps `preg_replace_callback`, though does not support `$subject` being an array.
+     * If an error occurs, and exceptions are not being thrown, the original `$subject` is returned.
+     *
+     * Note that (unlike when calling `preg_replace_callback`), `$callback` cannot be a non-public method
+     * represented by an array comprising an object or class name and the method name.
+     * To circumvent that, use `\Closure::fromCallable([$objectOrClassName, 'method'])`.
+     *
+     * @param non-empty-string|non-empty-array<non-empty-string> $pattern
+     *
+     * @throws \RuntimeException
+     */
+    public function replaceCallback(
+        $pattern,
+        callable $callback,
+        string $subject,
+        int $limit = -1,
+        ?int &$count = null
+    ): string {
+        $result = \preg_replace_callback($pattern, $callback, $subject, $limit, $count);
+
+        if ($result === null) {
+            $this->logOrThrowPregLastError();
+            $result = $subject;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Obtains the name of the error constant for `preg_last_error`
+     * (based on code posted at {@see https://www.php.net/manual/en/function.preg-last-error.php#124124})
+     * and puts it into an error message which is either passed to `trigger_error`
+     * or used in the exception which is thrown (depending on the `$throwExceptions` property).
+     *
+     * @throws \RuntimeException
+     */
+    private function logOrThrowPregLastError(): void
+    {
+        $pcreConstants = \get_defined_constants(true)['pcre'];
+        $pcreErrorConstantNames = \array_flip(\array_filter(
+            $pcreConstants,
+            static function (string $key): bool {
+                return \substr($key, -6) === '_ERROR';
+            },
+            ARRAY_FILTER_USE_KEY
+        ));
+
+        $pregLastError = \preg_last_error();
+        $message = 'PCRE regex execution error `' . (string) ($pcreErrorConstantNames[$pregLastError] ?? $pregLastError)
+            . '`';
+
+        if ($this->throwExceptions) {
+            throw new \RuntimeException($message, 1592870147);
+        }
+        \trigger_error($message);
+    }
+}

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Support\Constraint;
 
+use Pelago\Emogrifier\Utilities\Preg;
 use PHPUnit\Framework\Constraint\Constraint;
 
 /**
@@ -163,9 +164,9 @@ abstract class CssConstraint extends Constraint
      */
     protected static function getCssRegularExpressionMatcher(string $css): string
     {
-        $matcher = \preg_replace_callback(
+        $matcher = (new Preg())->replaceCallback(
             self::CSS_REGULAR_EXPRESSION_PATTERN,
-            [self::class, 'getCssRegularExpressionReplacement'],
+            \Closure::fromCallable([self::class, 'getCssRegularExpressionReplacement']),
             $css
         );
 
@@ -183,7 +184,7 @@ abstract class CssConstraint extends Constraint
 
         foreach (self::CSS_REGULAR_EXPRESSION_REPLACEMENTS as $index => $replacement) {
             if (($matches[$index] ?? '') !== '') {
-                $regularExpressionEquivalent = \preg_replace_callback(
+                $regularExpressionEquivalent = (new Preg())->replaceCallback(
                     '/\\$(\\d++)/',
                     static function (array $referenceMatches) use ($matches): string {
                         return \preg_quote($matches[(int) $referenceMatches[1]] ?? '', '/');
@@ -216,7 +217,7 @@ abstract class CssConstraint extends Constraint
         $isPropertyDeclarationsOnly = \strpos($css, ':') !== false && \preg_match('/[@\\{\\}]/', $css) === 0;
 
         if ($isPropertyDeclarationsOnly) {
-            return \preg_replace(
+            return (new Preg())->replace(
                 self::OPTIONAL_TRAILING_SEMICOLON_MATCHER_PATTERN,
                 '(?:\\s*+;)?+',
                 $matcher

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -8,6 +8,7 @@ use Pelago\Emogrifier\Css\CssDocument;
 use Pelago\Emogrifier\CssInliner;
 use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 use Pelago\Emogrifier\Tests\Support\Traits\AssertCss;
+use Pelago\Emogrifier\Utilities\Preg;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
@@ -2036,9 +2037,10 @@ final class CssInlinerTest extends TestCase
     public function inlineCssWithValidMinifiedMediaQueryContainsInnerCss(string $css): void
     {
         // Minify CSS by removing unnecessary whitespace.
-        $css = \preg_replace('/\\s*{\\s*/', '{', $css);
-        $css = \preg_replace('/;?\\s*}\\s*/', '}', $css);
-        $css = \preg_replace('/@media{/', '@media {', $css);
+        $preg = new Preg();
+        $css = $preg->replace('/\\s*{\\s*/', '{', $css);
+        $css = $preg->replace('/;?\\s*}\\s*/', '}', $css);
+        $css = $preg->replace('/@media{/', '@media {', $css);
         $subject = $this->buildDebugSubject('<html><h1></h1><p></p></html>');
 
         $subject->inlineCss($css);

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -6,6 +6,7 @@ namespace Pelago\Emogrifier\Tests\Unit\HtmlProcessor;
 
 use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 use Pelago\Emogrifier\Tests\Unit\HtmlProcessor\Fixtures\TestingHtmlProcessor;
+use Pelago\Emogrifier\Utilities\Preg;
 use PHPUnit\Framework\TestCase;
 use TRegx\DataProvider\DataProviders;
 
@@ -1251,7 +1252,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     private static function assertContainsHtml(string $needle, string $haystack, string $message = ''): void
     {
         $needleMatcher = \preg_quote($needle, '%');
-        $needleMatcherWithNewlines = \preg_replace(
+        $needleMatcherWithNewlines = (new Preg())->replace(
             '%\\\\<(?:body|ul|dl|optgroup|table|tr|hr'
                 . '|/(?:li|dd|dt|option|optgroup|caption|colgroup|thead|tbody|tfoot|tr|td|th'
                 . '|p|dl|h[1-6]|menu|ol|pre|table|ul|address|blockquote|div|fieldset|form))\\\\>%',
@@ -1288,7 +1289,7 @@ final class AbstractHtmlProcessorTest extends TestCase
      */
     private static function normalizeHtmlElement(string $html): string
     {
-        return \preg_replace(
+        return (new Preg())->replace(
             [
                 '%(<html(?=[\\s>])[^>]*+>)\\s*+(<head[\\s>])%',
                 '%(</head>)\\s*+(<body[\\s>])%',

--- a/tests/Unit/Utilities/PregTest.php
+++ b/tests/Unit/Utilities/PregTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\Utilities;
+
+use Pelago\Emogrifier\Utilities\Preg;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Pelago\Emogrifier\Utilities\Preg
+ */
+final class PregTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function throwExceptionsProvidesFluentInterface(): void
+    {
+        $subject = new Preg();
+
+        $result = $subject->throwExceptions(false);
+
+        self::assertSame($subject, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionNotThrownByDefault(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $subject = new Preg();
+
+        // Version 6 of PHPUnit allowed setting `PHPUnit\Framework\Error\Notice::$enabled` to `false`
+        // to prevent its error handler throwing exceptions upon `trigger_error`.
+        // This functionality has been removed by version 9.
+        // Version 10 allows use of the #[WithoutErrorHandler] attribute, but this requires PHP 8.0 anyway.
+        // So we must `@` to suppress the triggered error.
+        // This also means we can't test for our own triggered error, since `preg_*` also triggers an error.
+        @$subject->replace('/', '', '');
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionThrownAfterThrowExceptionsTurnedOn(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $subject = new Preg();
+
+        $subject->throwExceptions(true);
+        @$subject->replace('/', '', '');
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionNotThrownAfterThrowExceptionsTurnedOff(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $subject = new Preg();
+
+        $subject->throwExceptions(true);
+        $subject->throwExceptions(false);
+        @$subject->replace('/', '', '');
+    }
+
+    /**
+     * @return array<array<array-key, string|non-empty-array<string>|int>>
+     */
+    public function providePregReplaceArgumentsAndExpectedResult(): array
+    {
+        return [
+            'string arguments' => [
+                'pattern' => '/a/',
+                'replacement' => 'fab',
+                'subject' => 'abba',
+                'limit' => -1,
+                'expect' => 'fabbbfab',
+            ],
+            'array pattern' => [
+                'pattern' => ['/a/', '/b/'],
+                'replacement' => 'fab',
+                'subject' => 'abba',
+                'limit' => -1,
+                'expect' => 'fafabfabfabfafab',
+            ],
+            'array pattern and replacement' => [
+                'pattern' => ['/a/', '/b/'],
+                'replacement' => ['fab', 'z'],
+                'subject' => 'abba',
+                'limit' => -1,
+                'expect' => 'fazzzfaz',
+            ],
+            'with limit' => [
+                'pattern' => '/a/',
+                'replacement' => 'fab',
+                'subject' => 'abba',
+                'limit' => 1,
+                'expect' => 'fabbba',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string|non-empty-array<non-empty-string> $pattern
+     * @param string|non-empty-array<string> $replacement
+     *
+     * @dataProvider providePregReplaceArgumentsAndExpectedResult
+     */
+    public function replaceReplaces($pattern, $replacement, string $subject, int $limit, string $expectedResult): void
+    {
+        $testSubject = new Preg();
+
+        $result = $testSubject->replace($pattern, $replacement, $subject, $limit);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string|non-empty-array<non-empty-string> $pattern
+     * @param string|non-empty-array<string> $replacement
+     *
+     * @dataProvider providePregReplaceArgumentsAndExpectedResult
+     */
+    public function replaceCallbackReplaces(
+        $pattern,
+        $replacement,
+        string $subject,
+        int $limit,
+        string $expectedResult
+    ): void {
+        $callback = static function (array $matches) use ($replacement): string {
+            if (\is_array($replacement)) {
+                static $lastMatch;
+                static $replacementIndex = -1;
+                if ($matches[0] !== $lastMatch) {
+                    ++$replacementIndex;
+                    $lastMatch = $matches[0];
+                }
+                return $replacement[$replacementIndex];
+            } else {
+                return $replacement;
+            }
+        };
+        $testSubject = new Preg();
+
+        $result = $testSubject->replaceCallback($pattern, $callback, $subject, $limit);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function replaceSetsCount(): void
+    {
+        $subject = new Preg();
+
+        $subject->replace('/a/', 'fab', 'abba', -1, $count);
+
+        self::assertSame(2, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function replaceCallbackSetsCount(): void
+    {
+        $subject = new Preg();
+
+        $subject->replaceCallback(
+            '/a/',
+            static function (array $matches): string {
+                return 'fab';
+            },
+            'abba',
+            -1,
+            $count
+        );
+
+        self::assertSame(2, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function replaceReturnsSubjectOnError(): void
+    {
+        $subject = new Preg();
+
+        $result = @$subject->replace('/', 'fab', 'abba');
+
+        self::assertSame('abba', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function replaceCallbackReturnsSubjectOnError(): void
+    {
+        $subject = new Preg();
+
+        $result = @$subject->replaceCallback(
+            '/',
+            static function (array $matches): string {
+                return 'fab';
+            },
+            'abba'
+        );
+
+        self::assertSame('abba', $result);
+    }
+}

--- a/tests/Unit/Utilities/PregTest.php
+++ b/tests/Unit/Utilities/PregTest.php
@@ -15,7 +15,7 @@ final class PregTest extends TestCase
     /**
      * @var string|array<string>
      */
-    private $replaceCallbackReplacement;
+    private $replaceCallbackReplacement = '';
 
     /**
      * @var ?string
@@ -25,7 +25,7 @@ final class PregTest extends TestCase
     /**
      * @var int
      */
-    private $replaceCallbackReplacementIndex;
+    private $replaceCallbackReplacementIndex = 0;
 
     /**
      * @test


### PR DESCRIPTION
The new class uses functionality that previously existed in `CssInliner`. The `preg_replace` wrapper is extended to also support arrays as the `$pattern` and `$replacement` parameters, and to support the `$limit` and `$count` parameters.  A `preg_replace_callback` wrapper is also added.

With these methods in a separate class, they can be independently tested, which is duly done.

All calls to `preg_replace` and `preg_replace_callback` are changed to use the new class.  This resolves a number of PHPStan errors.