### PR TITLE
[TASK] Require sabberworm/php-css-parser >= 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please also have a look at our
 
 ### Changed
 
+- Require `sabberworm/php-css-parser` version 9.1.0 or higher (#1465)
 - Improve declaration block parsing performance (#1452)
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "sabberworm/php-css-parser": "^9.0.0",
+        "sabberworm/php-css-parser": "^9.1.0",
         "symfony/css-selector": "^5.4.35 || ~6.3.12 || ^6.4.3 || ^7.0.3",
         "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.3"
     },


### PR DESCRIPTION
This is needed for supporting PHP 8.5.