### PR TITLE
[CLEANUP] Reformat the PHPUnit configuration file

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-         beStrictAboutChangesToGlobalState="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         cacheResult="false"
-         colors="true"
-         convertDeprecationsToExceptions="true"
-         forceCoversAnnotation="true"
-         verbose="true">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+  beStrictAboutChangesToGlobalState="true"
+  beStrictAboutOutputDuringTests="true"
+  beStrictAboutTodoAnnotatedTests="true"
+  cacheResult="false"
+  colors="true"
+  convertDeprecationsToExceptions="true"
+  forceCoversAnnotation="true"
+  verbose="true"
+>
   <testsuites>
     <testsuite name="default">
       <directory>tests</directory>


### PR DESCRIPTION
This gets rid of the 9-space indentation and also will make diffs cleaner in the future.