### PR TITLE
[CLEANUP] Reduce callbacks for data providers in the tests

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -243,24 +243,6 @@ parameters:
 			path: ../tests/Unit/HtmlProcessor/HtmlPrunerTest.php
 
 		-
-			message: '#^Method Pelago\\Emogrifier\\Tests\\Unit\\Support\\Constraint\\IsEquivalentCssTest\:\:arrayMapKeys\(\) should return array\<string, T\> but returns array\<string, T\>\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: ../tests/Unit/Support/Constraint/IsEquivalentCssTest.php
-
-		-
-			message: '#^Method Pelago\\Emogrifier\\Tests\\Unit\\Support\\Constraint\\StringContainsCssCountTest\:\:arrayMapKeys\(\) should return array\<string, T\> but returns array\<string, T\>\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: ../tests/Unit/Support/Constraint/StringContainsCssCountTest.php
-
-		-
-			message: '#^Method Pelago\\Emogrifier\\Tests\\Unit\\Support\\Constraint\\StringContainsCssTest\:\:arrayMapKeys\(\) should return array\<string, T\> but returns array\<string, T\>\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: ../tests/Unit/Support/Constraint/StringContainsCssTest.php
-
-		-
 			message: '#^Parameter \#1 \$input of function array_filter expects array, array\<int, array\<int, string\>\>\|null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/Support/Traits/CssDataProviders.php
+++ b/tests/Support/Traits/CssDataProviders.php
@@ -143,12 +143,10 @@ trait CssDataProviders
     {
         $datasetsWithoutStyleTags = $this->provideEquivalentCompleteCss();
 
-        $datasetsWithRenamedKeys = static::arrayMapKeys(
-            static function (string $description): string {
-                return $description . ' in <style> tag';
-            },
-            $datasetsWithoutStyleTags
-        );
+        $datasetsWithRenamedKeys = [];
+        foreach ($datasetsWithoutStyleTags as $description => $dataset) {
+            $datasetsWithRenamedKeys[$description . ' in <style> tag'] = $dataset;
+        }
 
         $datasets = \array_map(
             /**
@@ -345,18 +343,5 @@ trait CssDataProviders
         $result = DataProviders::cross($dataset, $dataset);
 
         return $result;
-    }
-
-    /**
-     * @template T
-     *
-     * @param callable(string):string $callback
-     * @param array<string, T> $array
-     *
-     * @return array<string, T>
-     */
-    private static function arrayMapKeys(callable $callback, array $array): array
-    {
-        return \array_combine(\array_map($callback, \array_keys($array)), \array_values($array));
     }
 }

--- a/tests/Unit/Support/Constraint/IsEquivalentCssTest.php
+++ b/tests/Unit/Support/Constraint/IsEquivalentCssTest.php
@@ -59,22 +59,10 @@ final class IsEquivalentCssTest extends TestCase
     {
         $datasets = $this->provideCssNeedleNotFoundInHaystack() + $this->provideCssNeedleFoundInLargerHaystack();
 
-        $transposedDatasets = \array_map(
-            /**
-             * @param array{0: string, 1: string} $dataset
-             *
-             * @return array{0: string, 1: string}
-             */
-            static function (array $dataset): array {
-                return [$dataset[1], $dataset[0]];
-            },
-            static::arrayMapKeys(
-                static function (string $description): string {
-                    return $description . ' (transposed)';
-                },
-                $datasets
-            )
-        );
+        $transposedDatasets = [];
+        foreach ($datasets as $description => $dataset) {
+            $transposedDatasets[$description . ' (transposed)'] = [$dataset[1], $dataset[0]];
+        }
 
         return $datasets + $transposedDatasets;
     }


### PR DESCRIPTION
Let's reduce cognitive complexity to make the lives of the poor developers a bit easier.

This is in preparation to migrating more data providers to the new `rawr/phpunit-data-provider` package.