### PR TITLE
[CLEANUP] Add `CssInliner::querySelectorAll` method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,7 +2,7 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:getAllNodesWithStyleAttribute\\(\\) return type with generic class DOMNodeList does not specify its types\\: TNode$#"
-			count: 1
+			count: 2
 			path: src/CssInliner.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Argument of an invalid type DOMNodeList\\<DOMNode\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: src/CssInliner.php
-
-		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:getAllNodesWithStyleAttribute\\(\\) return type with generic class DOMNodeList does not specify its types\\: TNode$#"
 			count: 1
 			path: src/CssInliner.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,7 +2,7 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\CssInliner\\:\\:getAllNodesWithStyleAttribute\\(\\) return type with generic class DOMNodeList does not specify its types\\: TNode$#"
-			count: 2
+			count: 1
 			path: src/CssInliner.php
 
 		-

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -533,18 +533,20 @@ class CssInliner extends AbstractHtmlProcessor
             }
 
             return $result;
-        } catch (ParseException|\RuntimeException $exception) {
+        } catch (ParseException $exception) {
+            $alwaysThrowParseException = $options[self::QSA_ALWAYS_THROW_PARSE_EXCEPTION] ?? false;
+            if ($this->debug || $alwaysThrowParseException) {
+                throw $exception;
+            }
+            return new \DOMNodeList();
+        } catch (\RuntimeException $exception) {
             if (
                 $this->debug
-                || ($options[self::QSA_ALWAYS_THROW_PARSE_EXCEPTION] ?? false) && $exception instanceof ParseException
             ) {
                 throw $exception;
             }
-            // In non-debug mode, `ParseException`s are silently ignored, whereas `RuntimeException`s (indicating a bug
-            // in CssSelector) have their message passed to the error handler (for logging or custom handling).
-            if ($exception instanceof \RuntimeException) {
-                \trigger_error($exception->getMessage());
-            }
+            // `RuntimeException` indicates a bug in CssSelector so pass the message to the error handler.
+            \trigger_error($exception->getMessage());
             return new \DOMNodeList();
         }
     }

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -54,6 +54,13 @@ class CssInliner extends AbstractHtmlProcessor
     private const COMBINATOR_MATCHER = '(?:\\s++|\\s*+[>+~]\\s*+)(?=[[:alpha:]_\\-.#*:\\[])';
 
     /**
+     * options array key for `querySelectorAll`
+     *
+     * @var string
+     */
+    private const QSA_ALWAYS_THROW_PARSE_EXCEPTION = 'alwaysThrowParseException';
+
+    /**
      * @var array<string, bool>
      */
     private $excludedSelectors = [];
@@ -164,7 +171,11 @@ class CssInliner extends AbstractHtmlProcessor
      * @return $this
      *
      * @throws ParseException in debug mode, if an invalid selector is encountered
-     * @throws \RuntimeException in debug mode, if an internal PCRE error occurs
+     * @throws \RuntimeException
+     *         in debug mode, if an internal PCRE error occurs
+     *         or `CssSelectorConverter::toXPath` returns an invalid XPath expression
+     * @throws \UnexpectedValueException
+     *         if a selector query result includes a node which is not a `DOMElement`
      */
     public function inlineCss(string $css = ''): self
     {
@@ -183,23 +194,12 @@ class CssInliner extends AbstractHtmlProcessor
 
         $excludedNodes = $this->getNodesToExclude();
         $cssRules = $this->collateCssRules($parsedCss);
-        $cssSelectorConverter = $this->getCssSelectorConverter();
         foreach ($cssRules['inlinable'] as $cssRule) {
-            try {
-                $nodesMatchingCssSelectors = $this->getXPath()
-                    ->query($cssSelectorConverter->toXPath($cssRule['selector']));
-
-                /** @var \DOMElement $node */
-                foreach ($nodesMatchingCssSelectors as $node) {
-                    if (\in_array($node, $excludedNodes, true)) {
-                        continue;
-                    }
-                    $this->copyInlinableCssToStyleAttribute($node, $cssRule);
+            foreach ($this->querySelectorAll($cssRule['selector']) as $node) {
+                if (\in_array($node, $excludedNodes, true)) {
+                    continue;
                 }
-            } catch (ParseException $e) {
-                if ($this->debug) {
-                    throw $e;
-                }
+                $this->copyInlinableCssToStyleAttribute($this->ensureNodeIsElement($node), $cssRule);
             }
         }
 
@@ -496,32 +496,70 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @return list<\DOMElement>
      *
-     * @throws ParseException
-     * @throws \UnexpectedValueException
+     * @throws ParseException in debug mode, if an invalid selector is encountered
+     * @throws \RuntimeException in debug mode, if `CssSelectorConverter::toXPath` returns an invalid XPath expression
+     * @throws \UnexpectedValueException if the selector query result includes a node which is not a `DOMElement`
      */
     private function getNodesToExclude(): array
     {
         $excludedNodes = [];
         foreach (\array_keys($this->excludedSelectors) as $selectorToExclude) {
-            try {
-                $matchingNodes = $this->getXPath()
-                    ->query($this->getCssSelectorConverter()->toXPath($selectorToExclude));
-
-                foreach ($matchingNodes as $node) {
-                    if (!$node instanceof \DOMElement) {
-                        $path = $node->getNodePath() ?? '$node';
-                        throw new \UnexpectedValueException($path . ' is not a DOMElement.', 1617975914);
-                    }
-                    $excludedNodes[] = $node;
-                }
-            } catch (ParseException $e) {
-                if ($this->debug) {
-                    throw $e;
-                }
+            foreach ($this->querySelectorAll($selectorToExclude) as $node) {
+                $excludedNodes[] = $this->ensureNodeIsElement($node);
             }
         }
 
         return $excludedNodes;
+    }
+
+    /**
+     * @param array{}|array{alwaysThrowParseException: bool} $options
+     *        This is an array of option values to control behaviour:
+     *        - `QSA_ALWAYS_THROW_PARSE_EXCEPTION` - `bool` - throw any `ParseException` regardless of debug setting.
+     *
+     * @return \DOMNodeList<\DOMNode> the HTML elements that match the provided CSS `$selectors`
+     *
+     * @throws ParseException
+     *         in debug mode (or with `QSA_ALWAYS_THROW_PARSE_EXCEPTION` option), if an invalid selector is encountered
+     * @throws \RuntimeException in debug mode, if `CssSelectorConverter::toXPath` returns an invalid XPath expression
+     */
+    private function querySelectorAll(string $selectors, array $options = []): \DOMNodeList
+    {
+        try {
+            $result = $this->getXPath()->query($this->getCssSelectorConverter()->toXPath($selectors));
+
+            if ($result === false) {
+                throw new \RuntimeException('query failed with selector \'' . $selectors . '\'', 1726533051);
+            }
+
+            return $result;
+        } catch (ParseException|\RuntimeException $exception) {
+            if (
+                $this->debug
+                || ($options[self::QSA_ALWAYS_THROW_PARSE_EXCEPTION] ?? false) && $exception instanceof ParseException
+            ) {
+                throw $exception;
+            }
+            // In non-debug mode, `ParseException`s are silently ignored, whereas `RuntimeException`s (indicating a bug
+            // in CssSelector) have their message passed to the error handler (for logging or custom handling).
+            if ($exception instanceof \RuntimeException) {
+                \trigger_error($exception->getMessage());
+            }
+            return new \DOMNodeList();
+        }
+    }
+
+    /**
+     * @throws \UnexpectedValueException if `$node` is not a `DOMElement`
+     */
+    private function ensureNodeIsElement(\DOMNode $node): \DOMElement
+    {
+        if (!$node instanceof \DOMElement) {
+            $path = $node->getNodePath() ?? '$node';
+            throw new \UnexpectedValueException($path . ' is not a DOMElement.', 1617975914);
+        }
+
+        return $node;
     }
 
     /**
@@ -952,12 +990,14 @@ class CssInliner extends AbstractHtmlProcessor
      *
      * @return bool
      *
-     * @throws ParseException
+     * @throws ParseException in debug mode, if an invalid selector is encountered
+     * @throws \RuntimeException in debug mode, if `CssSelectorConverter::toXPath` returns an invalid XPath expression
      */
     private function existsMatchForCssSelector(string $cssSelector): bool
     {
         try {
-            $nodesMatchingSelector = $this->getXPath()->query($this->getCssSelectorConverter()->toXPath($cssSelector));
+            $nodesMatchingSelector
+                = $this->querySelectorAll($cssSelector, [self::QSA_ALWAYS_THROW_PARSE_EXCEPTION => true]);
         } catch (ParseException $e) {
             if ($this->debug) {
                 throw $e;
@@ -965,7 +1005,7 @@ class CssInliner extends AbstractHtmlProcessor
             return true;
         }
 
-        return $nodesMatchingSelector !== false && $nodesMatchingSelector->length !== 0;
+        return $nodesMatchingSelector->length !== 0;
     }
 
     /**


### PR DESCRIPTION
This `private` method provides functionality that is used in three separate places (albeit a one-liner), and includes taking care of exception handling according to the debug mode setting.

The new method and parameter names match the equivalent in the [Web API](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll).

There will be a tiny performance impact due to additional method calls.  But the benefits include code re-use and common error handling.

Also add `ensureNodeIsElement` method for use with the result from `querySelectorAll` to ensure type safety.  `querySelectorAll` should always return a `DOMNodeList` of `DOMElement`s.  But this cannot be guaranteed if there is a bug in CssSelector whereby it returns an XPath expression which may match non-element nodes.  And it would (probably) be sub-optimal for `querySelectorAll` to have an extra loop checking this, when it can be done in the caller's loop over the returned data.