### PR TITLE
[CLEANUP] Use Preg::match to handle unexpected preg_match errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,21 +6,6 @@ parameters:
 			path: src/CssInliner.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
-			count: 2
-			path: src/CssInliner.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 2
-			path: src/CssInliner.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
-
-		-
 			message: "#^Parameter \\#1 \\$html of method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\AbstractHtmlProcessor\\:\\:removeSelfClosingTagsClosingTags\\(\\) expects string, string\\|false given\\.$#"
 			count: 2
 			path: src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -37,11 +22,6 @@ parameters:
 
 		-
 			message: "#^Method Pelago\\\\Emogrifier\\\\HtmlProcessor\\\\CssToAttributeConverter\\:\\:getAllNodesWithStyleAttribute\\(\\) should return DOMNodeList but returns DOMNodeList\\<DOMNode\\>\\|false\\.$#"
-			count: 1
-			path: src/HtmlProcessor/CssToAttributeConverter.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: src/HtmlProcessor/CssToAttributeConverter.php
 
@@ -89,11 +69,6 @@ parameters:
 			message: "#^Property object\\{selectorsAsKeys\\: array\\<string, \\(int\\|string\\)\\>, declarationsBlock\\: string\\}\\:\\:\\$selectorsAsKeys is not writable\\.$#"
 			count: 1
 			path: src/Utilities/CssConcatenator.php
-
-		-
-			message: "#^Offset 0 does not exist on array\\{0\\?\\: string\\}\\.$#"
-			count: 1
-			path: tests/Unit/Css/CssDocumentTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function trim expects string, string\\|false given\\.$#"

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Css;
 
+use Pelago\Emogrifier\Utilities\Preg;
 use Sabberworm\CSS\CSSList\AtRuleBlockList as CssAtRuleBlockList;
 use Sabberworm\CSS\CSSList\Document as SabberwormCssDocument;
 use Sabberworm\CSS\Parser as CssParser;
@@ -61,7 +62,8 @@ class CssDocument
      */
     private function hasNestedAtRule(string $css): bool
     {
-        return \preg_match('/@(?:media|supports|(?:-webkit-|-moz-|-ms-|-o-)?+(keyframes|document))\\b/', $css) === 1;
+        return (new Preg())
+            ->match('/@(?:media|supports|(?:-webkit-|-moz-|-ms-|-o-)?+(keyframes|document))\\b/', $css) !== 0;
     }
 
     /**
@@ -140,7 +142,8 @@ class CssDocument
                     $allowedMediaTypes
                 );
                 $mediaTypesMatcher = \implode('|', $escapedAllowedMediaTypes);
-                $isAllowed = \preg_match('/^\\s*+(?:only\\s++)?+(?:' . $mediaTypesMatcher . ')/i', $mediaType) > 0;
+                $isAllowed
+                    = (new Preg())->match('/^\\s*+(?:only\\s++)?+(?:' . $mediaTypesMatcher . ')/i', $mediaType) !== 0;
             } else {
                 $isAllowed = true;
             }

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -315,7 +315,7 @@ abstract class AbstractHtmlProcessor
 
         // We are trying to insert the meta tag to the right spot in the DOM.
         // If we just prepended it to the HTML, we would lose attributes set to the HTML tag.
-        $hasHeadTag = \preg_match('/<head[\\s>]/i', $html);
+        $hasHeadTag = (new Preg())->match('/<head[\\s>]/i', $html) !== 0;
         $hasHtmlTag = \stripos($html, '<html') !== false;
 
         if ($hasHeadTag) {
@@ -348,7 +348,11 @@ abstract class AbstractHtmlProcessor
      */
     private function hasContentTypeMetaTagInHead(string $html): bool
     {
-        \preg_match('%^.*?(?=<meta(?=\\s)[^>]*\\shttp-equiv=(["\']?+)Content-Type\\g{-1}[\\s/>])%is', $html, $matches);
+        (new Preg())->match(
+            '%^.*?(?=<meta(?=\\s)[^>]*\\shttp-equiv=(["\']?+)Content-Type\\g{-1}[\\s/>])%is',
+            $html,
+            $matches
+        );
         if (isset($matches[0])) {
             $htmlBefore = $matches[0];
             try {
@@ -378,9 +382,10 @@ abstract class AbstractHtmlProcessor
      */
     private function hasEndOfHeadElement(string $html): bool
     {
-        $headEndTagMatchCount
-            = \preg_match('%<(?!' . self::TAGNAME_ALLOWED_BEFORE_BODY_MATCHER . '[\\s/>])\\w|</head>%i', $html);
-        if (\is_int($headEndTagMatchCount) && $headEndTagMatchCount > 0) {
+        if (
+            (new Preg())->match('%<(?!' . self::TAGNAME_ALLOWED_BEFORE_BODY_MATCHER . '[\\s/>])\\w|</head>%i', $html)
+            !== 0
+        ) {
             // An exception to the implicit end of the `<head>` is any content within a `<template>` element, as well in
             // comments.  As an optimization, this is only checked for if a potential `<head>` end tag is found.
             $htmlWithoutCommentsOrTemplates = $this->removeHtmlTemplateElements($this->removeHtmlComments($html));

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -185,12 +185,14 @@ class CssToAttributeConverter extends AbstractHtmlProcessor
      */
     private function mapWidthOrHeightProperty(\DOMElement $node, string $value, string $property): void
     {
+        $preg = new Preg();
+
         // only parse values in px and %, but not values like "auto"
-        if (!\preg_match('/^(\\d+)(\\.(\\d+))?(px|%)$/', $value)) {
+        if ($preg->match('/^(\\d+)(\\.(\\d+))?(px|%)$/', $value) === 0) {
             return;
         }
 
-        $number = (new Preg())->replace('/[^0-9.%]/', '', $value);
+        $number = $preg->replace('/[^0-9.%]/', '', $value);
         $node->setAttribute($property, $number);
     }
 

--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -44,18 +44,20 @@ class DeclarationBlockParser
             return self::$cache[$declarationBlock];
         }
 
-        $declarations = (new Preg())->split('/;(?!base64|charset)/', $declarationBlock);
+        $preg = new Preg();
+
+        $declarations = $preg->split('/;(?!base64|charset)/', $declarationBlock);
 
         $properties = [];
         foreach ($declarations as $declaration) {
             $matches = [];
             if (
-                \preg_match(
+                $preg->match(
                     '/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s',
                     \trim($declaration),
                     $matches
                 )
-                !== 1
+                === 0
             ) {
                 continue;
             }

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -214,10 +214,11 @@ abstract class CssConstraint extends Constraint
      */
     private static function getCssMatcherAllowingOptionalTrailingSemicolon(string $matcher, string $css): string
     {
-        $isPropertyDeclarationsOnly = \strpos($css, ':') !== false && \preg_match('/[@\\{\\}]/', $css) === 0;
+        $preg = new Preg();
 
+        $isPropertyDeclarationsOnly = \strpos($css, ':') !== false && $preg->match('/[@\\{\\}]/', $css) === 0;
         if ($isPropertyDeclarationsOnly) {
-            return (new Preg())->replace(
+            return $preg->replace(
                 self::OPTIONAL_TRAILING_SEMICOLON_MATCHER_PATTERN,
                 '(?:\\s*+;)?+',
                 $matcher

--- a/tests/Support/Constraint/IsEquivalentCss.php
+++ b/tests/Support/Constraint/IsEquivalentCss.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Support\Constraint;
 
+use Pelago\Emogrifier\Utilities\Preg;
+
 /**
  * This constraint asserts that the string it is evaluated for is equivalent to some specific CSS, allowing for cosmetic
  * whitespace differences.
@@ -54,6 +56,6 @@ final class IsEquivalentCss extends CssConstraint
             return false;
         }
 
-        return \preg_match($this->cssPattern, $other) > 0;
+        return (new Preg())->match($this->cssPattern, $other) !== 0;
     }
 }

--- a/tests/Support/Constraint/StringContainsCss.php
+++ b/tests/Support/Constraint/StringContainsCss.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Support\Constraint;
 
+use Pelago\Emogrifier\Utilities\Preg;
+
 /**
  * This constraint asserts that the string it is evaluated for contains some specific CSS, allowing for cosmetic
  * whitespace differences.
@@ -54,6 +56,6 @@ final class StringContainsCss extends CssConstraint
             return false;
         }
 
-        return \preg_match($this->cssPattern, $other) > 0;
+        return (new Preg())->match($this->cssPattern, $other) !== 0;
     }
 }

--- a/tests/Unit/Css/CssDocumentTest.php
+++ b/tests/Unit/Css/CssDocumentTest.php
@@ -6,6 +6,7 @@ namespace Pelago\Emogrifier\Tests\Unit\Css;
 
 use Pelago\Emogrifier\Css\CssDocument;
 use Pelago\Emogrifier\Tests\Support\Traits\AssertCss;
+use Pelago\Emogrifier\Utilities\Preg;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
@@ -531,7 +532,7 @@ final class CssDocumentTest extends TestCase
 
         $result = $subject->renderNonConditionalAtRules();
 
-        \preg_match('/@[\\w\\-]++/', $atRuleCss, $atAndRuleNameMatches);
+        (new Preg())->match('/@[\\w\\-]++/', $atRuleCss, $atAndRuleNameMatches);
         $atAndRuleName = $atAndRuleNameMatches[0];
         self::assertStringNotContainsString($atAndRuleName, $result);
     }


### PR DESCRIPTION
For consistency with the return value being the number of matches, even though (unlike with `preg_match_all`) it can only be 0 or 1, code instances testing the result are changed to always use `=== 0` or `!== 0`.

This resolves several PHPStan errors.