### PR TITLE
[CLEANUP] Remove inapplicable comment in DeclarationBlockParser::parse

### DIFF
--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -52,8 +52,6 @@ class DeclarationBlockParser
             if (
                 \preg_match(
                     '/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s',
-                    // `$declaration` would only be an array if `PREG_SPLIT_OFFSET_CAPTURE` was used with `preg_split`,
-                    // which isn't the case
                     \trim($declaration),
                     $matches
                 )


### PR DESCRIPTION
This was added during development while `Preg::split` supported `PREG_SPLIT_OFFSET_CAPTURE` and thus could return an array of arrays, and the code contained a check for this.  But before #1311 was completed, #1313 was implemented to avoid the headache of a dynamic return type.  The check was removed, but not the corresponding comment explaining it.