### PR TITLE
[TASK] Drop support for Symfony versions without PHP 8.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,6 @@ jobs:
         dependencies:
           - lowest
           - highest
-        exclude:
-          - php-version: '8.4'
-            dependencies: lowest
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ Please also have a look at our
 
 ### Changed
 
+- Raise the minimum required Symfony bugfix versions (#1361)
+
 ### Deprecated
 
 ### Removed
 
-- Drop support for Symfony 4.4 (#1358)
+- Drop support for Symfony 4.4, 6.0., 6.1, 6.2 (#1358, #1361)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Removed
 
-- Drop support for Symfony 4.4, 6.0., 6.1, 6.2 (#1358, #1361)
+- Drop support for Symfony 4.4, 6.0, 6.1, 6.2 (#1358, #1361)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.7.0",
-        "symfony/css-selector": "^5.4.35 || ~6.3.12 || ~6.4.3 || ^7.0.3"
+        "symfony/css-selector": "^5.4.35 || ~6.3.12 || ^6.4.3 || ^7.0.3"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "sabberworm/php-css-parser": "^8.7.0",
-        "symfony/css-selector": "^5.4.0 || ^6.0.0 || ^7.0.0"
+        "symfony/css-selector": "^5.4.35 || ~6.3.12 || ~6.4.3 || ^7.0.3"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.4.0",


### PR DESCRIPTION
These Symfony versions are PHP-8.4-compatible:

- 7.1.0
- 7.0.3
- 6.4.3
- 6.3.12
- 6.2 (none)
- 6.1 (none)
- 6.0 (none)
- 5.4.35

The relevant thing is whether the `CssSelector/XPath/Translator.php` class does not use implicit nullable parameters anymore.

So we'll need to drop support for Symfony 6.0 through 6.2 altogether and raise the minimum required bugfix versions of the other minor versions.

Fixes #1359