### PR TITLE
[TASK] Drop a redundant PHPUnit configuration option

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,6 @@
          beStrictAboutChangesToGlobalState="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
-         bootstrap="vendor/autoload.php"
          colors="true"
          convertDeprecationsToExceptions="true"
          forceCoversAnnotation="true"


### PR DESCRIPTION
PHPUnit by default chooses the correct bootstrap. So we don't need to specify it.