### PR TITLE
[TASK] Add a Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     commit-message:
       prefix: "[Dependabot] "
     milestone: 21
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -27,3 +29,5 @@ updates:
     commit-message:
       prefix: "[Dependabot] "
     milestone: 21
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This reduces the risk of updating to packages
that have been taken over recently.

https://docs.zizmor.sh/audits/#dependabot-cooldown

Part of #1650