### PR TITLE
[TASK] Add `rawr/phpunit-data-provider` as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "phpstan/phpstan-strict-rules": "1.6.1",
         "phpunit/phpunit": "9.6.21",
         "rawr/cross-data-providers": "2.4.0",
+        "rawr/phpunit-data-provider": "3.3.0",
         "rector/rector": "1.2.10"
     },
     "prefer-stable": true,


### PR DESCRIPTION
This is the first step of migrating from the abandoned `rawr/cross-data-providers` package to this package.

Part of #1219