### PR TITLE
[CLEANUP] Add DeclarationBlockParser class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,18 +6,13 @@ parameters:
 			path: src/CssInliner.php
 
 		-
-			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/CssInliner.php
-
-		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:getAllNodesWithStyleAttribute\\(\\) return type with generic class DOMNodeList does not specify its types\\: TNode$#"
 			count: 1
 			path: src/CssInliner.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 3
+			count: 2
 			path: src/CssInliner.php
 
 		-
@@ -41,11 +36,6 @@ parameters:
 			path: src/HtmlProcessor/AbstractHtmlProcessor.php
 
 		-
-			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/HtmlProcessor/CssToAttributeConverter.php
-
-		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\CssToAttributeConverter\\:\\:getAllNodesWithStyleAttribute\\(\\) return type with generic class DOMNodeList does not specify its types\\: TNode$#"
 			count: 1
 			path: src/HtmlProcessor/CssToAttributeConverter.php
@@ -57,7 +47,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 2
+			count: 1
 			path: src/HtmlProcessor/CssToAttributeConverter.php
 
 		-

--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Utilities;
+
+/**
+ * Provides a common method for parsing CSS declaration blocks.
+ * These might be from actual CSS, or from the `style` attribute of an HTML DOM element.
+ *
+ * Caches results globally.
+ *
+ * @internal
+ */
+class DeclarationBlockParser
+{
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private static $cache = [];
+
+    /**
+     * Parses a CSS declaration block into property name/value pairs.
+     *
+     * Example:
+     *
+     * The declaration block
+     *
+     *   "color: #000; font-weight: bold;"
+     *
+     * will be parsed into the following array:
+     *
+     *   "color" => "#000"
+     *   "font-weight" => "bold"
+     *
+     * @param string $declarationBlock the CSS declarations block without the curly braces, may be empty
+     *
+     * @return array<string, string>
+     *         the CSS declarations with the property names as array keys and the property values as array values
+     */
+    public function parse(string $declarationBlock): array
+    {
+        if (isset(self::$cache[$declarationBlock])) {
+            return self::$cache[$declarationBlock];
+        }
+
+        $declarations = (new Preg())->split('/;(?!base64|charset)/', $declarationBlock);
+
+        $properties = [];
+        foreach ($declarations as $declaration) {
+            $matches = [];
+            if (
+                \preg_match(
+                    '/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s',
+                    // `$declaration` would only be an array if `PREG_SPLIT_OFFSET_CAPTURE` was used with `preg_split`,
+                    // which isn't the case
+                    \trim($declaration),
+                    $matches
+                )
+                !== 1
+            ) {
+                continue;
+            }
+
+            $propertyName = \strtolower($matches[1]);
+            $propertyValue = $matches[2];
+            $properties[$propertyName] = $propertyValue;
+        }
+        self::$cache[$declarationBlock] = $properties;
+
+        return $properties;
+    }
+}

--- a/tests/Unit/Utilities/DeclarationBlockParserTest.php
+++ b/tests/Unit/Utilities/DeclarationBlockParserTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\Utilities;
+
+use Pelago\Emogrifier\Utilities\DeclarationBlockParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Pelago\Emogrifier\Utilities\DeclarationBlockParser
+ */
+final class DeclarationBlockParserTest extends TestCase
+{
+    /**
+     * @return array<non-empty-string, array{string: string, array: array<non-empty-string, non-empty-string>}>
+     */
+    public function provideDeclratationBlockAsStringAndArray(): array
+    {
+        return [
+            'empty' => [
+                'string' => '',
+                'array' => [],
+            ],
+            'whitespace only' => [
+                'string' => " \r\n\t",
+                'array' => [],
+            ],
+            'semicolon only' => [
+                'string' => ';',
+                'array' => [],
+            ],
+            'whitespace and semicolon only' => [
+                'string' => " \r\n\t; \r\n\t",
+                'array' => [],
+            ],
+            '1 declaration without trailing semicolon' => [
+                'string' => 'color: green',
+                'array' => ['color' => 'green'],
+            ],
+            '1 declaration with trailing semicolon' => [
+                'string' => 'color: green;',
+                'array' => ['color' => 'green'],
+            ],
+            '1 declaration with leading semicolon' => [
+                'string' => '; color: green',
+                'array' => ['color' => 'green'],
+            ],
+            'declaration with space before colon' => [
+                'string' => 'color : green;',
+                'array' => ['color' => 'green'],
+            ],
+            'declaration without space after colon' => [
+                'string' => 'color:green;',
+                'array' => ['color' => 'green'],
+            ],
+            'declaration without value' => [
+                'string' => 'color: ;',
+                'array' => [],
+            ],
+            'declaration with only value' => [
+                'string' => 'red;',
+                'array' => [],
+            ],
+            'declaration without property name' => [
+                'string' => ' : red;',
+                'array' => [],
+            ],
+            '2 declarations' => [
+                'string' => 'color: green; background-color: green;',
+                'array' => ['color' => 'green', 'background-color' => 'green'],
+            ],
+            '2 declarations with extra semicolon between' => [
+                'string' => 'color: green;; background-color: green;',
+                'array' => ['color' => 'green', 'background-color' => 'green'],
+            ],
+            '2 declarations with newline between' => [
+                'string' => 'color: green;' . "\n" . 'background-color: green;',
+                'array' => ['color' => 'green', 'background-color' => 'green'],
+            ],
+            'declaration with !important' => [
+                'string' => 'color: green !important;',
+                'array' => ['color' => 'green !important'],
+            ],
+            'vendor property declaration' => [
+                'string' => '-moz-box-sizing: border-box;',
+                'array' => ['-moz-box-sizing' => 'border-box'],
+            ],
+            'custom property definition' => [
+                'string' => '--text-color: green;',
+                'array' => ['--text-color' => 'green'],
+            ],
+            'declaration using custom property' => [
+                'string' => 'color: var(--text-color);',
+                'array' => ['color' => 'var(--text-color)'],
+            ],
+            'declaration using CSS function' => [
+                'string' => 'width: calc(50% + 10vw + 10rem);',
+                'array' => ['width' => 'calc(50% + 10vw + 10rem)'],
+            ],
+            'shorthand property declaration' => [
+                'string' => 'border: 2px solid green',
+                'array' => ['border' => '2px solid green'],
+            ],
+            'declaration with text value (single quotes)' => [
+                'string' => 'content: \'Hello universe\';',
+                'array' => ['content' => '\'Hello universe\''],
+            ],
+            'declaration with text value (double quotes)' => [
+                'string' => 'content: "Hello universe";',
+                'array' => ['content' => '"Hello universe"'],
+            ],
+            'font declaration with size, line-height and family' => [
+                'string' => 'font: 1.2em/2 "Fira Sans", sans-serif;',
+                'array' => ['font' => '1.2em/2 "Fira Sans", sans-serif'],
+            ],
+            'declaration using data URL with charset' => [
+                'string' => 'text: url("data:text/plain;charset=UTF-8,Hello%20universe");',
+                'array' => ['text' => 'url("data:text/plain;charset=UTF-8,Hello%20universe")'],
+            ],
+            'declaration using data URL with base64-encoding' => [
+                'string' => 'text: url("data:;base64,SGVsbG8gdW5pdmVyc2U=");',
+                'array' => ['text' => 'url("data:;base64,SGVsbG8gdW5pdmVyc2U=")'],
+            ],
+            'declaration using data URL with charset and base64-encoding' => [
+                'string' => 'text: url("data:text/plain;charset=UTF-8;base64,SGVsbG8gdW5pdmVyc2U=");',
+                'array' => ['text' => 'url("data:text/plain;charset=UTF-8;base64,SGVsbG8gdW5pdmVyc2U=")'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param array<non-empty-string, non-empty-string> $declratationBlockAsArray
+     *
+     * @dataProvider provideDeclratationBlockAsStringAndArray
+     */
+    public function parses(string $declratationBlockAsString, array $declratationBlockAsArray): void
+    {
+        $subject = new DeclarationBlockParser();
+
+        $result = $subject->parse($declratationBlockAsString);
+
+        self::assertSame($declratationBlockAsArray, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function overridesEarlierDeclarationWithLaterOne(): void
+    {
+        $subject = new DeclarationBlockParser();
+
+        $result = $subject->parse('color: red; color: green;');
+
+        self::assertSame(['color' => 'green'], $result);
+    }
+
+    /**
+     * From a black (or orange) box point of view, the class under test may or may not implement some caching.
+     * If it does, check that the same result is obtained from a second identical request.
+     *
+     * @test
+     */
+    public function providesConsistentResults(): void
+    {
+        $subject = new DeclarationBlockParser();
+        $declarationBlock = 'color: green;';
+
+        $firstResult = $subject->parse($declarationBlock);
+        $secondResult = $subject->parse($declarationBlock);
+
+        self::assertSame($firstResult, $secondResult);
+    }
+}


### PR DESCRIPTION
This is essentially a refactoring to move the `parseCssDeclarationsBlock` method that was duplicated in both `CssInliner` and `CssToAttributeConverter` to a separate class.

As well as eliminating duplicate code/functionality, there are other benefits:
- The method can be tested independently, which is duly done;
- The results cache is now shared;
- The functionality is readily available to other classes, e.g. for the solution to #1276 (as currently proposed).

PHPStan errors from the original code have been resolved as follows:
- Use `Preg::split` to wrap `preg_split` to handle unexpected errors;
- Check the return value from `preg_match` precisely with `!== 1` instead of `!`.
  
Longer-term, we should be able to use functionality from PHP-CSS-Parser for more accurate parsing (e.g. strings containing semicolons), whereupon this class can become a wrapper for that, but currently that functionality is not available in a standalone class.