### PR TITLE
[CLEANUP] Drop unnecessary `@var` annotations

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -7,12 +7,6 @@ parameters:
 			path: ../src/Caching/SimpleStringCache.php
 
 		-
-			message: '#^PHPDoc tag @var with type Sabberworm\\CSS\\Renderable is not subtype of type Sabberworm\\CSS\\CSSList\\CSSList\|Sabberworm\\CSS\\Property\\Charset\|Sabberworm\\CSS\\Property\\Import\|Sabberworm\\CSS\\RuleSet\\RuleSet\.$#'
-			identifier: varTag.type
-			count: 2
-			path: ../src/Css/CssDocument.php
-
-		-
 			message: '#^Method Pelago\\Emogrifier\\CssInliner\:\:getAllNodesWithStyleAttribute\(\) return type with generic class DOMNodeList does not specify its types\: TNode$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -76,12 +76,10 @@ final class CssDocument
     public function getStyleRulesData(array $allowedMediaTypes): array
     {
         $ruleMatches = [];
-        /** @var CssRenderable $rule */
         foreach ($this->sabberwormCssDocument->getContents() as $rule) {
             if ($rule instanceof CssAtRuleBlockList) {
                 $containingAtRule = $this->getFilteredAtIdentifierAndRule($rule, $allowedMediaTypes);
                 if (\is_string($containingAtRule)) {
-                    /** @var CssRenderable $nestedRule */
                     foreach ($rule->getContents() as $nestedRule) {
                         if ($nestedRule instanceof CssDeclarationBlock) {
                             $ruleMatches[] = new StyleRule($nestedRule, $containingAtRule);


### PR DESCRIPTION
This change avoids conflicts with the latest version of the CSS parser by trusting its type annotations more.