### PR TITLE
[TASK] Require `sabberworm/php-css-parser:^8.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please also have a look at our
 
 ### Changed
 
+- Require `sabberworm/php-css-parser:^8.7.0` (#1355)
+
 ### Deprecated
 
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "sabberworm/php-css-parser": "^8.4.0",
+        "sabberworm/php-css-parser": "^8.7.0",
         "symfony/css-selector": "^4.4.23 || ^5.4.0 || ^6.0.0 || ^7.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is required to ensure compatibility up to PHP 8.4 even with the lowest permitted dependencies.