### PR TITLE
[CLEANUP] Fix type annotations for nullable types

### DIFF
--- a/src/Css/CssDocument.php
+++ b/src/Css/CssDocument.php
@@ -121,7 +121,7 @@ final class CssDocument
      * @param CssAtRuleBlockList $rule
      * @param array<array-key, string> $allowedMediaTypes
      *
-     * @return ?string
+     * @return string|null
      *         If the nested at-rule is supported, it's opening declaration (e.g. "@media (max-width: 768px)") is
      *         returned; otherwise the return value is null.
      */

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -87,7 +87,7 @@ final class CssInliner extends AbstractHtmlProcessor
     ];
 
     /**
-     * @var ?CssSelectorConverter
+     * @var CssSelectorConverter|null
      */
     private $cssSelectorConverter = null;
 

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -57,12 +57,12 @@ abstract class AbstractHtmlProcessor
         = '%<template[\\s>][^<]*+(?:<(?!/template>)[^<]*+)*+(?:</template>|$)%i';
 
     /**
-     * @var ?\DOMDocument
+     * @var \DOMDocument|null
      */
     protected $domDocument = null;
 
     /**
-     * @var ?\DOMXPath
+     * @var \DOMXPath|null
      */
     private $xPath = null;
 

--- a/src/HtmlProcessor/CssVariableEvaluator.php
+++ b/src/HtmlProcessor/CssVariableEvaluator.php
@@ -129,7 +129,7 @@ final class CssVariableEvaluator extends AbstractHtmlProcessor
     /**
      * @param array<non-empty-string, string> $declarations
      *
-     * @return ?array<non-empty-string, string> `null` is returned if no substitutions were made.
+     * @return array<non-empty-string, string>|null `null` is returned if no substitutions were made.
      */
     private function replaceVariablesInDeclarations(array $declarations): ?array
     {

--- a/tests/Unit/Utilities/PregTest.php
+++ b/tests/Unit/Utilities/PregTest.php
@@ -18,7 +18,7 @@ final class PregTest extends TestCase
     private $replaceCallbackReplacement = '';
 
     /**
-     * @var ?string
+     * @var string|null
      */
     private $lastReplaceCallbackMatch;
 


### PR DESCRIPTION
For nullable types, notations like `?string` are allowed only for native type declarations, but not for PHPDoc type annotations (even though they might work for some tools).