### PR TITLE
[CLEANUP] Use Preg::split to handle unexpected preg_split errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,7 +7,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
+			count: 1
 			path: src/CssInliner.php
 
 		-
@@ -23,11 +23,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 2
-			path: src/CssInliner.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of function array_map expects array, array\\<int, string\\>\\|false given\\.$#"
-			count: 1
 			path: src/CssInliner.php
 
 		-
@@ -82,11 +77,6 @@ parameters:
 
 		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\HtmlPruner\\:\\:removeClassesFromElements\\(\\) has parameter \\$elements with generic class DOMNodeList but does not specify its types\\: TNode$#"
-			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of method Pelago\\\\Emogrifier\\\\Utilities\\\\ArrayIntersector\\:\\:intersectWith\\(\\) expects array\\<\\(int\\|string\\)\\>, array\\<int, string\\>\\|false given\\.$#"
 			count: 1
 			path: src/HtmlProcessor/HtmlPruner.php
 

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -693,7 +693,8 @@ class CssInliner extends AbstractHtmlProcessor
             return false;
         }
 
-        foreach (\preg_split('/' . self::COMBINATOR_MATCHER . '/', $selector) as $selectorPart) {
+        $preg = (new Preg())->throwExceptions($this->debug);
+        foreach ($preg->split('/' . self::COMBINATOR_MATCHER . '/', $selector) as $selectorPart) {
             if ($this->selectorPartHasUnsupportedOfTypePseudoClass($selectorPart)) {
                 return true;
             }
@@ -1053,7 +1054,7 @@ class CssInliner extends AbstractHtmlProcessor
             function (string $selectorPart): string {
                 return $this->removeUnsupportedOfTypePseudoClasses($selectorPart);
             },
-            \preg_split(
+            (new Preg())->throwExceptions($this->debug)->split(
                 '/(' . self::COMBINATOR_MATCHER . ')/',
                 $selectorWithoutUnmatchablePseudoComponents,
                 -1,

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -291,8 +291,7 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      */
     private function parseCssShorthandValue(string $value): array
     {
-        /** @var array<int, string> $values */
-        $values = \preg_split('/\\s+/', $value);
+        $values = (new Preg())->split('/\\s+/', $value);
 
         $css = [];
         $css['top'] = $values[0];

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -6,6 +6,7 @@ namespace Pelago\Emogrifier\HtmlProcessor;
 
 use Pelago\Emogrifier\CssInliner;
 use Pelago\Emogrifier\Utilities\ArrayIntersector;
+use Pelago\Emogrifier\Utilities\Preg;
 
 /**
  * This class can remove things from HTML.
@@ -84,9 +85,10 @@ class HtmlPruner extends AbstractHtmlProcessor
     {
         $classesToKeepIntersector = new ArrayIntersector($classesToKeep);
 
+        $preg = new Preg();
         /** @var \DOMElement $element */
         foreach ($elements as $element) {
-            $elementClasses = \preg_split('/\\s++/', \trim($element->getAttribute('class')));
+            $elementClasses = $preg->split('/\\s++/', \trim($element->getAttribute('class')));
             $elementClassesToKeep = $classesToKeepIntersector->intersectWith($elementClasses);
             if ($elementClassesToKeep !== []) {
                 $element->setAttribute('class', \implode(' ', $elementClassesToKeep));


### PR DESCRIPTION
This resolves three PHPStan errors.

Instances of calls to `preg_split` in the two (identical) `parseCssDeclarationsBlock` methods are not updated - those are covered separately by #1311.