### PR TITLE
[BUGFIX] Avoid deprecated string casts

### DIFF
--- a/config/phpmd.xml
+++ b/config/phpmd.xml
@@ -10,7 +10,7 @@
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
             <!-- Avoid false positives when calling factory methods -->
-            <property name="ignorepattern" value="/^from/" />
+            <property name="ignorepattern" value="/^(from|create)/" />
         </properties>
     </rule>
 

--- a/src/Css/StyleRule.php
+++ b/src/Css/StyleRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Css;
 
+use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Property\Selector;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 
@@ -43,7 +44,7 @@ final class StyleRule
         $selectors = $this->declarationBlock->getSelectors();
         return \array_map(
             static function (Selector $selector): string {
-                return (string) $selector;
+                return $selector->getSelector();
             },
             $selectors
         );
@@ -54,7 +55,14 @@ final class StyleRule
      */
     public function getDeclarationAsText(): string
     {
-        return \implode(' ', $this->declarationBlock->getRules());
+        $rules = $this->declarationBlock->getRules();
+        $renderedRules = [];
+        $outputFormat = OutputFormat::create();
+        foreach ($rules as $rule) {
+            $renderedRules[] = $rule->render($outputFormat);
+        }
+
+        return \implode(' ', $renderedRules);
     }
 
     /**


### PR DESCRIPTION
This paves the way towards PHP-CSS-Parser V9 compatibility.