### PR TITLE
[TASK] Make PHPStan extension compatible with PHPStan 2.2.8

### DIFF
--- a/src/PhpStan/IgnoreBooleanAlways.php
+++ b/src/PhpStan/IgnoreBooleanAlways.php
@@ -28,7 +28,7 @@ final class IgnoreBooleanAlways implements IgnoreErrorExtension
         switch ($error->getIdentifier()) {
             case 'function.alreadyNarrowedType':
                 // For an `assert()` that the DocBlocks say cannot fail.
-                if ($node instanceof FunctionCallExpressionNode) {
+                if (\class_exists(FunctionCallExpressionNode::class) && $node instanceof FunctionCallExpressionNode) {
                     // Unwrap for PHPStan >= 2.2.8
                     $node = $node->getOriginalNode();
                 }

--- a/src/PhpStan/IgnoreBooleanAlways.php
+++ b/src/PhpStan/IgnoreBooleanAlways.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\IgnoreErrorExtension;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\FunctionCallExpressionNode;
 
 /**
  * Ignore PHPStan warnings where the DocBlocks indicate that a conditional expression would always be true (or false),
@@ -27,6 +28,10 @@ final class IgnoreBooleanAlways implements IgnoreErrorExtension
         switch ($error->getIdentifier()) {
             case 'function.alreadyNarrowedType':
                 // For an `assert()` that the DocBlocks say cannot fail.
+                if ($node instanceof FunctionCallExpressionNode) {
+                    // Unwrap for PHPStan >= 2.2.8
+                    $node = $node->getOriginalNode();
+                }
                 if ($node instanceof FuncCall) {
                     $nameNode = $node->name;
                     if ($nameNode instanceof Name && $nameNode->name === 'assert') {

--- a/src/PhpStan/IgnoreBooleanAlways.php
+++ b/src/PhpStan/IgnoreBooleanAlways.php
@@ -23,29 +23,47 @@ final class IgnoreBooleanAlways implements IgnoreErrorExtension
 {
     public function shouldIgnore(Error $error, Node $node, Scope $scope): bool
     {
-        $shouldIgnore = false;
-
         switch ($error->getIdentifier()) {
             case 'function.alreadyNarrowedType':
-                // For an `assert()` that the DocBlocks say cannot fail.
-                if (\class_exists(FunctionCallExpressionNode::class) && $node instanceof FunctionCallExpressionNode) {
-                    // Unwrap for PHPStan >= 2.2.8
-                    $node = $node->getOriginalNode();
-                }
-                if ($node instanceof FuncCall) {
-                    $nameNode = $node->name;
-                    if ($nameNode instanceof Name && $nameNode->name === 'assert') {
-                        $shouldIgnore = true;
-                    }
-                }
-                break;
+                return self::shouldIgnoreFunctionAlreadyNarrowedType($node);
             case 'instanceof.alwaysTrue':
-                // For `instanceof` within an `assert()` that the DocBlocks say cannot fail.
-                $functionCallStack = $scope->getFunctionCallStack();
-                if (isset($functionCallStack[0]) && $functionCallStack[0]->getName() === 'assert') {
-                    $shouldIgnore = true;
-                }
-                break;
+                return self::shouldIgnoreInstanceofAlwaysTrue($scope);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * For an `assert()` that the DocBlocks say cannot fail.
+     */
+    private static function shouldIgnoreFunctionAlreadyNarrowedType(Node $node): bool
+    {
+        $shouldIgnore = false;
+
+        if (\class_exists(FunctionCallExpressionNode::class) && $node instanceof FunctionCallExpressionNode) {
+            // Unwrap for PHPStan >= 2.2.8
+            $node = $node->getOriginalNode();
+        }
+        if ($node instanceof FuncCall) {
+            $nameNode = $node->name;
+            if ($nameNode instanceof Name && $nameNode->name === 'assert') {
+                $shouldIgnore = true;
+            }
+        }
+
+        return $shouldIgnore;
+    }
+
+    /**
+     * For `instanceof` within an `assert()` that the DocBlocks say cannot fail.
+     */
+    private static function shouldIgnoreInstanceofAlwaysTrue(Scope $scope): bool
+    {
+        $shouldIgnore = false;
+
+        $functionCallStack = $scope->getFunctionCallStack();
+        if (isset($functionCallStack[0]) && $functionCallStack[0]->getName() === 'assert') {
+            $shouldIgnore = true;
         }
 
         return $shouldIgnore;


### PR DESCRIPTION
The extension merely silences warnings about impossible `instanceof` assertions, on a global basis, avoiding the need to clutter the code with `phpstan-ignore` comments.

But if PHPStan's behaviour keeps changing with every point release, the extension may need to be dropped in favour of cluttering the code with `phpstan-ignore` comments.

In PHPStan 2.2.8, the applicable `Node` parameter passed to `shouldIgnore()` is now a `FunctionCallExpressionNode`, wrapping `FuncCall` that was passed in previous versions.