### PR TITLE
[TASK] Silence warnings from PHPStan

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -28,6 +28,11 @@ parameters:
       message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'
       path: '%currentWorkingDirectory%/tests/'
 
+  # This is a temporary but sadly necessary setting to allow upgrade to PHPStan 2.2.8.
+  # It maintains compatibility with PHPStan 2.2.7.
+  # When it has been bedded in, it can (and should) be removed.
+  reportUnmatchedIgnoredErrors: false
+
 services:
   -
     class: \Pelago\Emogrifier\PhpStan\IgnoreBooleanAlways

--- a/src/PhpStan/IgnoreBooleanAlways.php
+++ b/src/PhpStan/IgnoreBooleanAlways.php
@@ -40,8 +40,11 @@ final class IgnoreBooleanAlways implements IgnoreErrorExtension
     {
         $shouldIgnore = false;
 
+        // This is an unstable API that does not adhere to semver.
+        // @phpstan-ignore phpstanApi.classConstant, phpstanApi.class
         if (\class_exists(FunctionCallExpressionNode::class) && $node instanceof FunctionCallExpressionNode) {
             // Unwrap for PHPStan >= 2.2.8
+            // @phpstan-ignore phpstanApi.method
             $node = $node->getOriginalNode();
         }
         if ($node instanceof FuncCall) {


### PR DESCRIPTION
These would be emitted when we update PHPStan to 2.2.8 or later, breaking the build.

We use semantic versioning, but it seems disappointingly that PHPStan does not.