### PR TITLE
[TASK] Streamline `DeclarationBlockParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Please also have a look at our
 
 ### Changed
 
+- Improve declaration block parsing performance (#1452)
+
 ### Deprecated
 
 ### Removed

--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -15,7 +15,7 @@ namespace Pelago\Emogrifier\Utilities;
 final class DeclarationBlockParser
 {
     /**
-     * @var array<string, array<non-empty-string, string>>
+     * @var array<non-empty-string, array<non-empty-string, string>>
      */
     private static $cache = [];
 
@@ -31,9 +31,9 @@ final class DeclarationBlockParser
     {
         if (\substr($name, 0, 2) === '--') {
             return $name;
-        } else {
-            return \strtolower($name);
         }
+
+        return \strtolower($name);
     }
 
     /**
@@ -56,7 +56,7 @@ final class DeclarationBlockParser
      *   ]
      * ```
      *
-     * @param string $declarationBlock the CSS declarations block without the curly braces, may be empty
+     * @param string $declarationBlock the CSS declarations block (without the curly braces)
      *
      * @return array<non-empty-string, string>
      *         the CSS declarations with the property names as array keys and the property values as array values
@@ -65,25 +65,23 @@ final class DeclarationBlockParser
      */
     public function parse(string $declarationBlock): array
     {
-        if (isset(self::$cache[$declarationBlock])) {
-            return self::$cache[$declarationBlock];
+        $trimmedDeclarationBlock = \trim($declarationBlock, "; \n\r\t\v\x00");
+        if ($trimmedDeclarationBlock === '') {
+            return [];
+        }
+
+        if (isset(self::$cache[$trimmedDeclarationBlock])) {
+            return self::$cache[$trimmedDeclarationBlock];
         }
 
         $preg = new Preg();
 
-        $declarations = $preg->split('/;(?!base64|charset)/', $declarationBlock);
+        $declarations = $preg->split('/;(?!base64|charset)/', $trimmedDeclarationBlock);
 
         $properties = [];
         foreach ($declarations as $declaration) {
             $matches = [];
-            if (
-                $preg->match(
-                    '/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s',
-                    \trim($declaration),
-                    $matches
-                )
-                === 0
-            ) {
+            if ($preg->match('/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/s', \trim($declaration), $matches) === 0) {
                 continue;
             }
 
@@ -95,7 +93,7 @@ final class DeclarationBlockParser
             $propertyValue = $matches[2];
             $properties[$this->normalizePropertyName($propertyName)] = $propertyValue;
         }
-        self::$cache[$declarationBlock] = $properties;
+        self::$cache[$trimmedDeclarationBlock] = $properties;
 
         return $properties;
     }


### PR DESCRIPTION
- simplify a condition to use a guard clause
- make some types more specific
- add a special case for parsing an empty declaration block to improve performance and avoid empty cache keys
- reformat some code