### PR TITLE
Mark classes as final

### DIFF
--- a/src/Caching/SimpleStringCache.php
+++ b/src/Caching/SimpleStringCache.php
@@ -20,7 +20,7 @@ namespace Pelago\Emogrifier\Caching;
  *
  * @internal
  */
-class SimpleStringCache
+final class SimpleStringCache
 {
     /**
      * @var array<string, string>

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -22,7 +22,7 @@ use Sabberworm\CSS\Settings as ParserSettings;
  *
  * @internal
  */
-class CssDocument
+final class CssDocument
 {
     /**
      * @var SabberwormCssDocument

--- a/src/Css/StyleRule.php
+++ b/src/Css/StyleRule.php
@@ -12,7 +12,7 @@ use Sabberworm\CSS\RuleSet\DeclarationBlock;
  *
  * @internal
  */
-class StyleRule
+final class StyleRule
 {
     /**
      * @var DeclarationBlock

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -15,7 +15,7 @@ use Symfony\Component\CssSelector\Exception\ParseException;
 /**
  * This class provides functions for converting CSS styles into inline style attributes in your HTML code.
  */
-class CssInliner extends AbstractHtmlProcessor
+final class CssInliner extends AbstractHtmlProcessor
 {
     /**
      * @var int

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -15,7 +15,7 @@ use Pelago\Emogrifier\Utilities\Preg;
  *
  * To trigger the conversion, call the convertCssToVisualAttributes method.
  */
-class CssToAttributeConverter extends AbstractHtmlProcessor
+final class CssToAttributeConverter extends AbstractHtmlProcessor
 {
     /**
      * This multi-level array contains simple mappings of CSS properties to

--- a/src/HtmlProcessor/CssVariableEvaluator.php
+++ b/src/HtmlProcessor/CssVariableEvaluator.php
@@ -10,7 +10,7 @@ use Pelago\Emogrifier\Utilities\Preg;
 /**
  * This class can evaluate CSS custom properties that are defined and used in inline style attributes.
  */
-class CssVariableEvaluator extends AbstractHtmlProcessor
+final class CssVariableEvaluator extends AbstractHtmlProcessor
 {
     /**
      * temporary collection used by {@see replaceVariablesInDeclarations} and callee methods

--- a/src/HtmlProcessor/HtmlNormalizer.php
+++ b/src/HtmlProcessor/HtmlNormalizer.php
@@ -11,4 +11,4 @@ namespace Pelago\Emogrifier\HtmlProcessor;
  * - add HEAD and BODY elements (if they are missing)
  * - reformat the HTML
  */
-class HtmlNormalizer extends AbstractHtmlProcessor {}
+final class HtmlNormalizer extends AbstractHtmlProcessor {}

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -11,7 +11,7 @@ use Pelago\Emogrifier\Utilities\Preg;
 /**
  * This class can remove things from HTML.
  */
-class HtmlPruner extends AbstractHtmlProcessor
+final class HtmlPruner extends AbstractHtmlProcessor
 {
     /**
      * We need to look for display:none, but we need to do a case-insensitive search. Since DOMDocument only

--- a/src/Utilities/ArrayIntersector.php
+++ b/src/Utilities/ArrayIntersector.php
@@ -17,7 +17,7 @@ namespace Pelago\Emogrifier\Utilities;
  *
  * @internal
  */
-class ArrayIntersector
+final class ArrayIntersector
 {
     /**
      * the array with which the object was constructed, with all its keys exchanged with their associated values

--- a/src/Utilities/CssConcatenator.php
+++ b/src/Utilities/CssConcatenator.php
@@ -37,7 +37,7 @@ namespace Pelago\Emogrifier\Utilities;
  *
  * @internal
  */
-class CssConcatenator
+final class CssConcatenator
 {
     /**
      * Array of media rules in order.  Each element is an object with the following properties:

--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -12,7 +12,7 @@ namespace Pelago\Emogrifier\Utilities;
  *
  * @internal
  */
-class DeclarationBlockParser
+final class DeclarationBlockParser
 {
     /**
      * @var array<string, array<non-empty-string, string>>


### PR DESCRIPTION
This pull request addresses issue [#1339](https://github.com/MyIntervals/emogrifier/issues/1339) by explicitly marking several classes in the codebase final.

Classes made final:

* `src/Caching/SimpleStringCache.php`
* `src/Css/CssDocument.php`
* `src/Css/StyleRule.php`
* `src/CssInliner.php`
* `src/HtmlProcessor/CssToAttributeConverter.php`
* `src/HtmlProcessor/CssVariableEvaluator.php`
* `src/HtmlProcessor/HtmlNormalizer.php`
* `src/HtmlProcessor/HtmlPruner.php`
* `src/Utilities/ArrayIntersector.php`
* `src/Utilities/CssConcatenator.php`
* `src/Utilities/DeclarationBlockParser.php`