### PR TITLE
[TASK] Add `AbstractHtmlProcessor::getHtmlElement()`

### DIFF
--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -198,6 +198,23 @@ abstract class AbstractHtmlProcessor
     }
 
     /**
+     * Returns the HTML element.
+     *
+     * This method assumes that there always is an HTML element, throwing an exception otherwise.
+     *
+     * @throws \UnexpectedValueException
+     */
+    protected function getHtmlElement(): \DOMElement
+    {
+        $htmlElement = $this->getDomDocument()->getElementsByTagName('html')->item(0);
+        if (!$htmlElement instanceof \DOMElement) {
+            throw new \UnexpectedValueException('There is no HTML element although there should be one.', 1569930853);
+        }
+
+        return $htmlElement;
+    }
+
+    /**
      * Returns the BODY element.
      *
      * This method assumes that there always is a BODY element.
@@ -456,10 +473,6 @@ abstract class AbstractHtmlProcessor
             return;
         }
 
-        $htmlElement = $this->getDomDocument()->getElementsByTagName('html')->item(0);
-        if (!$htmlElement instanceof \DOMElement) {
-            throw new \UnexpectedValueException('There is no HTML element although there should be one.', 1569930853);
-        }
-        $htmlElement->appendChild($this->getDomDocument()->createElement('body'));
+        $this->getHtmlElement()->appendChild($this->getDomDocument()->createElement('body'));
     }
 }

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -62,6 +62,18 @@ final class AbstractHtmlProcessorTest extends TestCase
     /**
      * @test
      */
+    public function getHtmlElementReturnsHtmlElement(): void
+    {
+        $subject = TestingHtmlProcessor::fromHtml('<html><head></head><body><p></p></body></html>');
+
+        $result = $subject->callGetHtmlElement();
+
+        self::assertSame('html', $result->tagName);
+    }
+
+    /**
+     * @test
+     */
     public function renderRendersDocumentProvidedToFromDomDocument(): void
     {
         $innerHtml = '<p>Hello world!</p>';

--- a/tests/Unit/HtmlProcessor/Fixtures/TestingHtmlProcessor.php
+++ b/tests/Unit/HtmlProcessor/Fixtures/TestingHtmlProcessor.php
@@ -9,4 +9,10 @@ use Pelago\Emogrifier\HtmlProcessor\AbstractHtmlProcessor;
 /**
  * Fixture class for AbstractHtmlProcessor.
  */
-final class TestingHtmlProcessor extends AbstractHtmlProcessor {}
+final class TestingHtmlProcessor extends AbstractHtmlProcessor
+{
+    public function callGetHtmlElement(): \DOMElement
+    {
+        return $this->getHtmlElement();
+    }
+}


### PR DESCRIPTION
This is `protected` so that it can be used by subclasses, e.g. for iterating the DOM tree (which is likely for #1276).