### PR TITLE
[CLEANUP] Use valid example in PregTest for split with offset capture

### DIFF
--- a/tests/Unit/Utilities/PregTest.php
+++ b/tests/Unit/Utilities/PregTest.php
@@ -345,7 +345,7 @@ final class PregTest extends TestCase
         $this->expectExceptionMessage('PREG_SPLIT_OFFSET_CAPTURE');
         $subject = new Preg();
 
-        $result = @$subject->split('/', 'abba', -1, PREG_SPLIT_OFFSET_CAPTURE);
+        $result = $subject->split('/a/', 'abba', -1, PREG_SPLIT_OFFSET_CAPTURE);
     }
 
     /**


### PR DESCRIPTION
Also remove the error suppression operator.

This was overlooked #1313 when a new test method replaced another, but retained some of its code.