### PR TITLE
[TASK] Allow PHP 8.6 with PHPStan extension

### DIFF
--- a/tests/Unit/PhpStan/IgnoreBooleanAlwaysImpossibleAssertTest.php
+++ b/tests/Unit/PhpStan/IgnoreBooleanAlwaysImpossibleAssertTest.php
@@ -7,6 +7,7 @@ namespace Pelago\Emogrifier\Tests\Unit\PhpStan;
 use PHPStan\Analyser\IgnoreErrorExtension;
 use PHPStan\Rules\Comparison\ImpossibleCheckTypeFunctionCallRule;
 use PHPStan\Rules\Rule;
+use PHPUnit\Framework\Error\Deprecated;
 
 /**
  * This covers `function.alreadyNarrowedType` error handling in the `IgnoreBooleanAlways` PHPStan extension class.
@@ -39,15 +40,22 @@ final class IgnoreBooleanAlwaysImpossibleAssertTest extends IgnoreBooleanAlwaysT
             self::markTestSkipped('This is testing the testers, and only needs to run whenever possible.');
         }
 
-        // Second argument is array of expected warnings.
-        $this->analyse(
-            [self::FIXTURES_DIR . 'alwaystrue-pointlessassert.php'],
-            [
+        // TODO: remove try/catch block when PHPStan is fixed.
+        try {
+            // Second argument is array of expected warnings.
+            $this->analyse(
+                [self::FIXTURES_DIR . 'alwaystrue-pointlessassert.php'],
                 [
-                    'Call to function is_int() with int will always evaluate to true.',
-                    7,
+                    [
+                        'Call to function is_int() with int will always evaluate to true.',
+                        7,
+                    ],
                 ],
-            ],
-        );
+            );
+        } catch (Deprecated $e) {
+            self::markTestSkipped(
+                'PHPStan has a dependency on an Hoa library that triggers a deprecation warning with PHP 8.6.'
+            );
+        }
     }
 }


### PR DESCRIPTION
PHPStan has a dependency (Hoa) that triggers a deprecation warning in PHP 8.6.

PHPUnit fails tests if any warnings or notices are triggered.

This change is a temporary patch so that PHP 8.6 can be supported, until a permanent fix in PHPStan is released, and mirrors
https://github.com/MyIntervals/PHP-CSS-Parser/pull/1627.

Ref: https://github.com/phpstan/phpstan/issues/15127