### PR TITLE
[TASK] Don't cache the PHPUnit results

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
          convertDeprecationsToExceptions="true"
          forceCoversAnnotation="true"


### PR DESCRIPTION
PHPUnit result caching is not related to performance, but only to running failed tests only (which is a feature we don't use).

Disabling the PHPUnit result cache keeps the result cache files from littering the project directory.