### PR TITLE
[TASK] Remove support for PREG_SPLIT_OFFSET_CAPTURE from Preg::split

### DIFF
--- a/src/Utilities/Preg.php
+++ b/src/Utilities/Preg.php
@@ -101,7 +101,7 @@ final class Preg
     public function split(string $pattern, string $subject, int $limit = -1, int $flags = 0): array
     {
         if (($flags & PREG_SPLIT_OFFSET_CAPTURE) !== 0) {
-            throw new \RuntimeException('PREG_SPLIT_OFFSET_CAPTURE is not supported by Preg::split');
+            throw new \RuntimeException('PREG_SPLIT_OFFSET_CAPTURE is not supported by Preg::split', 1726506348);
         }
 
         $result = \preg_split($pattern, $subject, $limit, $flags);

--- a/src/Utilities/Preg.php
+++ b/src/Utilities/Preg.php
@@ -89,28 +89,26 @@ final class Preg
     /**
      * Wraps `preg_split`.
      * If an error occurs, and exceptions are not being thrown,
-     * a single-element array containing the original `$subject` is returned -
-     * or if the `PREG_SPLIT_OFFSET_CAPTURE` flag was specified,
-     * the fallback return array would comprise a single element which is an array
-     * with `$subject` at index 0 and the string offset `0` at index 1.
+     * a single-element array containing the original `$subject` is returned.
+     * This method does not support the `PREG_SPLIT_OFFSET_CAPTURE` flag and will throw an excpetion if it is specified.
      *
      * @param non-empty-string $pattern
      *
-     * @return array<int, string>|array<int, array{0: string, 1: int}>
+     * @return array<int, string>
      *
      * @throws \RuntimeException
      */
     public function split(string $pattern, string $subject, int $limit = -1, int $flags = 0): array
     {
+        if (($flags & PREG_SPLIT_OFFSET_CAPTURE) !== 0) {
+            throw new \RuntimeException('PREG_SPLIT_OFFSET_CAPTURE is not supported by Preg::split');
+        }
+
         $result = \preg_split($pattern, $subject, $limit, $flags);
 
         if ($result === false) {
             $this->logOrThrowPregLastError();
-            if (($flags & PREG_SPLIT_OFFSET_CAPTURE) !== 0) {
-                $result = [[$subject, 0]];
-            } else {
-                $result = [$subject];
-            }
+            $result = [$subject];
         }
 
         return $result;

--- a/tests/Unit/Utilities/PregTest.php
+++ b/tests/Unit/Utilities/PregTest.php
@@ -265,21 +265,13 @@ final class PregTest extends TestCase
                 'flags' => 0,
                 'expect' => ['', 'bba'],
             ],
-            // It is only necessary to test that the `$flags` parameter is passed on...
+            // It is only necessary to test that the `$flags` parameter is passed on.
             'with PREG_SPLIT_NO_EMPTY' => [
                 'pattern' => '/a/',
                 'subject' => 'abba',
                 'limit' => -1,
                 'flags' => PREG_SPLIT_NO_EMPTY,
                 'expect' => ['bb'],
-            ],
-            // ...but worth testing `PREG_SPLIT_OFFSET_CAPTURE` because that changes the return type
-            'with PREG_SPLIT_OFFSET_CAPTURE' => [
-                'pattern' => '/a/',
-                'subject' => 'abba',
-                'limit' => -1,
-                'flags' => PREG_SPLIT_OFFSET_CAPTURE,
-                'expect' => [['', 0], ['bb', 1], ['', 4]],
             ],
         ];
     }
@@ -346,13 +338,12 @@ final class PregTest extends TestCase
     /**
      * @test
      */
-    public function splitWithOffsetCaptureReturnsArrayContainingArrayWithSubjectAndZeroOffsetOnError(): void
+    public function splitWithOffsetCaptureIsNotSupported(): void
     {
+        $this->expectException(\RuntimeException::class);
         $subject = new Preg();
 
         $result = @$subject->split('/', 'abba', -1, PREG_SPLIT_OFFSET_CAPTURE);
-
-        self::assertSame([['abba', 0]], $result);
     }
 
     /**

--- a/tests/Unit/Utilities/PregTest.php
+++ b/tests/Unit/Utilities/PregTest.php
@@ -341,6 +341,8 @@ final class PregTest extends TestCase
     public function splitWithOffsetCaptureIsNotSupported(): void
     {
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1726506348);
+        $this->expectExceptionMessage('PREG_SPLIT_OFFSET_CAPTURE');
         $subject = new Preg();
 
         $result = @$subject->split('/', 'abba', -1, PREG_SPLIT_OFFSET_CAPTURE);


### PR DESCRIPTION
This flag is not used anywhere in the current code base.  It causes complications with static analysis due to its introduction of a dynamic return type for `preg_split`, which would require a PHPStan extension to properly solve (and which assumes PHPStan would always be used as the static analysis tool).