### PR TITLE
[CLEANUP] Remove an impossible `throw`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,18 +129,3 @@ parameters:
 			message: "#^Variable \\$classAttributeMatches in PHPDoc tag @var does not match any variable in the foreach loop\\: \\$classAttributeValue$#"
 			count: 1
 			path: tests/Unit/HtmlProcessor/HtmlPrunerTest.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\<string, T\\> and false will always evaluate to false\\.$#"
-			count: 1
-			path: tests/Unit/Support/Constraint/IsEquivalentCssTest.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\<string, T\\> and false will always evaluate to false\\.$#"
-			count: 1
-			path: tests/Unit/Support/Constraint/StringContainsCssCountTest.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\<string, T\\> and false will always evaluate to false\\.$#"
-			count: 1
-			path: tests/Unit/Support/Constraint/StringContainsCssTest.php

--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -354,17 +354,9 @@ trait CssDataProviders
      * @param array<string, T> $array
      *
      * @return array<string, T>
-     *
-     * @throws \RuntimeException
      */
     private static function arrayMapKeys(callable $callback, array $array): array
     {
-        $result = \array_combine(\array_map($callback, \array_keys($array)), \array_values($array));
-
-        if ($result === false) {
-            throw new \RuntimeException('`array_keys` and `array_values` did not give equal-length arrays', 1619201107);
-        }
-
-        return $result;
+        return \array_combine(\array_map($callback, \array_keys($array)), \array_values($array));
     }
 }


### PR DESCRIPTION
PHPStan is able to determine that `array_combine` when passed the results of `array_keys` and `array_values` for the same array can never fail (in the sense of returning `false`), because the two passed arrays will always be the same length.

Psalm could not, which was why the return value check and `throw` was originally put in.