### PR TITLE
[CLEANUP] Refactor preg usage in `CssInliner`

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -1016,13 +1016,13 @@ final class CssInliner extends AbstractHtmlProcessor
         $callback = function (array $matches): string {
             return $this->replaceUnmatchableNotComponent($matches);
         };
-        $selectorWithoutNots = (new Preg())->throwExceptions($this->debug)
+        $untrimmedSelectorWithoutNots = (new Preg())->throwExceptions($this->debug)
             ->replaceCallback($pattern, $callback, ' ' . $selector);
-        $trimmedSelectorWithoutNots = \ltrim($selectorWithoutNots);
+        $selectorWithoutNots = \ltrim($untrimmedSelectorWithoutNots);
 
         $selectorWithoutUnmatchablePseudoComponents = $this->removeSelectorComponents(
             ':(?!' . self::PSEUDO_CLASS_MATCHER . '):?+[\\w\\-]++(?:\\([^\\)]*+\\))?+',
-            $trimmedSelectorWithoutNots
+            $selectorWithoutNots
         );
 
         if ($preg->match(
@@ -1038,7 +1038,6 @@ final class CssInliner extends AbstractHtmlProcessor
             -1,
             PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
         );
-        /** @var list<string> $selectorParts */
 
         return \implode('', \array_map(
             function (string $selectorPart): string {

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -446,14 +446,13 @@ final class CssInliner extends AbstractHtmlProcessor
     {
         $declarationBlockParser = new DeclarationBlockParser();
 
-        $normalizedOriginalStyle = (new Preg())->throwExceptions($this->debug)->replaceCallback(
-            '/-{0,2}+[_a-zA-Z][\\w\\-]*+(?=:)/S',
-            /** @param array<array-key, string> $propertyNameMatches */
-            static function (array $propertyNameMatches) use ($declarationBlockParser): string {
-                return $declarationBlockParser->normalizePropertyName($propertyNameMatches[0]);
-            },
-            $node->getAttribute('style')
-        );
+        $pattern = '/-{0,2}+[_a-zA-Z][\\w\\-]*+(?=:)/S';
+        /** @param array<array-key, string> $propertyNameMatches */
+        $callback = static function (array $propertyNameMatches) use ($declarationBlockParser): string {
+            return $declarationBlockParser->normalizePropertyName($propertyNameMatches[0]);
+        };
+        $normalizedOriginalStyle = (new Preg())->throwExceptions($this->debug)
+            ->replaceCallback($pattern, $callback, $node->getAttribute('style'));
 
         // In order to not overwrite existing style attributes in the HTML, we have to save the original HTML styles.
         $nodePath = $node->getNodePath();
@@ -1012,39 +1011,40 @@ final class CssInliner extends AbstractHtmlProcessor
 
         // The regex allows nested brackets via `(?2)`.
         // A space is temporarily prepended because the callback can't determine if the match was at the very start.
-        $selectorWithoutNots = \ltrim((new Preg())->throwExceptions($this->debug)->replaceCallback(
-            '/([\\s>+~]?+):not(\\([^()]*+(?:(?2)[^()]*+)*+\\))/i',
-            /** @param array<array-key, string> $matches */
-            function (array $matches): string {
-                return $this->replaceUnmatchableNotComponent($matches);
-            },
-            ' ' . $selector
-        ));
+        $pattern = '/([\\s>+~]?+):not(\\([^()]*+(?:(?2)[^()]*+)*+\\))/i';
+        /** @param array<array-key, string> $matches */
+        $callback = function (array $matches): string {
+            return $this->replaceUnmatchableNotComponent($matches);
+        };
+        $selectorWithoutNots = (new Preg())->throwExceptions($this->debug)
+            ->replaceCallback($pattern, $callback, ' ' . $selector);
+        $trimmedSelectorWithoutNots = \ltrim($selectorWithoutNots);
 
         $selectorWithoutUnmatchablePseudoComponents = $this->removeSelectorComponents(
             ':(?!' . self::PSEUDO_CLASS_MATCHER . '):?+[\\w\\-]++(?:\\([^\\)]*+\\))?+',
-            $selectorWithoutNots
+            $trimmedSelectorWithoutNots
         );
 
-        if (
-            $preg->match(
-                '/:(?:' . self::OF_TYPE_PSEUDO_CLASS_MATCHER . ')/i',
-                $selectorWithoutUnmatchablePseudoComponents
-            )
-            === 0
-        ) {
+        if ($preg->match(
+            '/:(?:' . self::OF_TYPE_PSEUDO_CLASS_MATCHER . ')/i',
+            $selectorWithoutUnmatchablePseudoComponents
+        ) === 0) {
             return $selectorWithoutUnmatchablePseudoComponents;
         }
+
+        $selectorParts = $preg->split(
+            '/(' . self::COMBINATOR_MATCHER . ')/',
+            $selectorWithoutUnmatchablePseudoComponents,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+        );
+        /** @var list<string> $selectorParts */
+
         return \implode('', \array_map(
             function (string $selectorPart): string {
                 return $this->removeUnsupportedOfTypePseudoClasses($selectorPart);
             },
-            $preg->split(
-                '/(' . self::COMBINATOR_MATCHER . ')/',
-                $selectorWithoutUnmatchablePseudoComponents,
-                -1,
-                PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-            )
+            $selectorParts
         ));
     }
 


### PR DESCRIPTION
This is in preparation for using the safe versions of the preg functions.