### PR TITLE
[TASK] Drop support for Symfony 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please also have a look at our
 
 ### Removed
 
+- Drop support for Symfony 4.4 (#1358)
+
 ### Fixed
 
 ## 7.3.0: Add support for PHP 8.4 and CSS custom properties

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.7.0",
-        "symfony/css-selector": "^4.4.23 || ^5.4.0 || ^6.0.0 || ^7.0.0"
+        "symfony/css-selector": "^5.4.0 || ^6.0.0 || ^7.0.0"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.4.0",


### PR DESCRIPTION
We'll raise the minimum required bugfix versions for Symfony in a separate change to ensure PHP 8.4 compatibility even with the lowest dependencies.

Fixes #1242