### PR TITLE
[BUGFIX] Provide the authentication token for PHIVE on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
         run: composer install --no-progress
 
       - name: Install development tools
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: phive --no-progress install --trust-gpg-keys 0FDE18AE1D09E19F60F6B1CBC00543248C87FB13,BBAB5DF0A0D6672989CF1869E82B2FB314E9906E
 
       - name: Run Command


### PR DESCRIPTION
This will hopefully avoid the 403 errors when installing the PHIVE packages.