### PR TITLE
[CLEANUP] Drop redundantly-registered Rector rule

### DIFF
--- a/config/rector.php
+++ b/config/rector.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 
 return RectorConfig::configure()
     ->withPaths(
@@ -34,8 +33,5 @@ return RectorConfig::configure()
 
         PHPUnitSetList::PHPUNIT_90,
         // PHPUnitSetList::PHPUNIT_CODE_QUALITY,
-    ])
-    ->withRules([
-        AddVoidReturnTypeWhereNoReturnRector::class,
     ])
     ->withImportNames(true, true, false);


### PR DESCRIPTION
The removed rule already is part of one of the rulesets we use.