### PR TITLE
[TASK] Add PHPStan rules from Rector Type Perfect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "phpunit/phpunit": "9.6.22",
         "rawr/cross-data-providers": "2.4.0",
         "rawr/phpunit-data-provider": "3.3.1",
-        "rector/rector": "1.2.10 || 2.0.3"
+        "rector/rector": "1.2.10 || 2.0.3",
+        "rector/type-perfect": "1.0.0 || 2.0.2"
     },
     "prefer-stable": true,
     "autoload": {

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -8,6 +8,13 @@ parameters:
     - %currentWorkingDirectory%/src/
     - %currentWorkingDirectory%/tests/
 
+  type_perfect:
+    no_mixed_property: true
+    no_mixed_caller: true
+    null_over_false: true
+    narrow_param: true
+    narrow_return: true
+
   ignoreErrors:
     -
       message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'


### PR DESCRIPTION
This is an opiniated set of PHPStan rules to make code more explicit and intuitive to read.

https://github.com/rectorphp/type-perfect

As our code already is in pretty good shape, this new set of rules does not add any new warnings to our baseline.