### PR TITLE
[FEATURE] Support CSS custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please also have a look at our
 
 ### Added
 
+- Support CSS custom properties (variables) (#1336)
 - Support `:root` pseudo-class (#1306)
 - Add CSS selectors exclusion feature (#1236)
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ After `CssInliner` has inlined that CSS on the (contrived) HTML
         <p style="color: var(--text-color);">
         <p>
     </body>
-    </htm>
+</html>
 ```
 
 The `CssVariableEvaluator` method `evaluateVariables` will apply the value of

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ $visualHtml = CssToAttributeConverter::fromDomDocument($domDocument)
 ### Evaluating CSS custom properties (variables)
 
 The `CssVariableEvaluator` class can be used to apply the values of CSS
-variables which are defined in inline style attributes to inline style
-properties which use them.
+variables defined in inline style attributes to inline style properties which
+use them.
 
 For example, the following CSS defines and uses a custom property:
 
@@ -189,7 +189,7 @@ After `CssInliner` has inlined that CSS on the (contrived) HTML
 ```
 
 The `CssVariableEvaluator` method `evaluateVariables` will apply the value of
-`--text-color` so that the paragraph `style` attribute becomes `color: green`.
+`--text-color` so that the paragraph `style` attribute becomes `color: green;`.
 
 It can be used like this:
 
@@ -199,14 +199,14 @@ use Pelago\Emogrifier\HtmlProcessor\CssVariableEvaluator;
 …
 
 $evaluatedHtml = CssVariableEvaluator::fromHtml($html)
-  ->evaluateVariables ->render();
+  ->evaluateVariables()->render();
 ```
 
 You can also have the ` CssVariableEvaluator ` work on a `DOMDocument`:
 
 ```php
 $evaluatedHtml = CssVariableEvaluator::fromDomDocument($domDocument)
-  ->evaluateVariables ()->render();
+  ->evaluateVariables()->render();
 ```
 
 ### Removing redundant content and attributes from the HTML
@@ -446,8 +446,11 @@ They will, however, be preserved and copied to a `<style>` element in the HTML:
     }
   }
   ```
-  Any CSS variables defined in `@media` rules will not be applied to CSS
-  property values that have been inlined and evaluated.
+  Any CSS custom properties (variables) defined in `@media` rules cannot be
+  applied to CSS property values that have been inlined and evaluated. However,
+  `@media` rules using custom properties (with `var()`) would still be able to
+  obtain their values (from the inlined definitions or `@media` rules) in email
+  clients that support custom properties.
 * Emogrifier cannot inline CSS rules involving selectors with pseudo-elements
   (such as `::after`) or dynamic pseudo-classes (such as `:hover`) – it is
   impossible. However, such rules will be preserved and copied to a `<style>`

--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ For example, the following CSS defines and uses a custom property:
 
 ```css
 :root {
-  --text-color: green;
+    --text-color: green;
 }
+
 p {
-  color: var(--text-color);
+    color: var(--text-color);
 }
 ```
 
@@ -180,12 +181,13 @@ After `CssInliner` has inlined that CSS on the (contrived) HTML
 `<html><body><p></p></body></html>`, it will look like this:
 
 ```html
+
 <html style="--text-color: green;">
-  <body>
-    <p style="color: var(--text-color);">
-    <p>
-  </body>
-</htm>
+    <body>
+        <p style="color: var(--text-color);">
+        <p>
+    </body>
+    </htm>
 ```
 
 The `CssVariableEvaluator` method `evaluateVariables` will apply the value of

--- a/README.md
+++ b/README.md
@@ -159,6 +159,56 @@ $visualHtml = CssToAttributeConverter::fromDomDocument($domDocument)
   ->convertCssToVisualAttributes()->render();
 ```
 
+### Evaluating CSS custom properties (variables)
+
+The `CssVariableEvaluator` class can be used to apply the values of CSS
+variables which are defined in inline style attributes to inline style
+properties which use them.
+
+For example, the following CSS defines and uses a custom property:
+
+```css
+:root {
+  --text-color: green;
+}
+p {
+  color: var(--text-color);
+}
+```
+
+After `CssInliner` has inlined that CSS on the (contrived) HTML
+`<html><body><p></p></body></html>`, it will look like this:
+
+```html
+<html style="--text-color: green;">
+  <body>
+    <p style="color: var(--text-color);">
+    <p>
+  </body>
+</htm>
+```
+
+The `CssVariableEvaluator` method `evaluateVariables` will apply the value of
+`--text-color` so that the paragraph `style` attribute becomes `color: green`.
+
+It can be used like this:
+
+```php
+use Pelago\Emogrifier\HtmlProcessor\CssVariableEvaluator;
+
+…
+
+$evaluatedHtml = CssVariableEvaluator::fromHtml($html)
+  ->evaluateVariables ->render();
+```
+
+You can also have the ` CssVariableEvaluator ` work on a `DOMDocument`:
+
+```php
+$evaluatedHtml = CssVariableEvaluator::fromDomDocument($domDocument)
+  ->evaluateVariables ()->render();
+```
+
 ### Removing redundant content and attributes from the HTML
 
 The `HtmlPruner` class can reduce the size of the HTML by removing elements with
@@ -396,11 +446,12 @@ They will, however, be preserved and copied to a `<style>` element in the HTML:
     }
   }
   ```
+  Any CSS variables defined in `@media` rules will not be applied to CSS
+  property values that have been inlined and evaluated.
 * Emogrifier cannot inline CSS rules involving selectors with pseudo-elements
   (such as `::after`) or dynamic pseudo-classes (such as `:hover`) – it is
   impossible. However, such rules will be preserved and copied to a `<style>`
-  element, as for `@media` rules. The same caveat about the possible need for
-  the `!important` directive also applies with pseudo-classes.
+  element, as for `@media` rules, with the same caveats applying.
 * Emogrifier will grab existing inline style attributes _and_ will
   grab `<style>` blocks from your HTML, but it will not grab CSS files
   referenced in `<link>` elements or `@import` rules (though it will leave them

--- a/config/phpmd.xml
+++ b/config/phpmd.xml
@@ -7,7 +7,12 @@
     <!-- The commented-out rules will be enabled once the code does not generate any warnings anymore. -->
 
     <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
-    <rule ref="rulesets/cleancode.xml/StaticAccess"/>
+    <rule ref="rulesets/cleancode.xml/StaticAccess">
+        <properties>
+            <!-- Avoid false positives when calling factory methods -->
+            <property name="ignorepattern" value="/^from/" />
+        </properties>
+    </rule>
 
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
     <rule ref="rulesets/codesize.xml/NPathComplexity"/>

--- a/src/HtmlProcessor/CssVariableEvaluator.php
+++ b/src/HtmlProcessor/CssVariableEvaluator.php
@@ -186,8 +186,10 @@ class CssVariableEvaluator extends AbstractHtmlProcessor
             $variableDefinitions = $ancestorVariableDefinitions;
         }
 
-        for ($child = $element->firstElementChild; $child !== null; $child = $child->nextElementSibling) {
-            $this->evaluateVaraiblesInElementAndDescendants($child, $variableDefinitions);
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof \DOMElement) {
+                $this->evaluateVaraiblesInElementAndDescendants($child, $variableDefinitions);
+            }
         }
 
         return $this;

--- a/src/HtmlProcessor/CssVariableEvaluator.php
+++ b/src/HtmlProcessor/CssVariableEvaluator.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\HtmlProcessor;
+
+use Pelago\Emogrifier\Utilities\DeclarationBlockParser;
+use Pelago\Emogrifier\Utilities\Preg;
+
+/**
+ * This class can evaluate CSS custom properties that are defined and used in inline style attributes.
+ */
+class CssVariableEvaluator extends AbstractHtmlProcessor
+{
+    /**
+     * temporary collection used by {@see replaceVariablesInDeclarations} and callee methods
+     *
+     * @var array<non-empty-string, string>
+     */
+    private $currentVariableDefinitions = [];
+
+    /**
+     * Replaces all CSS custom property references in inline style attributes with their corresponding values where
+     * defined in inline style attributes (either from the element itself or the nearest ancestor).
+     *
+     * @throws \UnexpectedValueException
+     *
+     * @return $this
+     */
+    public function evaluateVariables(): self
+    {
+        return $this->evaluateVaraiblesInElementAndDescendants($this->getHtmlElement(), []);
+    }
+
+    /**
+     * @param array<non-empty-string, string> $declarations
+     *
+     * @return array<non-empty-string, string>
+     */
+    private function getVaraibleDefinitionsFromDeclarations(array $declarations): array
+    {
+        return \array_filter(
+            $declarations,
+            static function (string $key): bool {
+                return \substr($key, 0, 2) === '--';
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    /**
+     * Callback function for {@see replaceVariablesInPropertyValue} performing regular expression replacement.
+     *
+     * @param array<int, string> $matches
+     */
+    private function getPropertyValueReplacement(array $matches): string
+    {
+        $variableName = $matches[1];
+        if (isset($this->currentVariableDefinitions[$variableName])) {
+            return $this->currentVariableDefinitions[$variableName];
+        } else {
+            $fallbackValueSeparator = $matches[2] ?? '';
+            if ($fallbackValueSeparator !== '') {
+                $fallbackValue = $matches[3];
+                // The fallback value may use other CSS variables, so recurse
+                return $this->replaceVariablesInPropertyValue($fallbackValue);
+            } else {
+                return $matches[0];
+            }
+        }
+    }
+
+    /**
+     * Regular expression based on {@see https://stackoverflow.com/a/54143883/2511031 a StackOverflow answer}.
+     */
+    private function replaceVariablesInPropertyValue(string $propertyValue): string
+    {
+        return (new Preg())->replaceCallback(
+            '/
+                var\\(
+                    \\s*+
+                    # capture variable name including `--` prefix
+                    (
+                        --[^\\s\\),]++
+                    )
+                    \\s*+
+                    # capture optional fallback value
+                    (?:
+                        # capture separator to confirm there is a fallback value
+                        (,)\\s*
+                        # begin capture with named group that can be used recursively
+                        (?<recursable>
+                            # begin named group to match sequence without parentheses, except in strings
+                            (?<noparentheses>
+                                # repeated zero or more times:
+                                (?:
+                                    # sequence without parentheses or quotes
+                                    [^\\(\\)\'"]++
+                                    |
+                                    # string in double quotes
+                                    "(?>[^"\\\\]++|\\\\.)*"
+                                    |
+                                    # string in single quotes
+                                    \'(?>[^\'\\\\]++|\\\\.)*\'
+                                )*+
+                            )
+                            # repeated zero or more times:
+                            (?:
+                                # sequence in parentheses
+                                \\(
+                                    # using the named recursable pattern
+                                    (?&recursable)
+                                \\)
+                                # sequence without parentheses, except in strings
+                                (?&noparentheses)
+                            )*+
+                        )
+                    )?+
+                \\)
+            /x',
+            \Closure::fromCallable([$this, 'getPropertyValueReplacement']),
+            $propertyValue
+        );
+    }
+
+    /**
+     * @param array<non-empty-string, string> $declarations
+     *
+     * @return array<non-empty-string, string>|false `false` is returned if no substitutions were made.
+     */
+    private function replaceVariablesInDeclarations(array $declarations)
+    {
+        $substitutionsMade = false;
+        $result = \array_map(
+            function (string $propertyValue) use (&$substitutionsMade): string {
+                $newPropertyValue = $this->replaceVariablesInPropertyValue($propertyValue);
+                if ($newPropertyValue !== $propertyValue) {
+                    $substitutionsMade = true;
+                }
+                return $newPropertyValue;
+            },
+            $declarations
+        );
+
+        return $substitutionsMade ? $result : false;
+    }
+
+    /**
+     * @param array<non-empty-string, string> $declarations;
+     */
+    private function getDeclarationsAsString(array $declarations): string
+    {
+        $declarationStrings = \array_map(
+            static function (string $key, string $value): string {
+                return $key . ': ' . $value;
+            },
+            \array_keys($declarations),
+            \array_values($declarations)
+        );
+
+        return \implode('; ', $declarationStrings) . ';';
+    }
+
+    /**
+     * @param array<non-empty-string, string> $ancestorVariableDefinitions
+     *
+     * @return $this
+     */
+    private function evaluateVaraiblesInElementAndDescendants(
+        \DOMElement $element,
+        array $ancestorVariableDefinitions
+    ): self {
+        $style = $element->getAttribute('style');
+
+        // Avoid parsing declarations if none use or define a variable
+        if ((new Preg())->match('/(?<![\\w\\-])--[\\w\\-]/', $style) !== 0) {
+            $declarations = (new DeclarationBlockParser())->parse($style);
+            $variableDefinitions = $this->currentVariableDefinitions
+                = $this->getVaraibleDefinitionsFromDeclarations($declarations) + $ancestorVariableDefinitions;
+
+            $newDeclarations = $this->replaceVariablesInDeclarations($declarations);
+            if ($newDeclarations !== false) {
+                $element->setAttribute('style', $this->getDeclarationsAsString($newDeclarations));
+            }
+        } else {
+            $variableDefinitions = $ancestorVariableDefinitions;
+        }
+
+        for ($child = $element->firstElementChild; $child !== null; $child = $child->nextElementSibling) {
+            $this->evaluateVaraiblesInElementAndDescendants($child, $variableDefinitions);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
+++ b/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
@@ -57,7 +57,7 @@ final class CssVariableEvaluatorTest extends TestCase
     /**
      * @return array<non-empty-string, array{css: non-empty-string, expect: non-empty-string}>
      */
-    public function provideCssUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation(): array
+    public function provideCssUsingVariablesAndExpectedHtmlFragmentAfterInliningAndEvaluation(): array
     {
         return [
             'undefined variable' => [
@@ -316,7 +316,7 @@ final class CssVariableEvaluatorTest extends TestCase
      * @param non-empty-string $css
      * @param non-empty-string $expectedHtmlFragment
      *
-     * @dataProvider provideCssUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation
+     * @dataProvider provideCssUsingVariablesAndExpectedHtmlFragmentAfterInliningAndEvaluation
      */
     public function replacesReferencedVariableIfDefinedOrNotOtherwise(string $css, string $expectedHtmlFragment): void
     {
@@ -330,7 +330,7 @@ final class CssVariableEvaluatorTest extends TestCase
     /**
      * @return array<non-empty-string, array{html: non-empty-string, expect: non-empty-string}>
      */
-    public function provideHtmlUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation(): array
+    public function provideHtmlUsingVariablesAndExpectedHtmlFragmentAfterInliningAndEvaluation(): array
     {
         return [
             // The `CssInliner` step in the test with CSS data might strip whitespace.
@@ -379,7 +379,7 @@ final class CssVariableEvaluatorTest extends TestCase
      * @param non-empty-string $html
      * @param non-empty-string $expectedHtmlFragment
      *
-     * @dataProvider provideHtmlUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation
+     * @dataProvider provideHtmlUsingVariablesAndExpectedHtmlFragmentAfterInliningAndEvaluation
      */
     public function replacesReferencedVariableIfDefinedOrNotOtherwiseInHtml(
         string $html,

--- a/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
+++ b/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pelago\Emogrifier\Tests\Unit\HtmlProcessor;
+
+use Pelago\Emogrifier\CssInliner;
+use Pelago\Emogrifier\HtmlProcessor\CssVariableEvaluator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Pelago\Emogrifier\HtmlProcessor\CssVariableEvaluator
+ */
+final class CssVariableEvaluatorTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private const COMMON_TEST_HTML = '
+        <html>
+            <head>
+                <title>CssVariableEvaluator Test</title>
+            </head>
+            <body>
+                <h1>CssVariableEvaluator Test</h1>
+                <p>
+                    This tests the <code>CssVariableEvaluator</code> class.
+                </p>
+            </body>
+        </html>
+    ';
+
+    /**
+     * @test
+     */
+    public function evaluateVariablesProvidesFluentInterface(): void
+    {
+        $subject = CssVariableEvaluator::fromHtml('<html></html>');
+
+        $result = $subject->evaluateVariables();
+
+        self::assertSame($subject, $result);
+    }
+
+    /**
+     * Invokes `CssInliner` to provide a test subject wrapping a `DOMDocument` in which `$css` has been inlined into
+     * `$html`.
+     */
+    private function buildSubjectWithCssInlined(string $html, string $css): CssVariableEvaluator
+    {
+        $cssInliner = CssInliner::fromHtml($html);
+        $cssInliner->inlineCss($css);
+
+        return CssVariableEvaluator::fromDomDocument($cssInliner->getDomDocument());
+    }
+
+    /**
+     * @return array<non-empty-string, array{css: non-empty-string, expect: non-empty-string}>
+     */
+    public function provideCssUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation(): array
+    {
+        return [
+            'undefined variable' => [
+                'css' => '
+                    p {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<p style="color: var(--text-color);">',
+            ],
+            'variable defined in root, used in descendant' => [
+                'css' => '
+                    :root {
+                        --text-color: green;
+                    }
+                    p {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'variable defined in parent, used in child' => [
+                'css' => '
+                    p {
+                        --text-color: green;
+                    }
+                    code {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<code style="color: green;">',
+            ],
+            'variable defined and used in same element' => [
+                'css' => '
+                    p {
+                        --text-color: green;
+                    }
+                    p {
+                        color: var(--text-color);
+                    }
+                ',
+                // The variable definition is not removed, but its value should nonetheless be applied
+                'expect' => '<p style="--text-color: green; color: green;">',
+            ],
+            'variable defined in parent and root' => [
+                'css' => '
+                    :root {
+                        --text-color: red;
+                    }
+                    p {
+                        --text-color: green;
+                    }
+                    code {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<code style="color: green;">',
+            ],
+            'variable defined and used in same element, also defined in root' => [
+                'css' => '
+                    :root {
+                        --text-color: red;
+                    }
+                    p {
+                        --text-color: green;
+                    }
+                    p {
+                        color: var(--text-color);
+                    }
+                ',
+                // The variable definition is not removed, but its value should nonetheless be applied
+                'expect' => '<p style="--text-color: green; color: green;">',
+            ],
+            'variable defined only for descendant' => [
+                'css' => '
+                    code {
+                        --text-color: red;
+                    }
+                    p {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<p style="color: var(--text-color);">',
+            ],
+            'variable defined for root and descendant' => [
+                'css' => '
+                    :root {
+                        --text-color: green;
+                    }
+                    code {
+                        --text-color: red;
+                    }
+                    p {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'variable name with uppercase characters' => [
+                'css' => '
+                    :root {
+                        --Text-Color: green;
+                    }
+                    p {
+                        color: var(--Text-Color);
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'variable defined in parent and root but differently cased' => [
+                'css' => '
+                    :root {
+                        --text-color: green;
+                    }
+                    p {
+                        --Text-Color: red;
+                    }
+                    code {
+                        color: var(--text-color);
+                    }
+                ',
+                'expect' => '<code style="color: green;">',
+            ],
+            'with whitespace around `var` argument' => [
+                'css' => '
+                    :root {
+                        --text-color: green;
+                    }
+                    p {
+                        color: var(
+                            --text-color
+                        );
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'multiple variables used in property value' => [
+                'css' => '
+                    :root {
+                        --scale: 1.2;
+                        --size: 0.8rem;
+                    }
+                    p {
+                        font-size: calc(var(--size) * var(--scale));
+                    }
+                ',
+                // Processing through `CssInliner` results in `0.8rem` being optimized to `.8rem`.
+                'expect' => '<p style="font-size: calc(.8rem * 1.2);"',
+            ],
+            'fallback value provided for undefined variable' => [
+                'css' => '
+                    p {
+                        color: var(--text-color, green);
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'fallback value provided for defined variable' => [
+                'css' => '
+                    :root {
+                        --text-color: green;
+                    }
+                    p {
+                        color: var(--text-color, red);
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'fallback value refererencing another variable which is defined' => [
+                'css' => '
+                    :root {
+                        --default-text-color: green;
+                    }
+                    p {
+                        color: var(--text-color, var(--default-text-color));
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'fallback value refererencing another variable which is also not defined' => [
+                'css' => '
+                    p {
+                        color: var(--text-color, var(--default-text-color));
+                    }
+                ',
+                // The expected behaviour here is somewhat ambiguous.
+                'expect' => '<p style="color: var(--default-text-color);">',
+            ],
+            'nested fallback value' => [
+                'css' => '
+                    p {
+                        color: var(--text-color, var(--default-text-color, green));
+                    }
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            'fallback value with parentheses' => [
+                'css' => '
+                    body {
+                        width: var(--page-width, calc(100vw - 20px));
+                    }
+                ',
+                'expect' => '<body style="width: calc(100vw - 20px);">',
+            ],
+            'fallback value with nested parentheses' => [
+                'css' => '
+                    body {
+                        width: var(--page-width, calc(100vw - 2 * calc(1rem + 10px)));
+                    }
+                ',
+                'expect' => '<body style="width: calc(100vw - 2 * calc(1rem + 10px));">',
+            ],
+            // Processing through `CssInliner` may result in the quotes being changed.
+            // A direct test with HTML is also performed for the following four scenarios.
+            'fallback value with single-quoted string containing opening parenthesis' => [
+                'css' => '
+                    h1 {
+                        content: var(--main-heading, \'Missing heading :(\');
+                    }
+                ',
+                'expect' => '<h1 style=\'content: "Missing heading :(";\'>',
+            ],
+            'fallback value with single-quoted string containing closing parenthesis' => [
+                'css' => '
+                    h1 {
+                        content: var(--main-heading, \'Missing heading ):\');
+                    }
+                ',
+                'expect' => '<h1 style=\'content: "Missing heading ):";\'>',
+            ],
+            'fallback value with double-quoted string containing opening parenthesis' => [
+                'css' => '
+                    h1 {
+                        content: var(--main-heading, "Missing heading :(");
+                    }
+                ',
+                'expect' => '<h1 style=\'content: "Missing heading :(";\'>',
+            ],
+            'fallback value with double-quoted string containing closing parenthesis' => [
+                'css' => '
+                    h1 {
+                        content: var(--main-heading, "Missing heading ):");
+                    }
+                ',
+                'expect' => '<h1 style=\'content: "Missing heading ):";\'>',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * This test simplifies the provision of test data by using an initial `CssInliner` step on some standard HTML,
+     * so that CSS can be provided as the test data rather than direct HTML.
+     *
+     * @param non-empty-string $css
+     * @param non-empty-string $expectedHtmlFragment
+     *
+     * @dataProvider provideCssUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation
+     */
+    public function replacesReferencedVariableIfDefinedOrNotOtherwise(string $css, string $expectedHtmlFragment): void
+    {
+        $subject = $this->buildSubjectWithCssInlined(self::COMMON_TEST_HTML, $css);
+
+        $htmlResult = $subject->evaluateVariables()->render();
+
+        self::assertStringContainsString($expectedHtmlFragment, $htmlResult);
+    }
+
+    /**
+     * @return array<non-empty-string, array{html: non-empty-string, expect: non-empty-string}>
+     */
+    public function provideHtmlUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation(): array
+    {
+        return [
+            // The `CssInliner` step in the test with CSS data might strip whitespace.
+            'with whitespace around `var` argument' => [
+                'html' => '
+                    <html style="--text-color: green;">
+                        <p
+                            style="
+                                color: var(
+                                    --text-color
+                                );
+                            "
+                        >
+                        </p>
+                    </html>
+                ',
+                'expect' => '<p style="color: green;">',
+            ],
+            // The `CssInliner` step in the test with CSS data might change quoting style.
+            'fallback value with single-quoted string containing opening parenthesis' => [
+                'html' => '<h1 style="content: var(--main-heading, \'Missing heading :(\');"></h1>',
+                'expect' => '<h1 style="content: \'Missing heading :(\';">',
+            ],
+            'fallback value with single-quoted string containing closing parenthesis' => [
+                'html' => '<h1 style="content: var(--main-heading, \'Missing heading ):\');"></h1>',
+                'expect' => '<h1 style="content: \'Missing heading ):\';">',
+            ],
+            'fallback value with double-quoted string containing opening parenthesis' => [
+                'html' => '<h1 style="content: var(--main-heading, &quot;Missing heading :(&quot;);"></h1>',
+                'expect' => '<h1 style=\'content: "Missing heading :(";\'>',
+            ],
+            'fallback value with double-quoted string containing closing parenthesis' => [
+                'html' => '<h1 style="content: var(--main-heading, &quot;Missing heading ):&quot;);"></h1>',
+                'expect' => '<h1 style=\'content: "Missing heading ):";\'>',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * The test method {@see replacesReferencedVariableIfDefinedOrNotOtherwise} may result in changes to the quoting
+     * style of CSS property values (single vs double -quotes).
+     * This method allows testing with HTML directly.
+     *
+     * @param non-empty-string $html
+     * @param non-empty-string $expectedHtmlFragment
+     *
+     * @dataProvider provideHtmlUsingVaraiblesAndExpectedHtmlFragmentAfterInliningAndEvaluation
+     */
+    public function replacesReferencedVariableIfDefinedOrNotOtherwiseInHtml(
+        string $html,
+        string $expectedHtmlFragment
+    ): void {
+        $subject = CssVariableEvaluator::fromHtml($html);
+
+        $htmlResult = $subject->evaluateVariables()->render();
+
+        self::assertStringContainsString($expectedHtmlFragment, $htmlResult);
+    }
+}


### PR DESCRIPTION
Add a new `HtmlProcessor` class that can evaluate CSS custom properties (variables) after CSS which uses them has been inlined.

Resolves #1276, though an additional feature to remove unused variable definitions after evaluation could be provided.