### PR TITLE
[TASK] Move and polish the PHPStan configuration and scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,5 @@
 /CONTRIBUTING.md export-ignore
 /config/ export-ignore
 /docs/ export-ignore
-/phpstan-baseline.neon export-ignore
-/phpstan.neon export-ignore
 /phpunit.xml export-ignore
 /tests/ export-ignore

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "ci:php:lint": "parallel-lint config src tests",
         "ci:php:md": "\"./.phive/phpmd\" src text config/phpmd.xml",
         "ci:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
-        "ci:php:stan": "phpstan --no-progress  --error-format=github",
+        "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
         "ci:static": [
             "@ci:composer:normalize",
             "@ci:php:lint",
@@ -116,7 +116,7 @@
         "fix:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix config/ src/ tests/",
         "fix:php:rector": "rector --config=config/rector.php",
         "php:version": "@php -v | grep -Po 'PHP\\s++\\K(?:\\d++\\.)*+\\d++(?:-\\w++)?+'",
-        "phpstan:baseline": "phpstan --generate-baseline --allow-empty-baseline"
+        "phpstan:baseline": "phpstan --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon --allow-empty-baseline"
     },
     "scripts-descriptions": {
         "ci": "Runs all dynamic and static code checks.",

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -4,163 +4,163 @@ parameters:
 			message: '#^Method Pelago\\Emogrifier\\Caching\\SimpleStringCache\:\:set\(\) has BadMethodCallException in PHPDoc @throws tag but it''s not thrown\.$#'
 			identifier: throws.unusedType
 			count: 1
-			path: src/Caching/SimpleStringCache.php
+			path: ../src/Caching/SimpleStringCache.php
 
 		-
 			message: '#^PHPDoc tag @var with type Sabberworm\\CSS\\Renderable is not subtype of type Sabberworm\\CSS\\CSSList\\CSSList\|Sabberworm\\CSS\\Property\\Charset\|Sabberworm\\CSS\\Property\\Import\|Sabberworm\\CSS\\RuleSet\\RuleSet\.$#'
 			identifier: varTag.type
 			count: 2
-			path: src/Css/CssDocument.php
+			path: ../src/Css/CssDocument.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\CssInliner\:\:getAllNodesWithStyleAttribute\(\) return type with generic class DOMNodeList does not specify its types\: TNode$#'
 			identifier: missingType.generics
 			count: 1
-			path: src/CssInliner.php
+			path: ../src/CssInliner.php
 
 		-
 			message: '#^Only numeric types are allowed in \*, int\|null given on the right side\.$#'
 			identifier: mul.rightNonNumeric
 			count: 1
-			path: src/CssInliner.php
+			path: ../src/CssInliner.php
 
 		-
 			message: '#^Parameter \#1 \$html of method Pelago\\Emogrifier\\HtmlProcessor\\AbstractHtmlProcessor\:\:removeSelfClosingTagsClosingTags\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
+			path: ../src/HtmlProcessor/AbstractHtmlProcessor.php
 
 		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
 			count: 2
-			path: src/HtmlProcessor/AbstractHtmlProcessor.php
+			path: ../src/HtmlProcessor/AbstractHtmlProcessor.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\HtmlProcessor\\CssToAttributeConverter\:\:getAllNodesWithStyleAttribute\(\) return type with generic class DOMNodeList does not specify its types\: TNode$#'
 			identifier: missingType.generics
 			count: 1
-			path: src/HtmlProcessor/CssToAttributeConverter.php
+			path: ../src/HtmlProcessor/CssToAttributeConverter.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\HtmlProcessor\\CssToAttributeConverter\:\:getAllNodesWithStyleAttribute\(\) should return DOMNodeList but returns DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: return.type
 			count: 1
-			path: src/HtmlProcessor/CssToAttributeConverter.php
+			path: ../src/HtmlProcessor/CssToAttributeConverter.php
 
 		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Cannot access property \$length on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\HtmlProcessor\\HtmlPruner\:\:removeClassAttributeFromElements\(\) has parameter \$elements with generic class DOMNodeList but does not specify its types\: TNode$#'
 			identifier: missingType.generics
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\HtmlProcessor\\HtmlPruner\:\:removeClassesFromElements\(\) has parameter \$elements with generic class DOMNodeList but does not specify its types\: TNode$#'
 			identifier: missingType.generics
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Offset 1 might not exist on array\<int, array\<int, string\>\>\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Parameter \#1 \$elements of method Pelago\\Emogrifier\\HtmlProcessor\\HtmlPruner\:\:removeClassAttributeFromElements\(\) expects DOMNodeList, DOMNodeList\<DOMNode\>\|false given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Parameter \#1 \$elements of method Pelago\\Emogrifier\\HtmlProcessor\\HtmlPruner\:\:removeClassesFromElements\(\) expects DOMNodeList, DOMNodeList\<DOMNode\>\|false given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/HtmlProcessor/HtmlPruner.php
+			path: ../src/HtmlProcessor/HtmlPruner.php
 
 		-
 			message: '#^Property object\{media\: string, ruleBlocks\: array\<int, object\{selectorsAsKeys\: array\<string, \(int\|string\)\>, declarationsBlock\: string\}\>\}\:\:\$ruleBlocks is not writable\.$#'
 			identifier: assign.propertyReadOnly
 			count: 1
-			path: src/Utilities/CssConcatenator.php
+			path: ../src/Utilities/CssConcatenator.php
 
 		-
 			message: '#^Property object\{selectorsAsKeys\: array\<string, \(int\|string\)\>, declarationsBlock\: string\}\:\:\$declarationsBlock is not writable\.$#'
 			identifier: assign.propertyReadOnly
 			count: 1
-			path: src/Utilities/CssConcatenator.php
+			path: ../src/Utilities/CssConcatenator.php
 
 		-
 			message: '#^Property object\{selectorsAsKeys\: array\<string, \(int\|string\)\>, declarationsBlock\: string\}\:\:\$selectorsAsKeys is not writable\.$#'
 			identifier: assign.propertyReadOnly
 			count: 1
-			path: src/Utilities/CssConcatenator.php
+			path: ../src/Utilities/CssConcatenator.php
 
 		-
 			message: '#^Offset 1 might not exist on array\<int, string\>\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
-			path: src/Utilities/DeclarationBlockParser.php
+			path: ../src/Utilities/DeclarationBlockParser.php
 
 		-
 			message: '#^Offset 2 might not exist on array\<int, string\>\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
-			path: src/Utilities/DeclarationBlockParser.php
+			path: ../src/Utilities/DeclarationBlockParser.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\Utilities\\Preg\:\:match\(\) never assigns null to &\$matches so it can be removed from the by\-ref type\.$#'
 			identifier: parameterByRef.unusedType
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\Utilities\\Preg\:\:matchAll\(\) never assigns null to &\$matches so it can be removed from the by\-ref type\.$#'
 			identifier: parameterByRef.unusedType
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\Utilities\\Preg\:\:replace\(\) never assigns null to &\$count so it can be removed from the by\-ref type\.$#'
 			identifier: parameterByRef.unusedType
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '#^Method Pelago\\Emogrifier\\Utilities\\Preg\:\:replaceCallback\(\) never assigns null to &\$count so it can be removed from the by\-ref type\.$#'
 			identifier: parameterByRef.unusedType
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '#^Parameter \#1 \$array of function array_flip expects array\<int\|string\>, array\<string, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '#^Parameter &\$matches by\-ref type of method Pelago\\Emogrifier\\Utilities\\Preg\:\:match\(\) expects array\<int, string\>\|null, array\<string\> given\.$#'
 			identifier: parameterByRef.type
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '#^Parameter &\$matches by\-ref type of method Pelago\\Emogrifier\\Utilities\\Preg\:\:matchAll\(\) expects array\<int, array\<int, string\>\>\|null, array\<list\<string\>\> given\.$#'
 			identifier: parameterByRef.type
 			count: 1
-			path: src/Utilities/Preg.php
+			path: ../src/Utilities/Preg.php
 
 		-
 			message: '''
@@ -170,7 +170,7 @@ parameters:
 			'''
 			identifier: phpunit.dataProviderMethod
 			count: 1
-			path: tests/Unit/Css/CssDocumentTest.php
+			path: ../tests/Unit/Css/CssDocumentTest.php
 
 		-
 			message: '''
@@ -180,46 +180,46 @@ parameters:
 			'''
 			identifier: phpunit.dataProviderMethod
 			count: 1
-			path: tests/Unit/Css/CssDocumentTest.php
+			path: ../tests/Unit/Css/CssDocumentTest.php
 
 		-
 			message: '#^Offset 0 might not exist on array\<int, string\>\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
-			path: tests/Unit/Css/CssDocumentTest.php
+			path: ../tests/Unit/Css/CssDocumentTest.php
 
 		-
 			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/CssInlinerTest.php
+			path: ../tests/Unit/CssInlinerTest.php
 
 		-
 			message: '#^Parameter \#1 \$string of function strtolower expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+			path: ../tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
 
 		-
 			message: '#^Parameter \#2 \$actual of static method Pelago\\Emogrifier\\Tests\\Unit\\HtmlProcessor\\AbstractHtmlProcessorTest\:\:assertEqualsHtml\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+			path: ../tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
 
 		-
 			message: '#^Offset 1 might not exist on array\<int, array\<int, string\>\>\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
-			path: tests/Unit/HtmlProcessor/HtmlPrunerTest.php
+			path: ../tests/Unit/HtmlProcessor/HtmlPrunerTest.php
 
 		-
 			message: '#^Parameter \#1 \$array of function array_filter expects array, array\<int, array\<int, string\>\>\|null given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/Utilities/PregTest.php
+			path: ../tests/Unit/Utilities/PregTest.php
 
 		-
 			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, array\<int, array\<int, string\>\>\|null given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/Utilities/PregTest.php
+			path: ../tests/Unit/Utilities/PregTest.php

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -5,10 +5,10 @@ parameters:
   level: 9
 
   paths:
-    - src
-    - tests
+    - %currentWorkingDirectory%/src/
+    - %currentWorkingDirectory%/tests/
 
   ignoreErrors:
     -
       message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'
-      path: 'tests/'
+      path: '%currentWorkingDirectory%/tests/'


### PR DESCRIPTION
Move the configuration and baseline files to `config/` in order to declutter the project main directory (following our sister project).

Stop using the GitHub formatter as this makes it impossible for humans to see any errors if the CI pipeline fails.