### PR TITLE
[TASK] Move PHPMD from PHIVE to Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: composer install --no-progress
 
       - name: Install development tools
-        run: phive --no-progress install --trust-gpg-keys 0FDE18AE1D09E19F60F6B1CBC00543248C87FB13,BBAB5DF0A0D6672989CF1869E82B2FB314E9906E,E7A745102ECC980F7338B3079093F8B32E4815AA
+        run: phive --no-progress install --trust-gpg-keys 0FDE18AE1D09E19F60F6B1CBC00543248C87FB13,BBAB5DF0A0D6672989CF1869E82B2FB314E9906E
 
       - name: Run Command
         run: composer ci:${{ matrix.command }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,5 +2,4 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="composer-normalize" version="^2.42.0" installed="2.45.0" location="./.phive/composer-normalize" copy="false"/>
   <phar name="php-cs-fixer" version="^3.58.1" installed="3.66.0" location="./.phive/php-cs-fixer" copy="false"/>
-  <phar name="phpmd" version="^2.15.0" installed="2.15.0" location="./.phive/phpmd" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.4.0",
+        "phpmd/phpmd": "2.15.0",
         "phpstan/extension-installer": "1.4.3",
         "phpstan/phpstan": "1.12.13 || 2.0.4",
         "phpstan/phpstan-phpunit": "1.4.2 || 2.0.2",
@@ -90,7 +91,7 @@
         ],
         "ci:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots config/ src/ tests/",
         "ci:php:lint": "parallel-lint config src tests",
-        "ci:php:md": "\"./.phive/phpmd\" src text config/phpmd.xml",
+        "ci:php:md": "phpmd src text config/phpmd.xml",
         "ci:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
         "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
         "ci:static": [


### PR DESCRIPTION
The PHIVE version is no longer installable due to the GPG key not being available any more. Also, we can now install it via Composer just fine.